### PR TITLE
Allow configuring ports via env vars in docker-compose-dev.yml

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -77,7 +77,7 @@ services:
       context: ./flowapi
       dockerfile: Dockerfile
     ports:
-      - 9090:9090
+      - ${FLOWAPI_PORT:-9090}:9090
     environment:
       - SERVER=flowmachine
       - DB_USER=reporter
@@ -103,7 +103,7 @@ services:
       context: ./flowmachine
       dockerfile: Dockerfile
     ports:
-      - 5555:5555
+      - ${FLOWMACHINE_PORT:-5555}:5555
     volumes:
       - ./flowmachine/:/app
     tty: true
@@ -124,7 +124,7 @@ services:
     container_name: redis_flowkit
     image: redis
     ports:
-      - 6379:6379
+      - ${REDIS_PORT:-6379}:6379
     restart: always
     networks:
       redis:


### PR DESCRIPTION
Closes #102 

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate 