### PR TITLE
Convert test_proportion_outgoing to pytest form

### DIFF
--- a/flowmachine/tests/test_class_database.py
+++ b/flowmachine/tests/test_class_database.py
@@ -7,14 +7,7 @@ Unit tests for the Connection() class.
 """
 import datetime
 from unittest.mock import Mock
-
-import psycopg2 as pg
-
-from unittest import TestCase
-
 import pytest
-
-from flowmachine.core import Connection, Query
 
 
 @pytest.fixture

--- a/flowmachine/tests/test_feature_collection.py
+++ b/flowmachine/tests/test_feature_collection.py
@@ -6,7 +6,6 @@
 Tests for flowmachine.FeatureCollection
 """
 
-from unittest import TestCase
 from flowmachine import FeatureCollection
 from flowmachine.core import CustomQuery
 from flowmachine.features import RadiusOfGyration, NocturnalCalls, SubscriberDegree

--- a/flowmachine/tests/test_flow_division.py
+++ b/flowmachine/tests/test_flow_division.py
@@ -5,22 +5,9 @@
 """
 Unit tests for Flows() division operations.
 """
-from unittest import TestCase
 
 import pytest
-
 from flowmachine.features import Flows, daily_location
-import pandas as pd
-import numpy as np
-
-
-class test_flow_division(TestCase):
-    def setUp(get_dataframe):
-        dl1 = daily_location("2016-01-01")
-        dl2 = daily_location("2016-01-02")
-        dl3 = daily_location("2016-01-07")
-        flowA = Flows(dl1, dl2)
-        flowB = Flows(dl1, dl3)
 
 
 def test_a_div_b(get_dataframe):

--- a/flowmachine/tests/test_join_to_location.py
+++ b/flowmachine/tests/test_join_to_location.py
@@ -5,10 +5,7 @@
 import pytest
 
 from datetime import datetime, timezone
-from unittest import TestCase
 
-
-from pandas import DataFrame
 import numpy as np
 
 from flowmachine.features import subscriber_locations

--- a/flowmachine/tests/test_location_area.py
+++ b/flowmachine/tests/test_location_area.py
@@ -5,10 +5,6 @@
 """
 Tests for the LocationArea() class.
 """
-
-import pandas as pd
-from unittest import TestCase
-
 import pytest
 
 from flowmachine.features import LocationArea

--- a/flowmachine/tests/test_models_pwo.py
+++ b/flowmachine/tests/test_models_pwo.py
@@ -6,8 +6,6 @@
 Tests for the PopulationWeightedOpportunities() class.
 """
 
-from unittest import TestCase
-
 import pytest
 
 from flowmachine.models import PopulationWeightedOpportunities

--- a/flowmachine/tests/test_proportion_outgoing.py
+++ b/flowmachine/tests/test_proportion_outgoing.py
@@ -6,49 +6,41 @@
 Tests for the feature subscriber event proportions.
 """
 
-import pandas as pd
-from unittest import TestCase
+import pytest
 
 from flowmachine.features.subscriber.proportion_outgoing import ProportionOutgoing
 
 
-class ProportionOutgoingTestCase(TestCase):
+"""
+Tests for ProportionOutgoings() feature class.
+"""
+
+
+def test_returns_correct_column_names():
     """
-    Tests for ProportionOutgoings() feature class.
+    ProportionOutgoing() dataframe has expected column names.
     """
+    ud = ProportionOutgoing("2016-01-01", "2016-01-04")
+    assert [
+        "subscriber",
+        "proportion_outgoing",
+        "proportion_incoming",
+    ] == ud.column_names
 
-    def setUp(self):
-        self.ud = ProportionOutgoing("2016-01-01", "2016-01-04")
-        self.df = self.ud.get_dataframe()
-        self.expected_columns = [
-            "subscriber",
-            "proportion_outgoing",
-            "proportion_incoming",
-        ]
 
-    def test_returns_df(self):
-        """
-        ProportionOutgoing().get_dataframe() returns a dataframe.
-        """
-        self.assertIs(type(self.df), pd.DataFrame)
+def test_returns_correct_values(get_dataframe):
+    """
+    ProportionOutgoing() dataframe contains expected values.
+    """
+    ud = ProportionOutgoing("2016-01-01", "2016-01-04")
+    df1 = get_dataframe(ud).set_index("subscriber")
+    assert 0.600000 == df1.ix["ZM3zYAPqx95Rw15J"]["proportion_outgoing"]
+    assert 0.400000 == df1.ix["ZM3zYAPqx95Rw15J"]["proportion_incoming"]
 
-    def test_returns_correct_column_names(self):
-        """
-        ProportionOutgoing() dataframe has expected column names.
-        """
-        self.assertEquals(self.ud.column_names, self.expected_columns)
 
-    def test_returns_correct_values(self):
-        """
-        ProportionOutgoing() dataframe contains expected values.
-        """
-        df1 = self.ud.get_dataframe().set_index("subscriber")
-        self.assertEquals(df1.ix["ZM3zYAPqx95Rw15J"]["proportion_outgoing"], 0.600000)
-        self.assertEquals(df1.ix["ZM3zYAPqx95Rw15J"]["proportion_incoming"], 0.400000)
-
-    def test_passing_not_known_subscriber_identifier_raises_error(self):
-        """
-        ProportionOutgoing() passing not know `subscriber_identifier` raises error.
-        """
-        with self.assertRaises(ValueError):
-            ProportionOutgoing("2016-01-01", "2016-01-04", subscriber_identifier="foo")
+def test_passing_not_known_subscriber_identifier_raises_error():
+    """
+    ProportionOutgoing() passing not know `subscriber_identifier` raises error.
+    """
+    with pytest.raises(ValueError):
+        ProportionOutgoing("2016-01-01", "2016-01-04", subscriber_identifier="foo")

--- a/flowmachine/tests/test_query.py
+++ b/flowmachine/tests/test_query.py
@@ -8,13 +8,8 @@ pertain to any one particular query
 """
 
 import pytest
-from unittest import TestCase
-
-from flowmachine.core import CustomQuery, GeoTable
 from flowmachine.core.query import Query
-from flowmachine.core.table import Table
 from flowmachine.features import daily_location
-import pickle
 
 
 def test_method_not_implemented():

--- a/flowmachine/tests/test_utils.py
+++ b/flowmachine/tests/test_utils.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import pytest
 import pglast
 
-from flowmachine.core import Query
 from flowmachine.core.errors import BadLevelError
 from flowmachine.utils.utils import (
     parse_datestring,
@@ -24,8 +23,6 @@ from flowmachine.utils import time_period_add
 from flowmachine.features import daily_location, EventTableSubset
 
 from flowmachine.core.utils import _makesafe, pretty_sql
-
-from unittest import TestCase
 
 
 def test_time_period_add():


### PR DESCRIPTION
Converts the test for ProportionOutgoing to pytest-style, and cleans up some defunct imports in other test files.