### PR TITLE
Keep the docs build as an artifact for inspection. Closes #7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -501,10 +501,9 @@ jobs:
           key: flowkit-docs-deps1-{{ checksum "Pipfile.lock" }}
           paths:
             - /home/circleci/.local/share/virtualenvs/
-      - persist_to_workspace:
-          root: /home/circleci/project
-          paths:
-            - docs/flowkit-docs.zip
+      - store_artifacts:
+          path: /home/circleci/project/docs/flowkit-docs.zip
+          destination: docs
 
   build_client_wheel:
     docker: *base_docker


### PR DESCRIPTION
Closes #7

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate 

### Description

This makes the docs built in the `build_docs` available as an artifact to download on CircleCI.