### PR TITLE
Allow enabling JIT via env var and setting default stats target

### DIFF
--- a/flowdb/bin/build/configurate.py
+++ b/flowdb/bin/build/configurate.py
@@ -14,7 +14,8 @@ with placeholder fields:
 - `effective_cache_size` (75% of total memory)
 - `shared_buffers` (25% of total memory up to a max of 16GB)
 - `gendate` (Run time stamp of this script)
-
+- `stats_target` (default_statistics_target)
+- `use_jit` (enable/disable jit)
 """
 
 import datetime
@@ -62,6 +63,10 @@ workers = int(os.getenv("MAX_WORKERS", ceil(cores / 2)))
 workers_per_gather = int(os.getenv("MAX_WORKERS_PER_GATHER", ceil(cores / 2)))
 effective_cache_size = _humansize(ceil(0.75 * total_mem))
 debugging = ",plugin_debugger" if bool_env("DEBUG") else ""
+use_jit = "on" if bool_env("JIT") else "off"
+stats_target = int(
+    os.getenv("STATS_TARGET", 10000)
+)  # Default to higher than pg default
 
 config_path = os.getenv(
     "AUTO_CONFIG_PATH", "/var/lib/postgresql/data/postgresql.configurator.conf"
@@ -80,6 +85,8 @@ with open("/docker-entrypoint-initdb.d/pg_config_template.conf") as fin:
         effective_cache_size=effective_cache_size,
         shared_buffers=shared_buffers,
         gendate=datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        stats_target=stats_target,
+        use_jit=use_jit,
     )
 
 print("Writing config file to", config_path)

--- a/flowdb/bin/build/pg_config_template.conf
+++ b/flowdb/bin/build/pg_config_template.conf
@@ -93,3 +93,12 @@ listen_addresses = '*'
 max_worker_processes = {cores}
 max_parallel_workers = {workers}
 max_parallel_workers_per_gather = {workers_per_gather}
+
+# JIT Settings
+
+jit = {use_jit}
+
+# Statistics target
+default_statistics_target = {stats_target}
+
+


### PR DESCRIPTION
Closes #143

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate 

### Description

This adds two new environment variables that can be passed to the FlowDB container at spinup:

- `JIT` (true/false) enables or disables Postgres' JIT (off be default)
- `STATS_TARGET` changes the default stats target. This PR also increases it from 1000 to 10000, which makes more sense for our OLAP/worm workloads.