### PR TITLE
Fix make up behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 # flowmachine and flowapi will connected to the first flowdb service in the list.
 
 DOCKER_COMPOSE_FILE_DEV ?= docker-compose-dev.yml
-export FLOWDB_SERVICES ?= flowdb_testdata
+FLOWDB_SERVICES ?= flowdb_testdata
 DOCKER_SERVICES ?= flowapi flowmachine redis $(FLOWDB_SERVICES)
 export DB_HOST=$(word 1, $(FLOWDB_SERVICES))
 

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,19 @@
 # only.
 #
 # By setting the variable FLOWDB_SERVICE you can choose which flowdb
-# version you'd like to use when running `make up`. Examples:
+# version or versions you'd like to use when running `make up`. Examples:
 #
-#     FLOWDB=flowdb-testdata make up
-#     FLOWDB=flowdb-synthetic-data make up
+#     FLOWDB_SERVICE=flowdb_testdata make up
+#     FLOWDB_SERVICE=flowdb_synthetic_data make up
+#     FLOWDB_SERVICE="flowdb_testdata flowdb_synthetic_data" make up
 #
+# flowmachine and flowapi will connected to the first flowdb service in the list.
 
 DOCKER_COMPOSE_FILE_DEV ?= docker-compose-dev.yml
-FLOWDB_SERVICES ?= flowdb-testdata
+export FLOWDB_SERVICES ?= flowdb_testdata
 DOCKER_SERVICES ?= flowapi flowmachine redis $(FLOWDB_SERVICES)
+export DB_HOST=$(word 1, $(FLOWDB_SERVICES))
+
 
 all:
 
@@ -28,17 +32,17 @@ up:
 down:
 	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) down
 
-flowdb-testdata-up:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d flowdb-testdata
+flowdb_testdata-up:
+	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d flowdb_testdata
 
-flowdb-testdata-down:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) rm -f -s -v flowdb-testdata
+flowdb_testdata-down:
+	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) rm -f -s -v flowdb_testdata
 
-flowdb-synthetic-data-up:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d --build flowdb-synthetic-data
+flowdb_synthetic_data-up:
+	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d --build flowdb_synthetic_data
 
-flowdb-synthetic-data-down:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) rm -f -s -v flowdb-synthetic-data
+flowdb_synthetic_data-down:
+	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) rm -f -s -v flowdb_synthetic_data
 
 flowapi-up:
 	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d --build flowapi

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -30,7 +30,7 @@ services:
     networks:
       - db
 
-  flowdb-testdata:
+  flowdb_testdata:
     container_name: flowdb_testdata
     image: flowminder/flowdb:testdata-master
     ports:
@@ -47,7 +47,7 @@ services:
     networks:
       - db
 
-  flowdb-synthetic-data:
+  flowdb_synthetic_data:
     container_name: flowdb_synthetic_data
     image: flowminder/flowdb:synthetic-data-latest
     build:


### PR DESCRIPTION
Fixes #170 

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate 

### Description

Changes the makefile to export the DB_HOST env var as the first flowdb service passed as FLOWDB_SERVICES. Changes the compose-file so that container names and service names match.
