### PR TITLE
Fix link to `docker-compose.yml` in top-level README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ venv.bak/
 
 # vscode
 .vscode
+*.code-workspace
 
 # tag files
 tags

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/Flowminder/FlowKit.svg?style=shield)](https://circleci.com/gh/Flowminder/FlowKit) [![codecov](https://codecov.io/gh/Flowminder/FlowKit/branch/master/graph/badge.svg)](https://codecov.io/gh/Flowminder/FlowKit) 
 
-FlowKit is a platform for analysis of CDR and other data. The system is designed to be deployed as a set of [Docker](https://docs.docker.com) containers on a server. The three main server components are:
+FlowKit is a platform for analysis of call detail records (CDR) and other data. The system is designed to be deployed as a set of [Docker](https://docs.docker.com) containers on a server. The three main server components are:
 
 -   [FlowDB](https://flowminder.github.io/FlowKit/flowdb)
 
@@ -28,7 +28,7 @@ There are two other components of FlowKit:
 
     An authentication management system used to generate access tokens for use with FlowClient.
 
-FlowKit is an open-source product. The source code can be found at https://github.com/Flowminder/flowkit, and documentation is available at https://flowminder.github.io/FlowKit.
+FlowKit is an open-source product. The source code can be found at https://github.com/Flowminder/FlowKit, and documentation is available at https://flowminder.github.io/FlowKit.
 
 ## Installation using docker cloud repositories
 
@@ -36,7 +36,7 @@ FlowKit is an open-source product. The source code can be found at https://githu
 
 Docker containers for FlowAPI, FlowMachine and FlowDB are provided in the docker cloud repositories `flowminder/flowapi`, `flowminder/flowmachine` and `flowminder/flowdb`, respectively. To set up FlowKit using the docker cloud repositories, you will need [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/).
 
-The file [`docker-compose.yml`](https://github.com/Flowminder/flowkit/blob/master/docker-compose.yml) can be used to start FlowKit and populate FlowDB with a test dataset. The compose file expects the `JWT_SECRET_KEY` environment variable to be set. This is used to sign and verify access tokens for the API.
+The file [`docker-compose.yml`](https://github.com/Flowminder/FlowKit/raw/master/docker-compose.yml) can be used to start FlowKit and populate FlowDB with a test dataset. The compose file expects the `JWT_SECRET_KEY` environment variable to be set. This is used to sign and verify access tokens for the API.
 
 The FlowKit test system can be started by running `JWT_SECRET_KEY=<secret> docker-compose up -d` in the same directory as the `docker-compose.yml` file. This will pull any necessary docker containers, and start the system in the background with the API exposed on port `9090` by default.
 

--- a/docs/source/README.md
+++ b/docs/source/README.md
@@ -26,7 +26,7 @@ There are two other components of FlowKit:
 
     An authentication management system used to generate access tokens for use with FlowClient.
 
-FlowKit is an open-source product. The source code can be found at https://github.com/Flowminder/flowkit, and documentation is available at https://flowminder.github.io/flowkit.
+FlowKit is an open-source product. The source code can be found at https://github.com/Flowminder/FlowKit, and documentation is available at https://flowminder.github.io/FlowKit.
 
 ## Installation using docker cloud repositories
 
@@ -34,7 +34,7 @@ FlowKit is an open-source product. The source code can be found at https://githu
 
 Docker containers for FlowAPI, FlowMachine and FlowDB are provided in the docker cloud repositories `flowminder/flowapi`, `flowminder/flowmachine` and `flowminder/flowdb`, respectively. To set up FlowKit using the docker cloud repositories, you will need [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/).
 
-The file [`docker-compose.yml`](https://github.com/Flowminder/flowkit/blob/master/docker-compose.yml) can be used to start FlowKit and populate FlowDB with a test dataset. The compose file expects the `JWT_SECRET_KEY` environment variable to be set. This is used to sign and verify access tokens for the API.
+The file [`docker-compose.yml`](https://github.com/Flowminder/FlowKit/raw/master/docker-compose.yml) can be used to start FlowKit and populate FlowDB with a test dataset. The compose file expects the `JWT_SECRET_KEY` environment variable to be set. This is used to sign and verify access tokens for the API.
 
 The FlowKit test system can be started by running `JWT_SECRET_KEY=<secret> docker-compose up -d` in the same directory as the `docker-compose.yml` file. This will pull any necessary docker containers, and start the system in the background with the API exposed on port `9090` by default.
 
@@ -54,7 +54,7 @@ The FlowAuth Docker container is provided in the docker cloud repository `flowmi
 
 ## Installation for developers
 
-After cloning the [GitHub repository](https://github.com/Flowminder/flowkit), the FlowKit system can be started by running `make up` in the root directory. This requires [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/) to be installed, and starts the flowapi, flowmachine, flowdb and redis docker containers using the `docker-compose-dev.yml` file.
+After cloning the [GitHub repository](https://github.com/Flowminder/FlowKit), the FlowKit system can be started by running `make up` in the root directory. This requires [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/) to be installed, and starts the flowapi, flowmachine, flowdb and redis docker containers using the `docker-compose-dev.yml` file.
 
 FlowKit uses [pipenv](https://pipenv.readthedocs.io/) to manage Python environments. To start a Python session in which you can use FlowClient:
 


### PR DESCRIPTION
Closes #2

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate 

### Description

Link to raw `docker-compose.yml` (instead of blob) in the top-level README, so that `wget` will get the file instead of a page of html.
Also correct the case of FlowKit in a couple more links, and explicitly say "call detail records" in the description.

@greenape
