### PR TITLE
Fix FlowAuth login failing on some browsers

### DIFF
--- a/flowauth/backend/flowauth/__init__.py
+++ b/flowauth/backend/flowauth/__init__.py
@@ -35,7 +35,7 @@ def create_app(test_config=None):
     # Set up flask-login
     login_manager = LoginManager()
     login_manager.init_app(app)
-    login_manager.login_view = "flowauth.login.signin"
+    login_manager.login_view = "/"
 
     # Set up flask-principal for roles management
     principals = Principal()

--- a/flowauth/frontend/src/util/api.js
+++ b/flowauth/frontend/src/util/api.js
@@ -987,6 +987,7 @@ export async function login(username, password) {
     headers: {
       "Content-Type": "application/json"
     },
+    credentials: "same-origin",
     body: JSON.stringify({ username: username, password: password })
   };
 

--- a/flowmachine/tests/test_location_area.py
+++ b/flowmachine/tests/test_location_area.py
@@ -14,17 +14,6 @@ import pytest
 from flowmachine.features import LocationArea
 
 
-class LocationAreaTestCase(TestCase):
-    """
-    Tests for the LocationArea() class
-    """
-
-    def setUp(get_dataframe):
-        """
-        Method for instantiating test environment.
-        """
-
-
 n_sites = 30
 site_ids = ["o9yyxY", "B8OaG5", "DbWg4K", "0xqNDj"]
 


### PR DESCRIPTION
Closes #18

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate 

### Description

This resolves not being able to stay logged into FlowAuth when using Electron 59, and Firefox 60.

Changes the redirect for an unauthorised access to an api route to "/" to avoid breaking the frontend, and adds the "same-origins" setting to the `login` API function.