### PR TITLE
Read SSH keys from specific file, to allow multiple keys to be added

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,8 +1,18 @@
-To provision the machine, set the environment variables `HOST` and `SSH_USER` and
-run the following command (make sure you don't forget the comma after `${HOST}`
-if you type it manually):
-```
-pipenv install
-pipenv run ansible-playbook -i ${HOST}, --user=${SSH_USER} provision.yml
-```
+To provision the machine:
+
+- Set the environment variables `HOST` and `SSH_USER` to the host and username
+  of the machine to be provisioned (note that the provisioning user needs admin
+  rights because it needs to be able to install packages on the system).
+
+- Create a file called `ssh_keys/authorized_keys.txt` which contains the public
+  SSH keys of the users who should be able to log into the `flowkit` account
+  once the machine is provisioned.
+
+- Finally, run the following command (make sure you don't forget the comma
+  after `${HOST}` if you type it manually):
+  ```
+  pipenv install
+  pipenv run ansible-playbook -i ${HOST}, --user=${SSH_USER} provision.yml
+  ```
+
 This has been tested with CentOS Linux release 7.5.1804.

--- a/deployment/roles/user_accounts/tasks/main.yml
+++ b/deployment/roles/user_accounts/tasks/main.yml
@@ -14,6 +14,6 @@
   authorized_key:
     user: "{{ item }}"
     state: present
-    key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_rsa.pub') }}"
+    key: "{{ lookup('file', playbook_dir + '/ssh_keys/authorized_keys.txt') }}"
   with_items:
     - flowkit

--- a/deployment/ssh_keys/.gitignore
+++ b/deployment/ssh_keys/.gitignore
@@ -1,0 +1,1 @@
+authorized_keys.txt

--- a/deployment/ssh_keys/README.md
+++ b/deployment/ssh_keys/README.md
@@ -1,0 +1,7 @@
+This is a placeholder directory. Before running the ansible playbooks to
+provision a given host, you should add a file called `authorized_keys.txt`
+in this folder. This file should contain one (or multiple) lines with the
+public SSH keys for all users that should be able to log into the `flowkit`
+user account that will be created as part of the provisioning process.
+These keys will be placed in the file `/home/flowkit/.ssh/authorized_keys`.
+on the host during provisioning.


### PR DESCRIPTION
Closes #26 

### I have:

- [] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [X] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate 

### Description

This PR changes the way in which the ansible playbooks determine the SSH keys which are to be put on the to-be-provisioned host. Previously, they would just read the file `~/.ssh/authorized_keys` of the provisioning user, but this doesn't allow any configuration. Now they require an explicit step of copying any relevant public SSH keys into a file called `ssh_keys/authorized_keys.txt` under the deployment folder. This allows configuring the SSH key to be used, and also to use multiple SSH keys.