### PR TITLE
Bump test data expiry to next year

### DIFF
--- a/flowauth/backend/tests/conftest.py
+++ b/flowauth/backend/tests/conftest.py
@@ -149,7 +149,7 @@ def test_data(app):
             GroupServerTokenLimits(
                 group=groups[0],
                 longest_life=2,
-                latest_end=datetime.datetime(2019, 1, 1),
+                latest_end=datetime.datetime(2020, 1, 1),
                 server=dummy_server_a,
             )
         )

--- a/flowauth/backend/tests/test_server_admin.py
+++ b/flowauth/backend/tests/test_server_admin.py
@@ -307,7 +307,7 @@ def test_group_server_time_limits(client, auth):
     assert 200 == response.status_code
     json = response.get_json()
     assert 2 == json["longest_token_life"]
-    assert "Tue, 01 Jan 2019 00:00:00 GMT" == json["latest_token_expiry"]
+    assert "Wed, 01 Jan 2020 00:00:00 GMT" == json["latest_token_expiry"]
 
 
 @pytest.mark.usefixtures("test_data_with_access_rights")

--- a/flowdb/tests/test_synthetic_data.py
+++ b/flowdb/tests/test_synthetic_data.py
@@ -48,22 +48,22 @@ def test_correct_cell_indexes(cursor):
     """Cells table should have five indexes - id, site_id, primary key and spatial ones on geom_point and geom_polygon."""
     expected_indexes = [
         {
-            "index_definition": "CREATE INDEX cells_site_id_idx ON infrastructure.cells USING btree (site_id)"
-        },
-        {
             "index_definition": "CREATE INDEX cells_id_idx ON infrastructure.cells USING btree (id)"
         },
         {
-            "index_definition": "CREATE INDEX infrastructure_cells_geom_polygon_index ON infrastructure.cells USING gist (geom_polygon)"
+            "index_definition": "CREATE INDEX cells_site_id_idx ON infrastructure.cells USING btree (site_id)"
         },
         {
             "index_definition": "CREATE INDEX infrastructure_cells_geom_point_index ON infrastructure.cells USING gist (geom_point)"
         },
         {
+            "index_definition": "CREATE INDEX infrastructure_cells_geom_polygon_index ON infrastructure.cells USING gist (geom_polygon)"
+        },
+        {
             "index_definition": "CREATE UNIQUE INDEX cells_pkey ON infrastructure.cells USING btree (id, version)"
         },
     ]
-    query = "select pg_get_indexdef(indexrelid) as index_definition from pg_index where indrelid = 'infrastructure.cells'::regclass;"
+    query = "select pg_get_indexdef(indexrelid) as index_definition from pg_index where indrelid = 'infrastructure.cells'::regclass ORDER BY index_definition;;"
     cursor.execute(query)
     results = cursor.fetchall()
     assert expected_indexes == results
@@ -75,13 +75,13 @@ def test_correct_site_indexes(cursor):
     """
     expected_indexes = [
         {
-            "index_definition": "CREATE INDEX sites_id_idx ON infrastructure.sites USING btree (id)"
+            "index_definition": "CREATE INDEX infrastructure_sites_geom_point_index ON infrastructure.sites USING gist (geom_point)"
         },
         {
             "index_definition": "CREATE INDEX infrastructure_sites_geom_polygon_index ON infrastructure.sites USING gist (geom_polygon)"
         },
         {
-            "index_definition": "CREATE INDEX infrastructure_sites_geom_point_index ON infrastructure.sites USING gist (geom_point)"
+            "index_definition": "CREATE INDEX sites_id_idx ON infrastructure.sites USING btree (id)"
         },
         {
             "index_definition": "CREATE UNIQUE INDEX sites_pkey ON infrastructure.sites USING btree (id, version)"

--- a/flowdb/tests/test_synthetic_data.py
+++ b/flowdb/tests/test_synthetic_data.py
@@ -63,7 +63,7 @@ def test_correct_cell_indexes(cursor):
             "index_definition": "CREATE UNIQUE INDEX cells_pkey ON infrastructure.cells USING btree (id, version)"
         },
     ]
-    query = "select pg_get_indexdef(indexrelid) as index_definition from pg_index where indrelid = 'infrastructure.cells'::regclass ORDER BY index_definition;;"
+    query = "select pg_get_indexdef(indexrelid) as index_definition from pg_index where indrelid = 'infrastructure.cells'::regclass ORDER BY index_definition;"
     cursor.execute(query)
     results = cursor.fetchall()
     assert expected_indexes == results
@@ -87,7 +87,7 @@ def test_correct_site_indexes(cursor):
             "index_definition": "CREATE UNIQUE INDEX sites_pkey ON infrastructure.sites USING btree (id, version)"
         },
     ]
-    query = "select pg_get_indexdef(indexrelid) index_definition from pg_index where indrelid = 'infrastructure.sites'::regclass;"
+    query = "select pg_get_indexdef(indexrelid) index_definition from pg_index where indrelid = 'infrastructure.sites'::regclass ORDER BY index_definition;"
     cursor.execute(query)
     results = cursor.fetchall()
     assert expected_indexes == results


### PR DESCRIPTION
Closes #192

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate 

### Description

Bumps the latest end date of tokens in the test data to new year's day 2020, from 2019. (Happy new year ;))