### PR TITLE
Convert test_networkx_export to pytest

### DIFF
--- a/flowmachine/tests/test_networkx_export.py
+++ b/flowmachine/tests/test_networkx_export.py
@@ -5,8 +5,7 @@
 """
 Unit tests for networkx export.
 """
-
-from unittest import TestCase
+import pytest
 
 from flowmachine.core import Query
 from flowmachine.core.mixins import GraphMixin
@@ -14,55 +13,60 @@ from flowmachine.core.mixins import GraphMixin
 from flowmachine.features import daily_location, Flows
 
 
-class FlowGraphTestCase(TestCase):
+def test_nx_object():
     """
-    Tests for the to_networkx() method.
+    to_networkx() creates a networkx.Graph() object.
     """
+    dl1 = daily_location("2016-01-01")
+    dl2 = daily_location("2016-01-02")
+    flow = Flows(dl1, dl2)
+    graph = flow.to_networkx()
+    assert graph.has_node("Arghakhanchi")
+    assert "Dadeldhura" in graph.neighbors("Arghakhanchi")
+    assert "Sankhuwasabha" not in graph.neighbors("Arghakhanchi")
 
-    def setUp(self):
-        dl1 = daily_location("2016-01-01")
-        dl2 = daily_location("2016-01-02")
-        self.flow = Flows(dl1, dl2)
 
-    def test_nx_object(self):
-        """
-        to_networkx() creates a networkx.Graph() object.
-        """
-        graph = self.flow.to_networkx()
-        self.assertTrue(graph.has_node("Arghakhanchi"))
-        self.assertIn("Dadeldhura", graph.neighbors("Arghakhanchi"))
-        self.assertNotIn("Sankhuwasabha", graph.neighbors("Arghakhanchi"))
+def test_undirected():
+    """
+    to_networkx() raises a warning if using duplicate edges are detected.
+    """
+    dl1 = daily_location("2016-01-01")
+    dl2 = daily_location("2016-01-02")
+    flow = Flows(dl1, dl2)
+    with pytest.warns(UserWarning):
+        graph = flow.to_networkx(directed_graph=False)
+    assert "Sankhuwasabha" in graph.neighbors("Arghakhanchi")
 
-    def test_undirected(self):
-        """
-        to_networkx() raises a warning if using duplicate edges are detected.
-        """
-        with self.assertWarns(UserWarning):
-            graph = self.flow.to_networkx(directed_graph=False)
-            self.assertIn("Sankhuwasabha", graph.neighbors("Arghakhanchi"))
 
-    def test_directed_dupe(self):
-        """
-        to_networkx() raises a warning if using duplicate edges are detected in digraph.
-        """
+def test_directed_dupe():
+    """
+    to_networkx() raises a warning if using duplicate edges are detected in digraph.
+    """
+    dl1 = daily_location("2016-01-01")
+    dl2 = daily_location("2016-01-02")
+    flow = Flows(dl1, dl2)
 
-        class DupeFlow(GraphMixin, Query):
-            def __init__(self, flow):
-                self.union = flow.union(flow)
-                super().__init__()
+    class DupeFlow(GraphMixin, Query):
+        def __init__(self, flow):
+            self.union = flow.union(flow)
+            super().__init__()
 
-            def _make_query(self):
-                return self.union.get_query()
+        def _make_query(self):
+            return self.union.get_query()
 
-        with self.assertWarns(UserWarning):
-            graph = DupeFlow(self.flow).to_networkx(directed_graph=True)
+    with pytest.warns(UserWarning):
+        graph = DupeFlow(flow).to_networkx(directed_graph=True)
 
-    def test_errors_with_one_param(self):
-        """
-        to_networkx() raises error if only one side of parameters is passed.
-        """
-        with self.assertRaises(ValueError):
-            self.flow.to_networkx(source="name_from")
 
-        with self.assertRaises(ValueError):
-            self.flow.to_networkx(target="name_from")
+def test_errors_with_one_param():
+    """
+    to_networkx() raises error if only one side of parameters is passed.
+    """
+    dl1 = daily_location("2016-01-01")
+    dl2 = daily_location("2016-01-02")
+    flow = Flows(dl1, dl2)
+    with pytest.raises(ValueError):
+        flow.to_networkx(source="name_from")
+
+    with pytest.raises(ValueError):
+        flow.to_networkx(target="name_from")


### PR DESCRIPTION
### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate 

### Description

Converts the tests of the networkx export functionality to pytest.