### PR TITLE
Shm size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,13 +182,13 @@ jobs:
       - run:
           name: Launch flowdb
           command: |
-            docker run --name flowdb --publish $DB_PORT:5432 --volume=${FLOWDB_DATA_DIR}:/var/lib/postgresql/data \
+            docker run --name flowdb --publish $DB_PORT:5432 --shm-size=1G --volume=${FLOWDB_DATA_DIR}:/var/lib/postgresql/data \
               --volume=${FLOWDB_INGESTION_DIR}:/ingestion -e FM_PASSWORD=foo -e API_PASSWORD=foo \
               -e MAX_CPUS=2 -e MAX_WORKERS=2 -e MAX_WORKERS_PER_GATHER=2 \
               --detach flowminder/flowdb:$SAFE_TAG
 
             echo "Waiting for flowdb to be ready.."
-            docker run --name flowdb_oracle --publish $ORACLE_DB_PORT:5432 -e FM_PASSWORD=foo -e API_PASSWORD=foo \
+            docker run --name flowdb_oracle --shm-size=1G --publish $ORACLE_DB_PORT:5432 -e FM_PASSWORD=foo -e API_PASSWORD=foo \
              --detach flowminder/flowdb:oracle-$SAFE_TAG
             docker exec flowdb bash -c 'i=0;until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432);do let i=i+1; echo Waiting 10s; sleep 10;done'
             echo "Waiting for flowdb with oracle_fdw to be ready.."

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -22,6 +22,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-flowflow}
       - FM_PASSWORD=${FM_PASSWORD:-foo}
       - API_PASSWORD=${API_PASSWORD:-foo}
+    shm_size: 1G
     tty: true
     stdin_open: true
     restart: always
@@ -42,6 +43,7 @@ services:
       - FM_PASSWORD=${FM_PASSWORD:-foo}
       - API_PASSWORD=${API_PASSWORD:-foo}
     tty: true
+    shm_size: 1G
     stdin_open: true
     restart: always
     networks:
@@ -65,6 +67,7 @@ services:
       - N_CELLS=${N_CELLS:-500}
       - N_CALLS=${N_CALLS:-2000}
     tty: true
+    shm_size: 1G
     stdin_open: true
     restart: always
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
         tty: true
         stdin_open: true
         restart: always
+        shm_size: 1G
         volumes:
             - data_volume_flowdb:/var/lib/postgresql/data
         networks:

--- a/docs/docs-build-containers.yml
+++ b/docs/docs-build-containers.yml
@@ -15,6 +15,7 @@ services:
       - FM_PASSWORD=${FM_PASSWORD:-foo}
       - API_PASSWORD=${API_PASSWORD:-foo}
     tty: true
+    shm_size: 1G
     ports:
       - "$DB_PORT:5432"
     stdin_open: true

--- a/docs/source/flowdb.md
+++ b/docs/source/flowdb.md
@@ -12,3 +12,8 @@ FlowDB is database designed for storing, serving, and analysing mobile operator 
     -   [pgRouting](http://pgrouting.org) for advanced spatial analysis
     -   Utilities for connecting with Oracle databases ([oracle_fdw](https://github.com/laurenz/oracle_fdw))
     -   Scheduled tasks run in database ([pg_cron](https://github.com/citusdata/pg_cron))
+
+
+## Caveats
+
+You will typically need to increase the default shared memory available to docker containers when running FlowDB. You can do this either by setting `shm_size` for the FlowDB container in your compose or stack file, or by passing the `--shm-size` argument to the `docker run` command.  

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -20,6 +20,7 @@ services:
             - FM_PASSWORD=${FM_PASSWORD:-foo}
             - API_PASSWORD=${API_PASSWORD:-foo}
         tty: true
+        shm_size: 1G
         stdin_open: true
         restart: always
         networks:

--- a/secrets_quickstart/docker-stack.yml
+++ b/secrets_quickstart/docker-stack.yml
@@ -33,6 +33,7 @@ services:
           - FM_DB_USER
           - FM_DB_PASS
         tty: true
+        shm_size: 1G
         stdin_open: true
         networks:
           db:


### PR DESCRIPTION
Closes #215 

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate 

### Description

This increases the size of /dev/shm in all our compose files, and the `docker run` instructions used on CircleCI, and adds a brief note to the FlowDB readme indicating that one should do so in a custom deployment scenario.