### PR TITLE
Fix duplicated spatial indexes in sites & cells in test & synth data containers

### DIFF
--- a/flowdb/sql/01_schema_infrastructure.sql
+++ b/flowdb/sql/01_schema_infrastructure.sql
@@ -94,6 +94,8 @@ CREATE SCHEMA IF NOT EXISTS infrastructure;
         ON infrastructure.sites
         USING GIST (geom_polygon);
 
+    CREATE INDEX ON infrastructure.sites (id);
+
     CREATE TABLE IF NOT EXISTS infrastructure.cells(
 
         id TEXT,
@@ -135,6 +137,9 @@ CREATE SCHEMA IF NOT EXISTS infrastructure;
     CREATE INDEX IF NOT EXISTS infrastructure_cells_geom_polygon_index
         ON infrastructure.cells
         USING GIST (geom_polygon);
+
+    CREATE INDEX ON infrastructure.cells (id);
+    CREATE INDEX ON infrastructure.cells (site_id);
     
     CREATE TABLE IF NOT EXISTS infrastructure.tacs(
 

--- a/flowdb/testdata/synthetic_data/sql/ingest_cells.sql
+++ b/flowdb/testdata/synthetic_data/sql/ingest_cells.sql
@@ -53,7 +53,5 @@ INSERT INTO infrastructure.sites(id, version, date_of_first_service, date_of_las
     SELECT site_id, version, date_of_first_service, date_of_last_service, geom_point FROM infrastructure.cells;
 CREATE INDEX ON infrastructure.cells (id);
 CREATE INDEX ON infrastructure.cells (site_id);
-CREATE INDEX ON infrastructure.cells USING GIST(geom_point);
 CREATE INDEX ON infrastructure.sites (id);
-CREATE INDEX ON infrastructure.cells USING GIST(geom_point);
 COMMIT;

--- a/flowdb/testdata/synthetic_data/sql/ingest_cells.sql
+++ b/flowdb/testdata/synthetic_data/sql/ingest_cells.sql
@@ -51,7 +51,4 @@ INSERT INTO infrastructure.cells (
         FROM temp_cells;
 INSERT INTO infrastructure.sites(id, version, date_of_first_service, date_of_last_service, geom_point) 
     SELECT site_id, version, date_of_first_service, date_of_last_service, geom_point FROM infrastructure.cells;
-CREATE INDEX ON infrastructure.cells (id);
-CREATE INDEX ON infrastructure.cells (site_id);
-CREATE INDEX ON infrastructure.sites (id);
 COMMIT;

--- a/flowdb/testdata/test_data/sql/ingest_cells.sql
+++ b/flowdb/testdata/test_data/sql/ingest_cells.sql
@@ -49,8 +49,5 @@ INSERT INTO infrastructure.cells (
             date_of_last_service::date,
             ST_SetSRID(ST_MakePoint(longitude, latitude), 4326) AS geom_point
         FROM temp_cells;
-
-CREATE INDEX ON infrastructure.cells (id);
-CREATE INDEX ON infrastructure.cells (site_id);
     
 COMMIT;

--- a/flowdb/testdata/test_data/sql/ingest_cells.sql
+++ b/flowdb/testdata/test_data/sql/ingest_cells.sql
@@ -52,6 +52,5 @@ INSERT INTO infrastructure.cells (
 
 CREATE INDEX ON infrastructure.cells (id);
 CREATE INDEX ON infrastructure.cells (site_id);
-CREATE INDEX ON infrastructure.cells USING GIST(geom_point);
     
 COMMIT;

--- a/flowdb/testdata/test_data/sql/ingest_sites.sql
+++ b/flowdb/testdata/test_data/sql/ingest_sites.sql
@@ -47,6 +47,5 @@ INSERT INTO infrastructure.sites (
         FROM temp_sites;
 
 CREATE INDEX ON infrastructure.sites (id);
-CREATE INDEX ON infrastructure.sites USING GIST(geom_point);
 
 COMMIT;

--- a/flowdb/testdata/test_data/sql/ingest_sites.sql
+++ b/flowdb/testdata/test_data/sql/ingest_sites.sql
@@ -46,6 +46,4 @@ INSERT INTO infrastructure.sites (
             ST_SetSRID(ST_MakePoint(longitude, latitude), 4326) AS geom_point
         FROM temp_sites;
 
-CREATE INDEX ON infrastructure.sites (id);
-
 COMMIT;

--- a/flowdb/tests/test_synthetic_data.py
+++ b/flowdb/tests/test_synthetic_data.py
@@ -70,7 +70,7 @@ def test_correct_cell_indexes(cursor):
 
 
 def test_correct_site_indexes(cursor):
-    """Cells table should have four indexes - id, primary key
+    """Sites table should have four indexes - id, primary key
      and spatial ones on geom_point and geom_polygon.
     """
     expected_indexes = [
@@ -87,7 +87,7 @@ def test_correct_site_indexes(cursor):
             "index_definition": "CREATE UNIQUE INDEX sites_pkey ON infrastructure.sites USING btree (id, version)"
         },
     ]
-    query = "select pg_get_indexdef(indexrelid) from pg_index where indrelid = 'infrastructure.cells'::regclass;"
+    query = "select pg_get_indexdef(indexrelid) from pg_index where indrelid = 'infrastructure.sites'::regclass;"
     cursor.execute(query)
     results = cursor.fetchall()
     assert expected_indexes == results

--- a/flowdb/tests/test_synthetic_data.py
+++ b/flowdb/tests/test_synthetic_data.py
@@ -63,7 +63,7 @@ def test_correct_cell_indexes(cursor):
             "index_definition": "CREATE UNIQUE INDEX cells_pkey ON infrastructure.cells USING btree (id, version)"
         },
     ]
-    query = "select pg_get_indexdef(indexrelid) from pg_index where indrelid = 'infrastructure.cells'::regclass;"
+    query = "select pg_get_indexdef(indexrelid) as index_definition from pg_index where indrelid = 'infrastructure.cells'::regclass;"
     cursor.execute(query)
     results = cursor.fetchall()
     assert expected_indexes == results
@@ -87,7 +87,7 @@ def test_correct_site_indexes(cursor):
             "index_definition": "CREATE UNIQUE INDEX sites_pkey ON infrastructure.sites USING btree (id, version)"
         },
     ]
-    query = "select pg_get_indexdef(indexrelid) from pg_index where indrelid = 'infrastructure.sites'::regclass;"
+    query = "select pg_get_indexdef(indexrelid) index_definition from pg_index where indrelid = 'infrastructure.sites'::regclass;"
     cursor.execute(query)
     results = cursor.fetchall()
     assert expected_indexes == results

--- a/flowdb/tests/test_synthetic_data.py
+++ b/flowdb/tests/test_synthetic_data.py
@@ -44,6 +44,55 @@ def test_correct_num_calls(cursor):
     assert results == set([4000])
 
 
+def test_correct_cell_indexes(cursor):
+    """Cells table should have five indexes - id, site_id, primary key and spatial ones on geom_point and geom_polygon."""
+    expected_indexes = [
+        {
+            "index_definition": "CREATE INDEX cells_site_id_idx ON infrastructure.cells USING btree (site_id)"
+        },
+        {
+            "index_definition": "CREATE INDEX cells_id_idx ON infrastructure.cells USING btree (id)"
+        },
+        {
+            "index_definition": "CREATE INDEX infrastructure_cells_geom_polygon_index ON infrastructure.cells USING gist (geom_polygon)"
+        },
+        {
+            "index_definition": "CREATE INDEX infrastructure_cells_geom_point_index ON infrastructure.cells USING gist (geom_point)"
+        },
+        {
+            "index_definition": "CREATE UNIQUE INDEX cells_pkey ON infrastructure.cells USING btree (id, version)"
+        },
+    ]
+    query = "select pg_get_indexdef(indexrelid) from pg_index where indrelid = 'infrastructure.cells'::regclass;"
+    cursor.execute(query)
+    results = cursor.fetchall()
+    assert expected_indexes == results
+
+
+def test_correct_site_indexes(cursor):
+    """Cells table should have four indexes - id, primary key
+     and spatial ones on geom_point and geom_polygon.
+    """
+    expected_indexes = [
+        {
+            "index_definition": "CREATE INDEX sites_id_idx ON infrastructure.sites USING btree (id)"
+        },
+        {
+            "index_definition": "CREATE INDEX infrastructure_sites_geom_polygon_index ON infrastructure.sites USING gist (geom_polygon)"
+        },
+        {
+            "index_definition": "CREATE INDEX infrastructure_sites_geom_point_index ON infrastructure.sites USING gist (geom_point)"
+        },
+        {
+            "index_definition": "CREATE UNIQUE INDEX sites_pkey ON infrastructure.sites USING btree (id, version)"
+        },
+    ]
+    query = "select pg_get_indexdef(indexrelid) from pg_index where indrelid = 'infrastructure.cells'::regclass;"
+    cursor.execute(query)
+    results = cursor.fetchall()
+    assert expected_indexes == results
+
+
 def test_correct_cells(cursor):
     """Checking that synthetic data container contains the correct number of cells."""
     query = """SELECT COUNT(*) FROM infrastructure.cells"""


### PR DESCRIPTION
Closes #169

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate 

### Description

Moves the index creation from site/cell ingest to the table creation in spinup scripts (where it was already happening)