### PR TITLE
Convert test_pareto to pytest form

### DIFF
--- a/flowmachine/tests/test_pareto.py
+++ b/flowmachine/tests/test_pareto.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from unittest import TestCase
 
 from flowmachine.features import ParetoInteractions, ContactBalance
 import pandas as pd
@@ -40,50 +39,48 @@ def paretos(df):
     return pd.DataFrame({"subscriber": subscribers, "pareto": ps})
 
 
-class TestPareto(TestCase):
-    def test_pareto(self):
-        """Test pareto proportion is correct for some hand picked subscribers."""
-        p = ParetoInteractions("2016-01-01", "2016-01-02")
-        self.assertTrue(
-            all(
-                p.get_dataframe().set_index("subscriber").ix["VkzMxYjv7mYn53oK"] == 0.75
-            )
-        )
+def test_pareto(get_dataframe):
+    """Test pareto proportion is correct for some hand picked subscribers."""
+    p = ParetoInteractions("2016-01-01", "2016-01-02")
+    assert all(get_dataframe(p).set_index("subscriber").ix["VkzMxYjv7mYn53oK"] == 0.75)
 
-    def test_pareto_nepal(self):
-        """Test flowmachine's method against the nepal code."""
-        cb = ContactBalance("2016-01-01", "2016-01-07", exclude_self_calls=False)
-        p = ParetoInteractions("2016-01-01", "2016-01-07")
-        df = p.get_dataframe()
-        df2 = paretos(cb.get_dataframe())
-        self.assertTrue(
-            all(
-                df.set_index("subscriber").sort_index()
-                == df2.set_index("subscriber").sort_index()
-            )
-        )
 
-    def test_pareto_self_call(self):
-        """
-        Test that subscribers who only call themselves get pareto 1.
-        """
+def test_pareto_nepal(get_dataframe):
+    """Test flowmachine's method against the nepal code."""
+    cb = ContactBalance("2016-01-01", "2016-01-07", exclude_self_calls=False)
+    p = ParetoInteractions("2016-01-01", "2016-01-07")
+    df = get_dataframe(p)
+    df2 = paretos(get_dataframe(cb))
+    assert all(
+        df.set_index("subscriber").sort_index()
+        == df2.set_index("subscriber").sort_index()
+    )
 
-        pi = ParetoInteractions(
+
+def test_pareto__call(get_dataframe):
+    """
+    Test that subscribers who only call themselves get pareto 1.
+    """
+
+    pi = get_dataframe(
+        ParetoInteractions(
             "2016-01-01 00:00:00",
             "2016-01-01 00:00:50",
             subscriber_subset="self_caller",
-        ).get_dataframe()
-        self.assertEqual(1.0, pi.pareto[0])
-
-    def test_pareto_self_call_exclusion(self):
-        """
-        Test that subscribers who only call themselves can be excluded from pareto.
-        """
-
-        pi = ParetoInteractions(
-            "2016-01-01 00:00:00",
-            "2016-01-01 00:00:50",
-            exclude_self_calls=True,
-            subscriber_subset="self_caller",
         )
-        self.assertEqual(0, len(pi))
+    )
+    assert 1.0 == pi.pareto[0]
+
+
+def test_pareto__call_exclusion(get_length):
+    """
+    Test that subscribers who only call themselves can be excluded from pareto.
+    """
+
+    pi = ParetoInteractions(
+        "2016-01-01 00:00:00",
+        "2016-01-01 00:00:50",
+        exclude_self_calls=True,
+        subscriber_subset="self_caller",
+    )
+    assert 0 == get_length(pi)


### PR DESCRIPTION
### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate 

### Description

Converts the tests for `ParetoInteractions` to pytest style, and removes any explicit dependency on the `get_dataframe` method of `Query`. 