### PR TITLE
Config for mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,28 @@
+pull_request_rules:
+  - name: automatic merge for Dependabot pull requests on master
+    conditions:
+      - author=dependabot[bot]
+      - status-success=continuous-integration/travis-ci/pr
+      - status-success=run_build_pipeline
+      - base=master
+    actions:
+      merge:
+        method: rebase
+        strict: true
+  - name: Automatic merge for approved PRs labelled as ready
+    conditions:
+      - base=master
+      - "#approved-reviews-by>=1"
+      - label=ready-to-merge
+      - status-success=codecov/project
+      - status-success=run_build_pipeline
+      - status-success=continuous-integration/travis-ci/pr
+    actions:
+      merge:
+        method: rebase
+        strict: true
+  - name: Delete branch after merge
+      actions:
+        delete_head_branch: {}
+      conditions:
+        - merged


### PR DESCRIPTION
This should turn on automatic merging of PRs, using https://mergify.io

If I've got the config right, this should: 

1. Automerge any PRs from Dependabot that pass CI
1. Automerge PRs with an approving review, that pass all the status checks, and are tagged with a 'ready-to-merge' label
1. Delete the branch after merging