### PR TITLE
Test FlowClient on multiple python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 dist: xenial
 language: python
 python:
-  - "3.3"
-  - "3.4"
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8-dev"  # 3.8 development branch
-  - "pypy3.5" # Pypy
 # command to install dependencies
 before_install:
   - cd flowclient

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+python:
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8-dev"  # 3.8 development branch
+  - "pypy3.5" # Pypy
+# command to install dependencies
+before_install:
+  - cd flowclient
+install:
+  - pip install .
+# command to run tests
+before_script:
+  - cd flowclient
+script:
+  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,5 @@ before_install:
 install:
   - pip install .
 # command to run tests
-before_script:
-  - cd flowclient
 script:
   - pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FlowKit
 
-[![CircleCI](https://circleci.com/gh/Flowminder/FlowKit.svg?style=shield)](https://circleci.com/gh/Flowminder/FlowKit) [![codecov](https://codecov.io/gh/Flowminder/FlowKit/branch/master/graph/badge.svg)](https://codecov.io/gh/Flowminder/FlowKit) [![Join the chat at https://gitter.im/Flowminder/FlowKit](https://badges.gitter.im/Flowminder/FlowKit.svg)](https://gitter.im/Flowminder/FlowKit?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
+[![CircleCI](https://circleci.com/gh/Flowminder/FlowKit.svg?style=shield)](https://circleci.com/gh/Flowminder/FlowKit) [![Build Status](https://travis-ci.com/Flowminder/FlowKit.svg?branch=master)](https://travis-ci.com/Flowminder/FlowKit) [![codecov](https://codecov.io/gh/Flowminder/FlowKit/branch/master/graph/badge.svg)](https://codecov.io/gh/Flowminder/FlowKit) [![Join the chat at https://gitter.im/Flowminder/FlowKit](https://badges.gitter.im/Flowminder/FlowKit.svg)](https://gitter.im/Flowminder/FlowKit?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
 
 FlowKit is a platform for analysis of call detail records (CDR) and other data. The system is designed to be deployed as a set of [Docker](https://docs.docker.com) containers on a server. The three main server components are:
 

--- a/flowclient/flowclient/client.py
+++ b/flowclient/flowclient/client.py
@@ -5,7 +5,6 @@
 import logging
 import warnings
 import re
-from dataclasses import dataclass
 
 import jwt
 import pandas as pd
@@ -17,10 +16,13 @@ from typing import Tuple, Union, Dict
 logger = logging.getLogger(__name__)
 
 
-@dataclass
 class QueryResult:
     query_id: str
     dataframe: pd.DataFrame
+
+    def __init__(self, query_id: str, dataframe: pd.DataFrame) -> None:
+        self.query_id = query_id
+        self.dataframe = dataframe
 
 
 class FlowclientConnectionError(Exception):

--- a/flowclient/flowclient/client.py
+++ b/flowclient/flowclient/client.py
@@ -16,15 +16,6 @@ from typing import Tuple, Union, Dict
 logger = logging.getLogger(__name__)
 
 
-class QueryResult:
-    query_id: str
-    dataframe: pd.DataFrame
-
-    def __init__(self, query_id: str, dataframe: pd.DataFrame) -> None:
-        self.query_id = query_id
-        self.dataframe = dataframe
-
-
 class FlowclientConnectionError(Exception):
     """
     Custom exception to indicate an error when connecting to a FlowKit API.
@@ -315,7 +306,7 @@ def get_result_by_query_id(connection: Connection, query_id: str) -> pd.DataFram
     return pd.DataFrame.from_records(result["query_result"])
 
 
-def get_result(connection: Connection, query: dict) -> QueryResult:
+def get_result(connection: Connection, query: dict) -> pd.DataFrame:
     """
     Run and retrieve a query of a specified kind with parameters.
 
@@ -328,8 +319,8 @@ def get_result(connection: Connection, query: dict) -> QueryResult:
 
     Returns
     -------
-    QueryResult
-        Named tuple with query_id, dataframe, and kind fields.
+    pd.DataFrame
+       Pandas dataframe containing the results
 
     """
     return get_result_by_query_id(connection, run_query(connection, query))

--- a/flowclient/setup.py
+++ b/flowclient/setup.py
@@ -23,7 +23,7 @@ __email__ = "flowkit@flowminder.org"
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-test_requirements = ["pytest"]
+test_requirements = ["pytest", "pytest-cov"]
 
 setup(
     name="flowclient",


### PR DESCRIPTION
Closes #107

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate 

### Description

This removes the dataclass usage from FlowClient, and adds tests for it across multiple python versions (3.6, 3.7, 3.8 - no lower because of the type annotations) which run on travis-ci.com