### PR TITLE
Add cache metadata, and cache management utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Added utilities for managing and inspecting the query cache
 
 ### Changed
 

--- a/docs/source/administrator/cache_management.md
+++ b/docs/source/administrator/cache_management.md
@@ -31,7 +31,19 @@ By default, calling this method will also flush from the cache any cached querie
 
 ### Configuring the Cache
 
-There are two parameters which control FlowKit's cache, both of which are in the `cache.cache_config` table. `half_life` controls how much weight is given to recency of access when updating the cache score. `cache_size` is the maximum size in bytes that the cache tables should occupy on disk. These settings default to 1000, and 10% of available space on the drive where `/var/lib/postgresql/data` is located.
+There are two parameters which control FlowKit's cache, both of which are in the `cache.cache_config` table. `half_life` controls how much weight is given to recency of access when updating the cache score. `half_life` is in units of number of cache retrievals, so a larger value for `half_life` will give less weight to recency and frequency of access. 
+
+!!! example
+    `big_query` and `small_query` both took 100 seconds to calculate. `big_query` takes 100 bytes to store, and `small_query` takes 10 bytes.
+    Their _costs_ are `compute_time/storage_size`, or 1 for `big_query` and 10 for `small_query`. `small_query` is stored first and has an initial cache score of 10.
+    If query `big_query` is stored next, with a `half_life` of 2, it will get an initial cache score of 1.35. 
+    
+    Just in terms of the balance between compute time and storage cost, `small_query` is more valuable in cache because it is relatively cheaper to store.  However, after only four retrievals of `big_query` from cache, `big_query` will have a cache score of 13.3, meaning it is more valuable in cache because it is so frequently used.
+    
+    If `half_life` was instead set to 10, `big_query` would need to be retrieved _seven_ times to exceed the cache score of `small_query`. 
+     
+ 
+`cache_size` is the maximum size in bytes that the cache tables should occupy on disk. These settings default to 1000, and 10% of available space on the drive where `/var/lib/postgresql/data` is located.
 
 These values can be overridden when creating a new FlowDB container by setting the `CACHE_SIZE` and `CACHE_HALF_LIFE` environment variables for the container, set by updating the `cache.cache_config` table after connecting directly to FlowDB, or modified using the cache submodule.
 

--- a/docs/source/administrator/cache_management.md
+++ b/docs/source/administrator/cache_management.md
@@ -1,0 +1,40 @@
+# Caching in FlowKit
+
+FlowKit implements a caching system to enhance performance. Queries requested via FlowAPI are cached in FlowDB, under the `cache` schema.
+
+Once cached, a query will not be recalulated - the cached version will simply be returned instead, which can save significant computation time. In addition to queries which are _directly_ returned, FlowKit may cache queries which are used in calculating other queries. For example, calculating a modal location aggregate, and a daily location aggregate will both use the same underlying query when the dates (and other parameters) overlap. Hence, caching the underlying query allows both the aggregate and the modal location aggregate to be produced faster.
+
+
+This performance boost is achieved at the cost of disk space usage, and management of the cached data will sometimes be required.
+
+## Cache Management
+
+FlowMachine and FlowDB provide tools to inspect and manage the content of FlowKit's cache. FlowDB also contains metadata about the content of cache, in the `cache.cached` table.
+
+Administrators can inspect this table directly by connecting to FlowDB, but in many scenarios the better option is to make use of FlowMachine's [cache management module](../../developer/api/flowmachine/core/cache/).
+
+The cache submodule provides functions to assess the disk usage of the cache tables, and to reduce the disk usage below a desired threshold.
+
+### Shrinking Cache
+
+To identify which tables should be discarded from cache, FlowKit keeps track of how expensive they were to calculate initially, how much disk space they occupy, and how often and recently they have been used. These factors are combined into a cache score, based on the [cachey](https://github.com/dask/cachey) algorithm.
+
+Each cache table has a cache score, with a higher score indicating that the table has more cache value.
+
+FlowMachine provides two functions which make use of this cache score to reduce the size of the cache - [`shrink_below_size`](../../developer/api/flowmachine/core/cache/#shrink_below_size), and [`shrink_one`](../../developer/api/flowmachine/core/cache/#shrink_one). `shrink_one` flushes the table with the _lowest_ cache score. `shrink_below_size` flushes tables until the disk space used by the cache falls below a threshold[^1] by calling `shrink_one` repeatedly.
+
+### Removing a Specific Query from Cache
+
+If a specific query must be removed from the cache, then an administrator can retrieve the query's _object_ from FlowDB by using the [`get_query_by_id`](../../developer/api/flowmachine/core/cache/#get_query_by_id) function of the `cache` submodule, and calling the object's [`invalidate_db_cache`](../../developer/api/flowmachine/core/query/#invalidate_db_cache) method.
+
+By default, calling this method will also flush from the cache any cached queries which used that query in their calculation. This will also cascade to any queries which used _those_ queries, and so on. Setting the `cascade` argument to `False` will remove only the one query.
+
+### Configuring the Cache
+
+There are two parameters which control FlowKit's cache, both of which are in the `cache.cache_config` table. `half_life` controls how much weight is given to recency of access when updating the cache score. `cache_size` is the maximum size in bytes that the cache tables should occupy on disk. These settings default to 1000, and 10% of available space on the drive where `/var/lib/postgresql/data` is located.
+
+These values can be overridden when creating a new FlowDB container by setting the `CACHE_SIZE` and `CACHE_HALF_LIFE` environment variables for the container, set by updating the `cache.cache_config` table after connecting directly to FlowDB, or modified using the cache submodule.
+
+    
+
+[^1]:By default, this uses the value set for `cache_size` in `cache.cache_config`.

--- a/docs/source/administrator/cache_management.md
+++ b/docs/source/administrator/cache_management.md
@@ -38,14 +38,14 @@ There are two parameters which control FlowKit's cache, both of which are in the
 !!! example
     `big_query` and `small_query` both took 100 seconds to calculate. `big_query` takes 100 bytes to store, and `small_query` takes 10 bytes.
     Their _costs_ are `compute_time/storage_size`, or 1 for `big_query` and 10 for `small_query`. `small_query` is stored first and has an initial cache score of 10.
-    If query `big_query` is stored next, with a `half_life` of 2, it will get an initial cache score of 1.35. 
+    If query `big_query` is stored next, with a `half_life` of 2.0, it will get an initial cache score of 1.35. 
     
     Just in terms of the balance between compute time and storage cost, `small_query` is more valuable in cache because it is relatively cheaper to store.  However, after only four retrievals of `big_query` from cache, `big_query` will have a cache score of 13.3, meaning it is more valuable in cache because it is so frequently used.
     
-    If `half_life` was instead set to 10, `big_query` would need to be retrieved _seven_ times to exceed the cache score of `small_query`. 
+    If `half_life` was instead set to 10.0, `big_query` would need to be retrieved _seven_ times to exceed the cache score of `small_query`. 
      
  
-`cache_size` is the maximum size in bytes that the cache tables should occupy on disk. These settings default to 1000, and 10% of available space on the drive where `/var/lib/postgresql/data` is located.
+`cache_size` is the maximum size in bytes that the cache tables should occupy on disk. These settings default to 1000.0, and 10% of available space on the drive where `/var/lib/postgresql/data` is located.
 
 These values can be overridden when creating a new FlowDB container by setting the `CACHE_SIZE` and `CACHE_HALF_LIFE` environment variables for the container, set by updating the `cache.cache_config` table after connecting directly to FlowDB, or modified using the cache submodule.
 

--- a/docs/source/administrator/cache_management.md
+++ b/docs/source/administrator/cache_management.md
@@ -23,11 +23,13 @@ Each cache table has a cache score, with a higher score indicating that the tabl
 
 FlowMachine provides two functions which make use of this cache score to reduce the size of the cache - [`shrink_below_size`](../../developer/api/flowmachine/core/cache/#shrink_below_size), and [`shrink_one`](../../developer/api/flowmachine/core/cache/#shrink_one). `shrink_one` flushes the table with the _lowest_ cache score. `shrink_below_size` flushes tables until the disk space used by the cache falls below a threshold[^1] by calling `shrink_one` repeatedly.
 
+If necessary, the cache can also be completely reset using the [`reset_cache`](../../developer/api/flowmachine/core/cache/#reset_cache) function.
+
 ### Removing a Specific Query from Cache
 
-If a specific query must be removed from the cache, then an administrator can retrieve the query's _object_ from FlowDB by using the [`get_query_by_id`](../../developer/api/flowmachine/core/cache/#get_query_by_id) function of the `cache` submodule, and calling the object's [`invalidate_db_cache`](../../developer/api/flowmachine/core/query/#invalidate_db_cache) method.
+If a specific query must be removed from the cache, then an administrator can use the [`invalidate_cache_by_id`](../../developer/api/flowmachine/core/cache/#invalidate_cache_by_id) function of the `cache` submodule.
 
-By default, calling this method will also flush from the cache any cached queries which used that query in their calculation. This will also cascade to any queries which used _those_ queries, and so on. Setting the `cascade` argument to `False` will remove only the one query.
+By default, this function only removes that specific query from cache. However, setting the `cascade` argument to `True` will also flush from the cache any cached queries which used that query in their calculation. This will also cascade to any queries which used _those_ queries, and so on.
 
 ### Configuring the Cache
 

--- a/flowdb/bin/build/002_tweak_config.sh
+++ b/flowdb/bin/build/002_tweak_config.sh
@@ -22,6 +22,7 @@
 #  Generates config file using the configurate.py script
 #  and adds it to the PostgreSQL general configuration.
 #
+set -e
 
 python3 /docker-entrypoint-initdb.d/configurate.py
 echo "include 'postgresql.configurator.conf'" >> /var/lib/postgresql/data/postgresql.conf

--- a/flowdb/bin/build/08_configure_cache.sh
+++ b/flowdb/bin/build/08_configure_cache.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+#
+#  Cache configuration
+#  -------------
+#
+#  Sends cache controlling environment variables to the cache
+#  settings table.
+#
+
+# Get available disk space where postgresql dir is mounted
+avail=$(df --output=avail -B 1 "/var/lib/postgresql/data" | tail -n 1)
+# Default cache to a tenth of available space
+CACHE_SIZE=${CACHE_SIZE:-$(expr $avail / 10)}
+# Default half-life to 1000
+CACHE_HALF_LIFE=${CACHE_HALF_LIFE:-1000}
+echo "Setting cache size to $CACHE_SIZE bytes"
+echo "Setting cache half-life to $CACHE_HALF_LIFE"
+export PGUSER="$POSTGRES_USER"
+psql --dbname="$POSTGRES_DB" -c "
+        UPDATE cache.cache_config set value='$CACHE_HALF_LIFE' WHERE key='half_life';
+        UPDATE cache.cache_config set value='$CACHE_SIZE' WHERE key='cache_size';
+        "

--- a/flowdb/bin/build/last_create_roles.sh
+++ b/flowdb/bin/build/last_create_roles.sh
@@ -140,6 +140,13 @@ do
         "
 done
 
+echo "Give $FM_USER role read and update access to cache_touches sequence"
+psql --dbname="$POSTGRES_DB" -c "
+    BEGIN;
+        GRANT USAGE, SELECT, UPDATE ON SEQUENCE cache.cache_touches TO $FM_USER;
+    COMMIT;
+    "
+
 echo "Give $API_USER role read access to tables created under cache schema."
 psql --dbname="$POSTGRES_DB" -c "
     BEGIN;

--- a/flowdb/sql/07_schema_cache.sql
+++ b/flowdb/sql/07_schema_cache.sql
@@ -46,5 +46,5 @@ CREATE TABLE IF NOT EXISTS cache.dependencies
                             );
 
 CREATE TABLE cache.cache_config (key text, value text);
-INSERT INTO cache.cache_config (key, value) VALUES ('half_life', 1000);
-INSERT INTO cache.cache_config (key, value) VALUES ('cache_size', 4950307635);
+INSERT INTO cache.cache_config (key, value) VALUES ('half_life', 0);
+INSERT INTO cache.cache_config (key, value) VALUES ('cache_size', 0);

--- a/flowdb/sql/07_schema_cache.sql
+++ b/flowdb/sql/07_schema_cache.sql
@@ -46,5 +46,5 @@ CREATE TABLE IF NOT EXISTS cache.dependencies
                             );
 
 CREATE TABLE cache.cache_config (key text, value text);
-INSERT INTO cache.cache_config (key, value) VALUES ('half_life', 0);
-INSERT INTO cache.cache_config (key, value) VALUES ('cache_size', 0);
+INSERT INTO cache.cache_config (key, value) VALUES ('half_life', NULL);
+INSERT INTO cache.cache_config (key, value) VALUES ('cache_size', NULL);

--- a/flowdb/sql/07_schema_cache.sql
+++ b/flowdb/sql/07_schema_cache.sql
@@ -17,13 +17,19 @@ CREATE TABLE IF NOT EXISTS cache.cached
                                 query_id CHARACTER(32) NOT NULL,
                                 version CHARACTER VARYING,
                                 query TEXT,
-                                ts TIMESTAMP WITH TIME ZONE,
+                                created TIMESTAMP WITH TIME ZONE,
+                                access_count INTEGER,
+                                last_accessed TIMESTAMP WITH TIME ZONE,
+                                compute_time NUMERIC,
+                                cache_score_multiplier NUMERIC,
                                 class CHARACTER VARYING,
                                 schema CHARACTER VARYING,
                                 tablename CHARACTER VARYING,
                                 obj BYTEA,
                                 CONSTRAINT cache_pkey PRIMARY KEY (query_id)
                             );
+/* Sequence counting total number of retrievals from cache */
+CREATE SEQUENCE cache.cache_touches START 1;
 CREATE TABLE IF NOT EXISTS cache.dependencies
                             (
                                 query_id CHARACTER(32) NOT NULL,
@@ -38,3 +44,7 @@ CREATE TABLE IF NOT EXISTS cache.dependencies
                                     ON UPDATE NO ACTION
                                     ON DELETE CASCADE
                             );
+
+CREATE TABLE cache.cache_config (key text, value text);
+INSERT INTO cache.cache_config (key, value) VALUES ('half_life', 1000);
+INSERT INTO cache.cache_config (key, value) VALUES ('cache_size', 4950307635);

--- a/flowdb/sql/functions_001_utilities.sql
+++ b/flowdb/sql/functions_001_utilities.sql
@@ -308,7 +308,7 @@ Calculate a cache score from a multiplier, compute time in ms and the size of th
 
 ***********************************/
 
-CREATE OR REPLACE FUNCTION cache_score(IN cache_score_multiplier FLOAT, IN compute_time FLOAT, IN tablesize INT)
+CREATE OR REPLACE FUNCTION cache_score(IN cache_score_multiplier numeric, IN compute_time numeric, IN tablesize double precision)
 	RETURNS float AS
 $$
   BEGIN

--- a/flowmachine/Pipfile
+++ b/flowmachine/Pipfile
@@ -32,6 +32,7 @@ pytest-asyncio = "*"
 pytest-cov = "*"
 asynctest = "*"
 flowmachine = {editable = true,path = "."}
+cachey = "*"
 
 [requires]
 python_version = "3.7"

--- a/flowmachine/Pipfile.lock
+++ b/flowmachine/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a4773eaf58d788d30c36a2c716a800df09a541948e1b9901b6edf0ac3469c144"
+            "sha256": "186904d8e7da6d2401d913810f4ad55ab4662b0f47dd8adec7aae2daefacff49"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -304,6 +304,13 @@
             "index": "pypi",
             "version": "==3.0.0"
         },
+        "cachey": {
+            "hashes": [
+                "sha256:de1db64409158d40acdfdd869ccbca7ce90b2f2ba20d44fb68f32e72f5679f21"
+            ],
+            "index": "pypi",
+            "version": "==0.1.1"
+        },
         "cfgv": {
             "hashes": [
                 "sha256:39d9055c47e3932908fe25abd5807e21dc002630db01c7a5f05738d027e2b706",
@@ -427,6 +434,12 @@
             ],
             "index": "pypi",
             "version": "==0.4.0"
+        },
+        "heapdict": {
+            "hashes": [
+                "sha256:40c9e3680616cfdf942f77429a3a9e0a76f31ce965d62f4ffbe63a83a5ef1b5a"
+            ],
+            "version": "==1.0.0"
         },
         "identify": {
             "hashes": [
@@ -745,6 +758,16 @@
         },
         "pyproj": {
             "hashes": [
+                "sha256:026074694f9e9a3110013802c5ceb2728070dbdde9f1038609f942845f4207d1",
+                "sha256:25e244b84da0b673e2969fdfe2d98f2f94c74a8baea1dd88928f2cf7c1410cba",
+                "sha256:30739f8f0dc266563643799609c5d404d48d6b412bdba1d2fef8eed7f5782c5f",
+                "sha256:379cf8afd80f254dc7ee30c2a7a499e71bcc0f33c435e46b6c0ea30496faacb2",
+                "sha256:569c764b391e31d4b156acb09acde9afb0c1bf1a71ca6e829e4677220ca64a56",
+                "sha256:56dc74a5aa0878d2332e4edd931687e5b8fb18edd242cf8cff60217ce4ef0720",
+                "sha256:5b1553d80b35c6582a79252fc2a4e5d82d95383fbbfc671650d6fe54e18bbb9c",
+                "sha256:629acc34d8c2ff6fa2875e6075555fcb17a033cd3e181613e8782110fcc2f6b1",
+                "sha256:a7fa5da448dcdbd787e70e21dcf6c71a14bc048db86027f2fc3fe005b9440b93",
+                "sha256:c6d7c3c11c9f8f043fb00658f2146c10e3e0e21b5459022ae5716994650d6a02",
                 "sha256:e0c02b1554b20c710d16d673817b2a89ff94738b0b537aead8ecb2edc4c4487b"
             ],
             "version": "==1.9.6"

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -110,7 +110,9 @@ def get_query_object_by_id(connection: "Connection", query_id: str) -> "Query":
         raise ValueError(f"Query id '{query_id}' is not in cache on this connection.")
 
 
-def get_cached_query_objects_ordered_by_score(connection: "Connection") -> List[Tuple["Query", int]]:
+def get_cached_query_objects_ordered_by_score(
+    connection: "Connection"
+) -> List[Tuple["Query", int]]:
     """
     Get all cached query objects in ascending cache score order.
 

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -169,6 +169,9 @@ def shrink_below_size(
     else:
         shrink = shrink_one
 
+    if size_threshold is None:
+        size_threshold = get_max_size_of_cache(connection)
+
     while initial_cache_size > size_threshold:
         obj_removed, cache_reduction = shrink(connection)
         removed.append(obj_removed)

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -51,6 +51,11 @@ def reset_cache(connection: "Connection") -> None:
     ----------
     connection : Connection
     """
+    # For deletion purposes, we ignore Table objects. These either point to something
+    # outside the cache schema and hence shouldn't be removed by calling this, or
+    # they point to a cache table and hence are a duplicate of a Query entry which
+    # will also point to that table.
+
     qry = f"SELECT tablename FROM cache.cached WHERE NOT class='Table'"
     tables = connection.fetch(qry)
     with connection.engine.begin() as trans:

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -184,7 +184,7 @@ def shrink_below_size(
     list of "Query"
         List of the queries that were removed
     """
-    initial_cache_size = size_of_cache(connection)
+    initial_cache_size = get_size_of_cache(connection)
     removed = []
     logger.info(
         f"Shrinking cache from {initial_cache_size} to below {size_threshold}{' (dry run)' if dry_run else ''}."
@@ -209,7 +209,9 @@ def shrink_below_size(
     return removed
 
 
-def size_of_table(connection: "Connection", table_name: str, table_schema: str) -> int:
+def get_size_of_table(
+    connection: "Connection", table_name: str, table_schema: str
+) -> int:
     """
     Get the size on disk in bytes of a table in the database.
 
@@ -236,7 +238,7 @@ def size_of_table(connection: "Connection", table_name: str, table_schema: str) 
         )
 
 
-def size_of_cache(connection: "Connection") -> int:
+def get_size_of_cache(connection: "Connection") -> int:
     """
     Get the total size in bytes of all cache tables.
 
@@ -331,7 +333,7 @@ def set_max_size_of_cache(connection: "Connection", cache_size_limit: int) -> No
         trans.execute(sql)
 
 
-def compute_time(connection: "Connection", query_id: str) -> float:
+def get_compute_time(connection: "Connection", query_id: str) -> float:
     """
     Get the time in seconds that a cached query took to compute.
 
@@ -358,7 +360,7 @@ def compute_time(connection: "Connection", query_id: str) -> float:
         raise ValueError(f"Query id '{query_id}' is not in cache on this connection.")
 
 
-def score(connection: "Connection", query_id: str) -> float:
+def get_score(connection: "Connection", query_id: str) -> float:
     """
     Get the current cache score for a cached query.
 

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -86,7 +86,7 @@ def invalidate_cache_by_id(
     return query_obj
 
 
-def get_query_by_id(connection: "Connection", query_id: str) -> "Query":
+def get_query_object_by_id(connection: "Connection", query_id: str) -> "Query":
     """
     Get a query object from cache by id.
 

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -162,7 +162,7 @@ def shrink_one(connection: "Connection", dry_run: bool = False) -> "Query":
         f"{'Would' if dry_run else 'Will'} remove cache record for {obj_to_remove.md5} of type {obj_to_remove.__class__}"
     )
     logger.info(
-        f"Table {obj_to_remove.table_name} ({obj_size} bytes) {'would' if dry_run else 'will'} be removed."
+        f"Table {obj_to_remove.fully_qualified_table_name} ({obj_size} bytes) {'would' if dry_run else 'will'} be removed."
     )
 
     if not dry_run:
@@ -203,7 +203,9 @@ def shrink_below_size(
             logger.info(
                 f"Would remove cache record for {obj.md5} of type {obj.__class__}"
             )
-            logger.info(f"Table {obj.table_name} ({obj_size} bytes) would be removed.")
+            logger.info(
+                f"Table {obj.fully_qualified_table_name} ({obj_size} bytes) would be removed."
+            )
             return obj, obj_size
 
         shrink = dry_run_shrink

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -185,7 +185,7 @@ def shrink_below_size(
     initial_cache_size = size_of_cache(connection)
     removed = []
     logger.info(
-        f"Shrinking cache from {initial_cache_size} to below {size_threshold}{'(dry run)' if dry_run else ''}."
+        f"Shrinking cache from {initial_cache_size} to below {size_threshold}{' (dry run)' if dry_run else ''}."
     )
 
     if dry_run:

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -192,7 +192,16 @@ def shrink_below_size(
 
     if dry_run:
         cached_queries = iter(get_cached_query_objects_ordered_by_score(connection))
-        shrink = lambda x: cached_queries.__next__()
+
+        def dry_run_shrink(connection):
+            obj, obj_size = cached_queries.__next__()
+            logger.info(
+                f"Would remove cache record for {obj.md5} of type {obj.__class__}"
+            )
+            logger.info(f"Table {obj.table_name} ({obj_size} bytes) would be removed.")
+            return obj, obj_size
+
+        shrink = dry_run_shrink
     else:
         shrink = shrink_one
 

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -309,9 +309,8 @@ def set_cache_half_life(connection: "Connection", cache_half_life: float) -> Non
     Changing this setting without flushing the cache first may have unpredictable consequences
     and should be avoided.
     """
-    sql = (
-        f"UPDATE cache.cache_config SET value='{cache_half_life}' WHERE key='half_life'"
-    )
+
+    sql = f"UPDATE cache.cache_config SET value='{float(cache_half_life)}' WHERE key='half_life'"
     with connection.engine.begin() as trans:
         trans.execute(sql)
 
@@ -327,7 +326,7 @@ def set_max_size_of_cache(connection: "Connection", cache_size_limit: int) -> No
         Size in bytes to set as the cache limit
 
     """
-    sql = f"UPDATE cache.cache_config SET value='{cache_size_limit}' WHERE key='cache_size'"
+    sql = f"UPDATE cache.cache_config SET value='{int(cache_size_limit)}' WHERE key='cache_size'"
     with connection.engine.begin() as trans:
         trans.execute(sql)
 

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -291,7 +291,7 @@ def set_cache_half_life(connection: "Connection", cache_half_life: float) -> Non
 
 def set_max_size_of_cache(connection: "Connection", cache_size_limit: int) -> None:
     """
-    Get the upper limit set in FlowDB for the cache size, in bytes.
+    Set the upper limit set in FlowDB for the cache size, in bytes.
 
     Parameters
     ----------

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -332,7 +332,7 @@ def set_max_size_of_cache(connection: "Connection", cache_size_limit: int) -> No
 
 def compute_time(connection: "Connection", query_id: str) -> float:
     """
-    Get the time in ms that a cached query took to compute.
+    Get the time in seconds that a cached query took to compute.
 
     Parameters
     ----------

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -266,7 +266,7 @@ def get_max_size_of_cache(connection: "Connection") -> int:
     Returns
     -------
     int
-        Number of bytes in total available cache tables
+        Number of bytes in total available to cache tables
 
     """
     sql = "SELECT cache_max_size()"

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -14,8 +14,6 @@ from typing import TYPE_CHECKING, Tuple, List
 
 from psycopg2 import InternalError
 
-from flowmachine.core import Query
-
 if TYPE_CHECKING:
     from .query import Query
     from .connection import Connection

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -112,7 +112,7 @@ def get_query_object_by_id(connection: "Connection", query_id: str) -> "Query":
 
 def get_cached_query_objects_ordered_by_score(connection: "Connection") -> List[Tuple["Query", int]]:
     """
-    Get all cached queries in ascending cache score order.
+    Get all cached query objects in ascending cache score order.
 
     Parameters
     ----------

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -110,7 +110,7 @@ def get_query_object_by_id(connection: "Connection", query_id: str) -> "Query":
         raise ValueError(f"Query id '{query_id}' is not in cache on this connection.")
 
 
-def get_cached_queries_by_score(connection: "Connection") -> List[Tuple["Query", int]]:
+def get_cached_query_objects_ordered_by_score(connection: "Connection") -> List[Tuple["Query", int]]:
     """
     Get all cached queries in ascending cache score order.
 

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -1,0 +1,356 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# -*- coding: utf-8 -*-
+
+"""
+Functions which deal with inspecting cached tables.
+"""
+import logging
+import pickle
+
+from typing import TYPE_CHECKING, Tuple, List
+
+from psycopg2 import InternalError
+
+if TYPE_CHECKING:
+    from .query import Query
+    from .connection import Connection
+
+logger = logging.getLogger("flowmachine").getChild(__name__)
+
+
+def touch_cache(connection: "Connection", query_id: str) -> float:
+    """
+    'Touch' a cache record and update the cache score for it.
+
+    Parameters
+    ----------
+    connection : Connection
+    query_id : str
+        md5 id of the query to touch
+
+    Returns
+    -------
+    float
+        The new cache score
+    """
+    try:
+        return float(connection.fetch(f"SELECT touch_cache('{query_id}')")[0][0])
+    except (IndexError, InternalError):
+        raise ValueError(f"Query id '{query_id}' is not in cache on this connection.")
+
+
+def reset_cache(connection: "Connection") -> None:
+    """
+    Reset the query cache. Deletes any tables under cache schema, resets the cache count
+    and clears the cached and dependencies tables.
+
+    Parameters
+    ----------
+    connection : Connection
+    """
+    qry = f"SELECT tablename FROM cache.cached WHERE NOT class='Table'"
+    tables = connection.fetch(qry)
+    with connection.engine.begin() as trans:
+        trans.execute("SELECT setval('cache.cache_touches', 1)")
+        for table in tables:
+            trans.execute(f"DROP TABLE IF EXISTS cache.{table[0]} CASCADE")
+        trans.execute("TRUNCATE cache.cached CASCADE")
+        trans.execute("TRUNCATE cache.dependencies CASCADE")
+
+
+def get_query_by_id(connection: "Connection", query_id: str) -> "Query":
+    """
+    Get a query object from cache by id.
+
+    Parameters
+    ----------
+    connection : Connection
+    query_id : str
+        md5 id of the query
+
+    Returns
+    -------
+    Query
+        The original query object.
+
+    """
+    qry = f"SELECT obj FROM cache.cached WHERE query_id='{query_id}'"
+    try:
+        obj = connection.fetch(qry)[0][0]
+        return pickle.loads(obj)
+    except IndexError:
+        raise ValueError(f"Query id '{query_id}' is not in cache on this connection.")
+
+
+def get_cached_queries_by_score(connection: "Connection") -> List[Tuple["Query", int]]:
+    """
+    Get all cached queries in ascending cache score order.
+
+    Parameters
+    ----------
+    connection : Connection
+
+    Returns
+    -------
+    list of tuples
+        Returns a list of cached Query objects with their on disk sizes
+
+    """
+    qry = """SELECT obj, table_size(tablename, schema) as table_size
+        FROM cache.cached
+        WHERE NOT cached.class='Table'
+        ORDER BY cache_score_multiplier*((compute_time/1000)/table_size(tablename, schema)) ASC
+        """
+    cache_queries = connection.fetch(qry)
+    return [(pickle.loads(obj), table_size) for obj, table_size in cache_queries]
+
+
+def shrink_one(connection: "Connection", dry_run: bool = False) -> "Query":
+    """
+    Remove the lowest scoring cached query from cache and return it and size of it
+    in bytes.
+
+    Parameters
+    ----------
+    connection : "Connection"
+    dry_run : bool, default False
+        Set to true to just report the object that would be removed and not remove it
+
+    Returns
+    -------
+    tuple of "Query", int
+        The "Query" object that was removed from cache and the size of it
+    """
+    obj_to_remove, obj_size = get_cached_queries_by_score(connection)[0]
+
+    logger.info(
+        f"{'Would' if dry_run else 'Will'} remove cache record for {obj_to_remove.md5} of type {obj_to_remove.__class__}"
+    )
+    logger.info(
+        f"Table {obj_to_remove.table_name} ({obj_size} bytes) {'would' if dry_run else 'will'} be removed."
+    )
+
+    if not dry_run:
+        obj_to_remove.invalidate_db_cache(cascade=False, drop=True)
+    return obj_to_remove, obj_size
+
+
+def shrink_below_size(
+    connection: "Connection", size_threshold: int = None, dry_run: bool = False
+) -> "Query":
+    """
+    Remove queries from the cache until it is below a specified size threshold.
+
+    Parameters
+    ----------
+    connection : "Connection"
+    size_threshold : int, default None
+        Optionally override the maximum cache size set in flowdb.
+    dry_run : bool, default False
+        Set to true to just report the objects that would be removed and not remove them
+
+    Returns
+    -------
+    list of "Query"
+        List of the queries that were removed
+    """
+    initial_cache_size = size_of_cache(connection)
+    removed = []
+    logger.info(
+        f"Shrinking cache from {initial_cache_size} to below {size_threshold}{'(dry run)' if dry_run else ''}."
+    )
+
+    if dry_run:
+        cached_queries = iter(get_cached_queries_by_score(connection))
+        shrink = lambda x: cached_queries.__next__()
+    else:
+        shrink = shrink_one
+
+    while initial_cache_size > size_threshold:
+        obj_removed, cache_reduction = shrink(connection)
+        removed.append(obj_removed)
+        initial_cache_size -= cache_reduction
+    logger.info(
+        f"New cache size {'would' if dry_run else 'will'} be {initial_cache_size}."
+    )
+    return removed
+
+
+def size_of_table(connection: "Connection", table_name: str, table_schema: str) -> int:
+    """
+    Get the size on disk in bytes of a table in the database.
+
+    Parameters
+    ----------
+    connection : "Connection"
+    table_name : str
+        Name of table to get size of
+    table_schema : str
+        Schema of the table
+
+    Returns
+    -------
+    int
+        Number of bytes on disk this table uses in total
+
+    """
+    sql = f"SELECT table_size('{table_name}', '{table_schema}')"
+    try:
+        return int(connection.fetch(sql)[0][0])
+    except IndexError:
+        raise ValueError(
+            f"Table '{table_schema}.{table_name}' does not exist on this connection."
+        )
+
+
+def size_of_cache(connection: "Connection") -> int:
+    """
+    Get the total size in bytes of all cache tables.
+
+    Parameters
+    ----------
+    connection : "Connection"
+
+    Returns
+    -------
+    int
+        Number of bytes in total used by cache tables
+
+    """
+    sql = """SELECT sum(table_size(tablename, schema)) as total_bytes 
+        FROM cache.cached  
+        WHERE NOT cached.class='Table'"""
+    cache_bytes = connection.fetch(sql)[0][0]
+    return 0 if cache_bytes is None else int(cache_bytes)
+
+
+def get_max_size_of_cache(connection: "Connection") -> int:
+    """
+    Get the upper limit set in FlowDB for the cache size, in bytes.
+
+    Parameters
+    ----------
+    connection : "Connection"
+
+    Returns
+    -------
+    int
+        Number of bytes in total available cache tables
+
+    """
+    sql = "SELECT cache_max_size()"
+    return int(connection.fetch(sql)[0][0])
+
+
+def get_cache_half_life(connection: "Connection") -> float:
+    """
+    Get the current setting for cache half-life.
+
+    Parameters
+    ----------
+    connection : "Connection"
+
+    Returns
+    -------
+    float
+        Cache half-life setting
+
+    """
+    sql = "SELECT cache_half_life()"
+    return float(connection.fetch(sql)[0][0])
+
+
+def set_cache_half_life(connection: "Connection", cache_half_life: float) -> None:
+    """
+    Set the cache's half-life.
+
+    Parameters
+    ----------
+    connection : "Connection"
+    cache_half_life : float
+        Setting for half-life
+
+    Notes
+    -----
+
+    Changing this setting without flushing the cache first may have unpredictable consequences
+    and should be avoided.
+    """
+    sql = (
+        f"UPDATE cache.cache_config SET value='{cache_half_life}' WHERE key='half_life'"
+    )
+    with connection.engine.begin() as trans:
+        trans.execute(sql)
+
+
+def set_max_size_of_cache(connection: "Connection", cache_size_limit: int) -> None:
+    """
+    Get the upper limit set in FlowDB for the cache size, in bytes.
+
+    Parameters
+    ----------
+    connection : "Connection"
+    cache_size_limit : int
+        Size in bytes to set as the cache limit
+
+    """
+    sql = f"UPDATE cache.cache_config SET value='{cache_size_limit}' WHERE key='cache_size'"
+    with connection.engine.begin() as trans:
+        trans.execute(sql)
+
+
+def compute_time(connection: "Connection", query_id: str) -> float:
+    """
+    Get the time in ms that a cached query took to compute.
+
+    Parameters
+    ----------
+    connection : "Connection"
+    query_id : str
+        md5 identifier of the query
+
+    Returns
+    -------
+    float
+        Number of seconds the query took to compute
+
+    """
+    try:
+        return float(
+            connection.fetch(
+                f"SELECT compute_time FROM cache.cached WHERE query_id='{query_id}'"
+            )[0][0]
+            / 1000
+        )
+    except IndexError:
+        raise ValueError(f"Query id '{query_id}' is not in cache on this connection.")
+
+
+def score(connection: "Connection", query_id: str) -> float:
+    """
+    Get the current cache score for a cached query.
+
+    Parameters
+    ----------
+    connection: "Connection"
+    query_id : str
+        md5 id of the cached query
+
+    Returns
+    -------
+    float
+        Current cache score of this query
+
+    """
+    try:
+        return float(
+            connection.fetch(
+                f"""SELECT cache_score_multiplier*((compute_time/1000)/table_size(tablename, schema))
+                 FROM cache.cached WHERE query_id='{query_id}'"""
+            )[0][0]
+        )
+    except IndexError:
+        raise ValueError(f"Query id '{query_id}' is not in cache on this connection.")

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -81,7 +81,7 @@ def invalidate_cache_by_id(
         The original query object.
 
     """
-    query_obj = get_query_by_id(connection, query_id)
+    query_obj = get_query_object_by_id(connection, query_id)
     query_obj.invalidate_db_cache(cascade=cascade)
     return query_obj
 
@@ -151,7 +151,7 @@ def shrink_one(connection: "Connection", dry_run: bool = False) -> "Query":
     tuple of "Query", int
         The "Query" object that was removed from cache and the size of it
     """
-    obj_to_remove, obj_size = get_cached_queries_by_score(connection)[0]
+    obj_to_remove, obj_size = get_cached_query_objects_ordered_by_score(connection)[0]
 
     logger.info(
         f"{'Would' if dry_run else 'Will'} remove cache record for {obj_to_remove.md5} of type {obj_to_remove.__class__}"
@@ -191,7 +191,7 @@ def shrink_below_size(
     )
 
     if dry_run:
-        cached_queries = iter(get_cached_queries_by_score(connection))
+        cached_queries = iter(get_cached_query_objects_ordered_by_score(connection))
         shrink = lambda x: cached_queries.__next__()
     else:
         shrink = shrink_one

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING, Tuple, List
 
 from psycopg2 import InternalError
 
+from flowmachine.core import Query
+
 if TYPE_CHECKING:
     from .query import Query
     from .connection import Connection
@@ -399,3 +401,25 @@ def get_score(connection: "Connection", query_id: str) -> float:
         )
     except IndexError:
         raise ValueError(f"Query id '{query_id}' is not in cache on this connection.")
+
+
+def cache_table_exists(connection: "Connection", query_id: str) -> bool:
+    """
+    Return True if a cache table for the query with
+    id `query_id` exist, otherwise return False.
+
+    Parameters
+    ----------
+    connection: "Connection"
+    query_id : str
+        md5 id of the cached query
+
+    Returns
+    -------
+    bool
+    """
+    try:
+        _ = get_query_object_by_id(connection, query_id)
+        return True
+    except ValueError:
+        return False

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -5,7 +5,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Functions which deal with inspecting cached tables.
+Functions which deal with inspecting and managing the query cache.
 """
 import logging
 import pickle

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -61,6 +61,31 @@ def reset_cache(connection: "Connection") -> None:
         trans.execute("TRUNCATE cache.dependencies CASCADE")
 
 
+def invalidate_cache_by_id(
+    connection: "Connection", query_id: str, cascade=False
+) -> "Query":
+    """
+    Remove a query object from cache by id.
+
+    Parameters
+    ----------
+    connection : Connection
+    query_id : str
+        md5 id of the query
+    cascade : bool, default False
+        Set to true to remove any queries that depend on the one being removed
+
+    Returns
+    -------
+    Query
+        The original query object.
+
+    """
+    query_obj = get_query_by_id(connection, query_id)
+    query_obj.invalidate_db_cache(cascade=cascade)
+    return query_obj
+
+
 def get_query_by_id(connection: "Connection", query_id: str) -> "Query":
     """
     Get a query object from cache by id.

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -134,7 +134,7 @@ def get_cached_query_objects_ordered_by_score(
     qry = """SELECT obj, table_size(tablename, schema) as table_size
         FROM cache.cached
         WHERE NOT cached.class='Table'
-        ORDER BY cache_score_multiplier*((compute_time/1000)/table_size(tablename, schema)) ASC
+        ORDER BY cache_score(cache_score_multiplier, compute_time, table_size(tablename, schema)) ASC
         """
     cache_queries = connection.fetch(qry)
     return [(pickle.loads(obj), table_size) for obj, table_size in cache_queries]
@@ -393,7 +393,7 @@ def get_score(connection: "Connection", query_id: str) -> float:
     try:
         return float(
             connection.fetch(
-                f"""SELECT cache_score_multiplier*((compute_time/1000)/table_size(tablename, schema))
+                f"""SELECT cache_score(cache_score_multiplier, compute_time, table_size(tablename, schema))
                  FROM cache.cached WHERE query_id='{query_id}'"""
             )[0][0]
         )

--- a/flowmachine/flowmachine/core/model.py
+++ b/flowmachine/flowmachine/core/model.py
@@ -14,6 +14,7 @@ running the model.
 
 
 """
+import time
 from abc import ABCMeta, abstractmethod
 from functools import wraps
 
@@ -72,7 +73,9 @@ def model_result(f):
         mr = ModelResult(self, run_args=args, run_kwargs=kwargs)
         if mr.is_stored:
             return mr
+        start_time = time.perf_counter()  # TODO: Should use process time here really
         mr._df = f(self, *args, **kwargs)
+        mr._runtime = time.perf_counter() - start_time
         return mr
 
     return new_f

--- a/flowmachine/flowmachine/core/model.py
+++ b/flowmachine/flowmachine/core/model.py
@@ -73,9 +73,9 @@ def model_result(f):
         mr = ModelResult(self, run_args=args, run_kwargs=kwargs)
         if mr.is_stored:
             return mr
-        start_time = time.perf_counter()  # TODO: Should use process time here really
+        start_time = time.process_time()
         mr._df = f(self, *args, **kwargs)
-        mr._runtime = time.perf_counter() - start_time
+        mr._runtime = time.process_time() - start_time
         return mr
 
     return new_f

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -572,7 +572,7 @@ class Query(metaclass=ABCMeta):
     @property
     def fully_qualified_table_name(self):
         """
-        Returns a unique name for the query to be stored under, based on
+        Returns a unique fully qualified name for the query to be stored as under the cache schema, based on
         a hash of the parameters, class, and subqueries.
 
         Returns
@@ -580,7 +580,20 @@ class Query(metaclass=ABCMeta):
         str
             String form of the table's fqn
         """
-        return "cache.x{}".format(self.md5)
+        return f"cache.{self.table_name}"
+
+    @property
+    def table_name(self):
+        """
+        Returns a uniquename for the query to be stored as, based on
+        a hash of the parameters, class, and subqueries.
+
+        Returns
+        -------
+        str
+            String form of the table's fqn
+        """
+        return f"x{self.md5}"
 
     @property
     def is_stored(self):

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -758,9 +758,9 @@ class Query(metaclass=ABCMeta):
         with rlock(self.redis, self.md5):
             con = self.connection.engine
             try:
-                table_form = self.get_table()
-                if table_form is not self:
-                    table_form.invalidate_db_cache(
+                table_reference_to_this_query = self.get_table()
+                if table_reference_to_this_query is not self:
+                    table_reference_to_this_query.invalidate_db_cache(
                         cascade=cascade, drop=drop
                     )  # Remove any Table pointing as this query
             except (ValueError, NotImplementedError) as e:

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -8,11 +8,13 @@ This is the base class that defines any query on our database.  It simply
 defines methods that returns the query as a string and as a pandas dataframe.
 
 """
-import csv
+
+import os
 import pickle
 import logging
 import weakref
-from typing import List
+from concurrent.futures import Future
+from typing import List, Union
 
 import psycopg2
 import networkx as nx
@@ -20,6 +22,9 @@ import pandas as pd
 
 from hashlib import md5
 
+from sqlalchemy.exc import ResourceClosedError
+
+from flowmachine.core.cache import touch_cache
 from flowmachine.utils.utils import rlock
 from abc import ABCMeta, abstractmethod
 
@@ -188,6 +193,10 @@ class Query(metaclass=ABCMeta):
             schema, name = table_name.split(".")
             with rlock(self.redis, self.md5):
                 if self.connection.has_table(schema=schema, name=name):
+                    try:
+                        touch_cache(self.connection, self.md5)
+                    except ValueError:
+                        pass  # Cache record not written yet
                     return "SELECT * FROM {}".format(table_name)
         except NotImplementedError:
             pass
@@ -405,7 +414,9 @@ class Query(metaclass=ABCMeta):
         subset_class = subset_numbers_factory(self.__class__)
         return subset_class(self, col, low, high)
 
-    def _make_sql(self, name=None, schema=None, as_view=False, force=False):
+    def _make_sql(
+        self, name: str, schema: Union[str, None] = None, force: bool = False
+    ) -> List[str]:
         """
         Create the SQL necessary to store the result of the calculation back
         into the database.
@@ -417,9 +428,6 @@ class Query(metaclass=ABCMeta):
         schema : str, default None
             Name of an existing schema. If none will use the postgres default,
             see postgres docs for more info.
-        as_view : bool, default False
-            Set to True to store as a view rather than a table. A view
-            is always up to date even if the underlying data changes.
         force : bool, default False
             Will overwrite an existing table if the name already exists
 
@@ -428,12 +436,6 @@ class Query(metaclass=ABCMeta):
         list
             Ordered list of SQL strings to execute.
         """
-
-        table_type = ""
-        if as_view:
-            table_type += "VIEW "
-        else:
-            table_type += "TABLE "
 
         if schema is not None:
             full_name = "{}.{}".format(schema, name)
@@ -445,23 +447,20 @@ class Query(metaclass=ABCMeta):
             logger.info("Table already exists")
             return []
 
-        Q = "CREATE "
-        Q += table_type
-        Q += full_name
-        Q += " AS ({})".format(self._make_query() if force else self.get_query())
+        Q = f"""EXPLAIN (ANALYZE TRUE, TIMING FALSE, FORMAT JSON) CREATE TABLE {full_name} AS 
+            ({self._make_query() if force else self.get_query()})"""
         queries.append(Q)
-        if not as_view:  # Views can't be indexed
-            for ix in self.index_cols:
-                queries.append(
-                    "CREATE INDEX ON {tbl} ({ixen})".format(
-                        tbl=full_name, ixen=",".join(ix) if isinstance(ix, list) else ix
-                    )
+        for ix in self.index_cols:
+            queries.append(
+                "CREATE INDEX ON {tbl} ({ixen})".format(
+                    tbl=full_name, ixen=",".join(ix) if isinstance(ix, list) else ix
                 )
+            )
         return queries
 
-    def to_sql_async(
-        self, name=None, schema=None, as_view=False, as_temp=False, force=False
-    ):
+    def to_sql(
+        self, name: str, schema: Union[str, None] = None, force: bool = False
+    ) -> Future:
         """
         Store the result of the calculation back into the database.
 
@@ -472,12 +471,6 @@ class Query(metaclass=ABCMeta):
         schema : str, default None
             Name of an existing schema. If none will use the postgres default,
             see postgres docs for more info.
-        as_view : bool, default False
-            Set to True to store as a view rather than a table. A view
-            is always up to date even if the underlying data changes.
-        as_temp : bool, default False
-            Set to true to store this only for the duration of the
-            interpreter session
         force : bool, default False
             Will overwrite an existing table if the name already exists
 
@@ -498,62 +491,42 @@ class Query(metaclass=ABCMeta):
             ).format(name, len(name), MAX_POSTGRES_NAME_LENGTH)
             raise NameTooLongError(err_msg)
 
-        def do_query():
+        def do_query() -> Query:
             logger.debug("Getting storage lock.")
             with rlock(self.redis, self.md5):
                 logger.debug("Obtained storage lock.")
-                Qs = self._make_sql(name, schema=schema, as_view=as_view, force=force)
+                Qs = self._make_sql(name, schema=schema, force=force)
                 logger.debug("Made SQL.")
                 con = self.connection.engine
-                if force and not as_view:
+                if force:
                     self.invalidate_db_cache(name, schema=schema)
+                plan_time = 0
                 with con.begin():
-                    sql = """CREATE SCHEMA IF NOT EXISTS {}""".format(schema)
-                    con.execute(sql)
-                    try:
-                        for Q in Qs:
-                            con.execute(Q)
-                    except Exception as e:
-                        logger.error(f"Error executing SQL: '{Q}'. Error was {e}")
-                        raise e
+                    rs = []
+                    for Q in Qs:
+                        try:
+                            r = con.execute(Q)
+                        except Exception as e:
+                            logger.error(f"Error executing SQL: '{Q}'. Error was {e}")
+                            raise e
+                        try:
+                            rs.append(r.fetchall())
+                        except ResourceClosedError:
+                            pass  # Nothing to do here
+                        for r in rs:
+                            try:
+                                plan = r[0][0][0]
+                                plan_time += plan["Execution Time"]
+                            except (IndexError, KeyError):
+                                pass  # Not an explain result
                     logger.debug("Executed queries.")
-                    if not as_view and schema == "cache":
-                        self._db_store_cache_metadata()
+                    if schema == "cache":
+                        self._db_store_cache_metadata(compute_time=plan_time)
             logger.debug("Released storage lock.")
             return self
 
         store_future = self.tp.submit(do_query)
         return store_future
-
-    def to_sql(self, name=None, schema=None, as_view=False, force=False):
-        """
-        Store the result of the calculation back into the database.
-
-        Parameters
-        ----------
-        name : str
-            name of the table
-        schema : str, default None
-            Name of an existing schema. If none will use the postgres default,
-            see postgres docs for more info.
-        as_view : bool, default False
-            Set to True to store as a view rather than a table. A view
-            is always up to date even if the underlying data changes.
-        as_temp : bool, default False
-            Set to true to store this only for the duration of the
-            interpreter session
-        force : bool, default False
-            Will overwrite an existing table if the name already exists
-
-        Notes
-        -----
-
-        This method will block until the store has completed.
-        """
-
-        return self.to_sql_async(
-            name, schema=schema, as_view=as_view, force=force
-        ).result()
 
     def explain(self, format="text", analyse=False):
         """
@@ -615,12 +588,6 @@ class Query(metaclass=ABCMeta):
 
         try:
             schema, name = self.table_name.split(".")
-            with self.connection.engine.begin():
-                self.connection.engine.execute(
-                    "UPDATE cache.cached SET ts = NOW() WHERE query_id ='{}'".format(
-                        self.md5
-                    )
-                )
             return self.connection.has_table(name, schema)
         except NotImplementedError:
             return False
@@ -649,10 +616,10 @@ class Query(metaclass=ABCMeta):
 
         schema, name = table_name.split(".")
 
-        store_future = self.to_sql_async(name, schema=schema, force=force)
+        store_future = self.to_sql(name, schema=schema, force=force)
         return store_future
 
-    def _db_store_cache_metadata(self):
+    def _db_store_cache_metadata(self, compute_time=None):
         """
         Helper function for store, updates flowmachine metadata table to
         log that this query is stored, but does not actually store
@@ -676,19 +643,27 @@ class Query(metaclass=ABCMeta):
                     "SELECT * FROM cache.cached WHERE query_id='{}'".format(self.md5)
                 )
             )
+
             with con.begin():
+                cache_record_insert = """
+                INSERT INTO cache.cached 
+                (query_id, version, query, created, access_count, last_accessed, compute_time, 
+                cache_score_multiplier, class, schema, tablename, obj) 
+                VALUES (%s, %s, %s, NOW(), 0, NOW(), %s, 0, %s, %s, %s, %s)
+                 ON CONFLICT (query_id) DO UPDATE SET last_accessed = NOW();"""
                 con.execute(
-                    "INSERT INTO cache.cached values (%s, %s, %s, NOW(), %s, %s, %s, %s)"
-                    + " ON CONFLICT (query_id) DO UPDATE SET ts = NOW();",
+                    cache_record_insert,
                     (
                         self.md5,
                         __version__,
                         self._make_query(),
+                        compute_time,
                         self.__class__.__name__,
                         *self.table_name.split("."),
                         psycopg2.Binary(self_storage),
                     ),
                 )
+                con.execute("SELECT touch_cache(%s);", self.md5)
                 logger.debug("{} added to cache.".format(self.table_name))
                 if not in_cache:
                     for dep in self._get_deps(root=True):
@@ -777,6 +752,14 @@ class Query(metaclass=ABCMeta):
         """
         with rlock(self.redis, self.md5):
             con = self.connection.engine
+            try:
+                table_form = self.get_table()
+                if table_form is not self:
+                    table_form.invalidate_db_cache(
+                        cascade=cascade, drop=drop
+                    )  # Remove any Table pointing as this query
+            except (ValueError, NotImplementedError) as e:
+                pass  # This cache record isn't actually stored
             try:
                 deps = self.connection.fetch(
                     """SELECT obj FROM cache.cached LEFT JOIN cache.dependencies
@@ -879,6 +862,7 @@ class Query(metaclass=ABCMeta):
             "_query_object",
             "_cols",
             "_md5",
+            "_runtime",
         ]
         for k in bad_keys:
             try:

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -520,7 +520,7 @@ class Query(metaclass=ABCMeta):
                             pass  # Nothing to do here
                         for ddl_op_result in ddl_op_results:
                             try:
-                                plan = ddl_op_result[0][0][0]
+                                plan = ddl_op_result[0][0][0]  # Should be a query plan
                                 plan_time += plan["Execution Time"]
                             except (IndexError, KeyError):
                                 pass  # Not an explain result

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -196,7 +196,10 @@ class Query(metaclass=ABCMeta):
                     try:
                         touch_cache(self.connection, self.md5)
                     except ValueError:
-                        pass  # Cache record not written yet
+                        pass  # Cache record not written yet, which can happen for Models
+                        # which will call through to this method from their `_make_query` method while writing metadata.
+                    # In that scenario, the table _is_ written, but won't be visible from the connection touch_cache uses
+                    # as the cache metadata transaction isn't complete!
                     return "SELECT * FROM {}".format(table_name)
         except NotImplementedError:
             pass

--- a/flowmachine/flowmachine/core/random.py
+++ b/flowmachine/flowmachine/core/random.py
@@ -262,7 +262,7 @@ def random_factory(parent_class):
             """
 
             self.query = query
-            self.table = self.query.table_name
+            self.table = self.query.fully_qualified_table_name
             self.size = size
             self.fraction = fraction
             self.method = method
@@ -301,14 +301,14 @@ def random_factory(parent_class):
                 raise AttributeError
             return self.query.__getattribute__(name)
 
-        # Overwrite the get_table_name method so that it cannot
+        # Overwrite the table_name method so that it cannot
         # be stored by accident.
         @property
         def table_name(self):
             if self.seed is None or self.method == "system_rows":
                 raise NotImplementedError
             else:
-                return "cache.x{}".format(self.md5)
+                return f"x{self.md5}"
 
         # Overwrite to call on parent instead
         def get_column_names(self):

--- a/flowmachine/flowmachine/core/server/query_proxy.py
+++ b/flowmachine/flowmachine/core/server/query_proxy.py
@@ -5,7 +5,7 @@ from json import dumps, loads, JSONDecodeError
 
 
 from flowmachine.core import Query
-from flowmachine.core.cache import get_query_by_id
+from flowmachine.core.cache import get_query_object_by_id
 from flowmachine.features import (
     daily_location,
     ModalLocation,
@@ -269,7 +269,7 @@ def cache_table_exists(query_id):
     bool
     """
     try:
-        _ = get_query_by_id(Query.connection, query_id)
+        _ = get_query_object_by_id(Query.connection, query_id)
         return True
     except ValueError:
         return False
@@ -289,7 +289,7 @@ def get_sql_for_query_id(query_id):
     -------
     str
     """
-    q = get_query_by_id(Query.connection, query_id)
+    q = get_query_object_by_id(Query.connection, query_id)
     sql = q.get_query()
     return sql
 

--- a/flowmachine/flowmachine/core/server/query_proxy.py
+++ b/flowmachine/flowmachine/core/server/query_proxy.py
@@ -3,7 +3,9 @@ import redis
 import redis_lock
 from json import dumps, loads, JSONDecodeError
 
-from flowmachine.core import Query, Table
+
+from flowmachine.core import Query
+from flowmachine.core.cache import get_query_by_id
 from flowmachine.features import (
     daily_location,
     ModalLocation,
@@ -267,9 +269,9 @@ def cache_table_exists(query_id):
     bool
     """
     try:
-        _ = Table(f"x{query_id}", "cache")
+        _ = get_query_by_id(Query.connection, query_id)
         return True
-    except (AttributeError, ValueError):
+    except ValueError:
         return False
 
 
@@ -287,7 +289,7 @@ def get_sql_for_query_id(query_id):
     -------
     str
     """
-    q = Table(f"x{query_id}", "cache")
+    q = get_query_by_id(Query.connection, query_id)
     sql = q.get_query()
     return sql
 

--- a/flowmachine/flowmachine/core/server/query_proxy.py
+++ b/flowmachine/flowmachine/core/server/query_proxy.py
@@ -5,7 +5,7 @@ from json import dumps, loads, JSONDecodeError
 
 
 from flowmachine.core import Query
-from flowmachine.core.cache import get_query_object_by_id
+from flowmachine.core.cache import get_query_object_by_id, cache_table_exists
 from flowmachine.features import (
     daily_location,
     ModalLocation,
@@ -254,27 +254,6 @@ def construct_query_object(query_kind, params):  # pragma: no cover
     return q
 
 
-def cache_table_exists(query_id):
-    """
-    Return True if a cache table for the query with
-    id `query_id` exist, otherwise return False.
-
-    Parameters
-    ----------
-    query_id : str
-        The query id to check.
-
-    Returns
-    -------
-    bool
-    """
-    try:
-        _ = get_query_object_by_id(Query.connection, query_id)
-        return True
-    except ValueError:
-        return False
-
-
 def get_sql_for_query_id(query_id):
     """
     Return the SQL which, when run against flowdb, will
@@ -416,7 +395,7 @@ class QueryProxy:
         if self.redis_interface.has_lock(query_id):
             status = "running"
         else:
-            if cache_table_exists(query_id):
+            if cache_table_exists(Query.connection, query_id):
                 status = "done"
             else:
                 status = "awol"

--- a/flowmachine/flowmachine/core/table.py
+++ b/flowmachine/flowmachine/core/table.py
@@ -141,7 +141,7 @@ class Table(Query):
         return self.connection.has_table(self.name, self.schema)
 
     @property
-    def table_name(self):
+    def fully_qualified_table_name(self):
         return self.fqn
 
     def get_table(self):

--- a/flowmachine/flowmachine/core/table.py
+++ b/flowmachine/flowmachine/core/table.py
@@ -114,7 +114,7 @@ class Table(Query):
         # Recorded provided columns to ensure that md5 differs with different columns
         self.columns = columns
         super().__init__()
-        self._db_store_cache_metadata()
+        self._db_store_cache_metadata(compute_time=0)
 
     @property
     def column_names(self) -> List[str]:
@@ -128,6 +128,12 @@ class Table(Query):
         return "SELECT {cols} FROM {fqn}".format(fqn=self.fqn, cols=cols)
 
     def get_query(self):
+        with self.connection.engine.begin():
+            self.connection.engine.execute(
+                "UPDATE cache.cached SET last_accessed = NOW(), access_count = access_count + 1 WHERE query_id ='{}'".format(
+                    self.md5
+                )
+            )
         return self._make_query()
 
     @property

--- a/flowmachine/flowmachine/features/spatial/location_area.py
+++ b/flowmachine/flowmachine/features/spatial/location_area.py
@@ -563,7 +563,7 @@ class LocationArea(GeoDataMixin, Query):
             GROUP BY location_id, geom_point
 
         """.format(
-            table_name=self.viewshedslopes.table_name
+            table_name=self.viewshedslopes.fully_qualified_table_name
         )
 
         return sql

--- a/flowmachine/flowmachine/features/utilities/sets.py
+++ b/flowmachine/flowmachine/features/utilities/sets.py
@@ -123,16 +123,16 @@ class EventTableSubset(Query):
         # If the subscriber does not pass a start or stop date, then we take
         # the min/max date in the events.calls table
         if self.start is None:
-            d1 = self.connection.min_date(self.table.table_name.split(".")[1]).strftime(
-                "%Y-%m-%d"
-            )
+            d1 = self.connection.min_date(
+                self.table.fully_qualified_table_name.split(".")[1]
+            ).strftime("%Y-%m-%d")
         else:
             d1 = self.start.split()[0]
 
         if self.stop is None:
-            d2 = self.connection.max_date(self.table.table_name.split(".")[1]).strftime(
-                "%Y-%m-%d"
-            )
+            d2 = self.connection.max_date(
+                self.table.fully_qualified_table_name.split(".")[1]
+            ).strftime("%Y-%m-%d")
         else:
             d2 = self.stop.split()[0]
 
@@ -182,7 +182,7 @@ class EventTableSubset(Query):
 
         sql = f"""
         SELECT {", ".join(self.columns)}
-        FROM {self.table.table_name}
+        FROM {self.table.fully_qualified_table_name}
         {where_clause}
         """
 
@@ -215,7 +215,7 @@ class EventTableSubset(Query):
         return sql
 
     @property
-    def table_name(self):
+    def fully_qualified_table_name(self):
         # EventTableSubset are a simple select from events, and should not be cached
         raise NotImplementedError
 
@@ -310,7 +310,7 @@ class EventsTablesUnion(Query):
         return sql
 
     @property
-    def table_name(self):
+    def fully_qualified_table_name(self):
         # EventTableSubset are a simple select from events, and should not be cached
         raise NotImplementedError
 

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -7,7 +7,6 @@
 Commonly used testing fixtures for flowmachine.
 """
 
-import os
 from unittest.mock import Mock
 
 import pandas as pd
@@ -15,6 +14,7 @@ import pytest
 import logging
 import flowmachine
 from flowmachine.core import Query
+from flowmachine.core.cache import reset_cache
 from flowmachine.features import EventTableSubset
 
 logger = logging.getLogger()
@@ -75,8 +75,7 @@ def skip_datecheck(monkeypatch):
 def flowmachine_connect():
     con = flowmachine.connect()
     yield con
-    for q in Query.get_stored():  # Remove any cached queries
-        q.invalidate_db_cache()
+    reset_cache(con)
     con.engine.dispose()  # Close the connection
     Query.redis.flushdb()  # Empty the redis
     del Query.connection  # Ensure we recreate everything at next use

--- a/flowmachine/tests/server/test_query_proxy.py
+++ b/flowmachine/tests/server/test_query_proxy.py
@@ -132,7 +132,7 @@ def test_poll(dummy_redis, monkeypatch):
 
 def test_get_sql(dummy_redis, monkeypatch):
     """
-    Running poll() returns the expected status.
+    Running get_sql returns the expected sql.
     """
     # Define mock query object and a function which returns it when called.
     # This serves as a drop-in replacement for 'construct_query_object' in
@@ -154,7 +154,8 @@ def test_get_sql(dummy_redis, monkeypatch):
 
     # Set conditions for this test
     monkeypatch.setattr(
-        "flowmachine.core.server.query_proxy.cache_table_exists", lambda query_id: True
+        "flowmachine.core.server.query_proxy.cache_table_exists",
+        lambda connection, query_id: True,
     )
     query_proxy.redis_interface.has_lock = lambda query_id: False
     monkeypatch.setattr(

--- a/flowmachine/tests/test_async.py
+++ b/flowmachine/tests/test_async.py
@@ -46,7 +46,7 @@ def test_store_async():
 
     schema = "cache"
     dl = daily_location("2016-01-01", level="cell")
-    table_name = dl.table_name.split(".")[1]
+    table_name = dl.fully_qualified_table_name.split(".")[1]
     store_future = dl.store()
     store_future.result()
     assert dl.connection.has_table(table_name, schema=schema)

--- a/flowmachine/tests/test_cache.py
+++ b/flowmachine/tests/test_cache.py
@@ -125,6 +125,8 @@ def test_invalidate_cache_multi(flowmachine_connect):
     dl1.store().result()
     hl1 = ModalLocation(daily_location("2016-01-01"), daily_location("2016-01-02"))
     hl1.store().result()
+    assert dl1.is_stored
+    assert hl1.is_stored
     dl1.invalidate_db_cache()
     assert not dl1.is_stored
     assert not hl1.is_stored
@@ -147,6 +149,9 @@ def test_invalidate_cache_midchain(flowmachine_connect):
     hl2 = ModalLocation(daily_location("2016-01-03"), daily_location("2016-01-04"))
     flow = Flows(hl1, hl2)
     flow.store().result()
+    assert dl1.is_stored
+    assert hl1.is_stored
+    assert flow.is_stored
     hl1.invalidate_db_cache()
     assert dl1.is_stored
     assert not hl1.is_stored
@@ -169,6 +174,8 @@ def test_invalidate_cache_multi(flowmachine_connect):
     dl1.store().result()
     hl1 = ModalLocation(daily_location("2016-01-01"), daily_location("2016-01-02"))
     hl1.store().result()
+    assert dl1.is_stored
+    assert hl1.is_stored
     dl1.invalidate_db_cache()
     assert not dl1.is_stored
     assert not hl1.is_stored
@@ -190,6 +197,9 @@ def test_invalidate_cascade(flowmachine_connect):
     hl2 = ModalLocation(daily_location("2016-01-03"), daily_location("2016-01-04"))
     flow = Flows(hl1, hl2)
     flow.store().result()
+    assert dl1.is_stored
+    assert hl1.is_stored
+    assert flow.is_stored
     dl1.invalidate_db_cache(cascade=False)
     assert not dl1.is_stored
     assert hl1.is_stored

--- a/flowmachine/tests/test_cache.py
+++ b/flowmachine/tests/test_cache.py
@@ -43,9 +43,8 @@ def test_do_cache_multi(flowmachine_connect):
 
     hl1 = ModalLocation(daily_location("2016-01-01"), daily_location("2016-01-02"))
     hl1._db_store_cache_metadata()
-    in_cache = cache_table_exists(flowmachine_connect, hl1.md5)
 
-    assert in_cache
+    assert cache_table_exists(flowmachine_connect, hl1.md5)
 
 
 def test_do_cache_nested(flowmachine_connect):
@@ -57,9 +56,8 @@ def test_do_cache_nested(flowmachine_connect):
     hl2 = ModalLocation(daily_location("2016-01-03"), daily_location("2016-01-04"))
     flow = Flows(hl1, hl2)
     flow._db_store_cache_metadata()
-    in_cache = cache_table_exists(flowmachine_connect, flow.md5)
 
-    assert in_cache
+    assert cache_table_exists(flowmachine_connect, flow.md5)
 
 
 def test_store_cache_simple(flowmachine_connect):
@@ -71,9 +69,8 @@ def test_store_cache_simple(flowmachine_connect):
     dl1.store().result()
     # Should be stored
     assert dl1.is_stored
-    in_cache = cache_table_exists(flowmachine_connect, dl1.md5)
 
-    assert in_cache
+    assert cache_table_exists(flowmachine_connect, dl1.md5)
 
 
 def test_store_cache_multi(flowmachine_connect):
@@ -85,9 +82,8 @@ def test_store_cache_multi(flowmachine_connect):
     hl1.store().result()
     # Should be stored
     assert hl1.is_stored
-    in_cache = cache_table_exists(flowmachine_connect, hl1.md5)
 
-    assert in_cache
+    assert cache_table_exists(flowmachine_connect, hl1.md5)
 
 
 def test_store_cache_nested(flowmachine_connect):

--- a/flowmachine/tests/test_cache.py
+++ b/flowmachine/tests/test_cache.py
@@ -12,6 +12,25 @@ from flowmachine.core.query import Query
 from flowmachine.features import daily_location, ModalLocation, Flows
 
 
+def test_table_records_removed(flowmachine_connect):
+    """Test that removing a query from cache removes any Tables in cache that pointed to it."""
+    dl = daily_location("2016-01-01")
+    dl.store().result()
+    assert dl.is_stored
+    table = dl.get_table()
+    assert bool(
+        flowmachine_connect.fetch(
+            f"SELECT * FROM cache.cached WHERE query_id='{table.md5}'"
+        )
+    )
+    dl.invalidate_db_cache()
+    assert not bool(
+        flowmachine_connect.fetch(
+            f"SELECT * FROM cache.cached WHERE query_id='{table.md5}'"
+        )
+    )
+
+
 def test_do_cache_simple(flowmachine_connect):
     """
     Test that a simple object can be cached.

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -37,7 +37,9 @@ def test_scoring(flowmachine_connect):
     """
     dl = daily_location("2016-01-01").store().result()
     dl_time = get_compute_time(flowmachine_connect, dl.md5)
-    dl_size = get_size_of_table(flowmachine_connect, *dl.table_name.split(".")[::-1])
+    dl_size = get_size_of_table(
+        flowmachine_connect, *dl.fully_qualified_table_name.split(".")[::-1]
+    )
     initial_score = get_score(flowmachine_connect, dl.md5)
     cachey_scorer = Scorer(halflife=1000.0)
     cache_score = cachey_scorer.touch("dl", dl_time / dl_size)
@@ -51,7 +53,9 @@ def test_scoring(flowmachine_connect):
     # Add another unrelated cache record, which should have a higher initial score
     dl_2 = daily_location("2016-01-02").store().result()
     dl_time = get_compute_time(flowmachine_connect, dl_2.md5)
-    dl_size = get_size_of_table(flowmachine_connect, *dl_2.table_name.split(".")[::-1])
+    dl_size = get_size_of_table(
+        flowmachine_connect, *dl_2.fully_qualified_table_name.split(".")[::-1]
+    )
     cache_score = cachey_scorer.touch("dl_2", dl_time / dl_size)
     assert cache_score == pytest.approx(get_score(flowmachine_connect, dl_2.md5))
 
@@ -205,7 +209,9 @@ def test_shrink_to_size_dry_run_reflects_wet_run(flowmachine_connect):
     Test that shrink_below_size dry run is an accurate report."""
     dl = daily_location("2016-01-01").store().result()
     dl2 = daily_location("2016-01-02").store().result()
-    shrink_to = get_size_of_table(flowmachine_connect, *dl.table_name.split(".")[::-1])
+    shrink_to = get_size_of_table(
+        flowmachine_connect, *dl.fully_qualified_table_name.split(".")[::-1]
+    )
     queries_that_would_be_removed = shrink_below_size(
         flowmachine_connect, shrink_to, dry_run=True
     )
@@ -226,7 +232,9 @@ def test_shrink_to_size_uses_score(flowmachine_connect):
     flowmachine_connect.engine.execute(
         f"UPDATE cache.cached SET cache_score_multiplier = 0.5 WHERE query_id='{dl.md5}'"
     )
-    table_size = get_size_of_table(flowmachine_connect, *dl.table_name.split(".")[::-1])
+    table_size = get_size_of_table(
+        flowmachine_connect, *dl.fully_qualified_table_name.split(".")[::-1]
+    )
     removed_queries = shrink_below_size(flowmachine_connect, table_size)
     assert 1 == len(removed_queries)
     assert not dl.is_stored
@@ -268,7 +276,9 @@ def test_size_of_table(flowmachine_connect):
     dl = daily_location("2016-01-01").store().result()
 
     total_cache_size = get_size_of_cache(flowmachine_connect)
-    table_size = get_size_of_table(flowmachine_connect, *dl.table_name.split(".")[::-1])
+    table_size = get_size_of_table(
+        flowmachine_connect, *dl.fully_qualified_table_name.split(".")[::-1]
+    )
     assert total_cache_size == table_size
 
 

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -26,6 +26,7 @@ from flowmachine.core.cache import (
     get_cache_half_life,
     set_cache_half_life,
     invalidate_cache_by_id,
+    cache_table_exists,
 )
 from flowmachine.features import daily_location
 
@@ -383,3 +384,13 @@ def test_get_set_cache_half_life(reset_cache_settings):
     # Now set it to something
     set_cache_half_life(reset_cache_settings, 10)
     assert 10 == get_cache_half_life(reset_cache_settings)
+
+
+def test_cache_table_exists(flowmachine_connect):
+    """
+    Test that cache_table_exists reports accurately.
+    """
+    assert not cache_table_exists(flowmachine_connect, "NONEXISTENT_CACHE_ID")
+    assert cache_table_exists(
+        flowmachine_connect, daily_location("2016-01-01").store().result().md5
+    )

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -353,7 +353,7 @@ def test_delete_query_by_id_can_cascade(flowmachine_connect):
 
 
 @pytest.fixture
-def reset_cache_settings(flowmachine_connect):
+def flowmachine_connect_with_cache_settings_reset(flowmachine_connect):
     """
     Fixture which ensures cache settings go back to what they were after
     they're manipulated.
@@ -365,25 +365,25 @@ def reset_cache_settings(flowmachine_connect):
     set_cache_half_life(flowmachine_connect, cache_half_life)
 
 
-def test_get_set_cache_size_limit(reset_cache_settings):
+def test_get_set_cache_size_limit(flowmachine_connect_with_cache_settings_reset):
     """
     Test that cache size can be got and set
     """
     # Initial setting depends on the disk space of the FlowDB container so just check it is nonzero
-    assert get_max_size_of_cache(reset_cache_settings) > 0
+    assert get_max_size_of_cache(flowmachine_connect_with_cache_settings_reset) > 0
     # Now set it to something
-    set_max_size_of_cache(reset_cache_settings, 10)
-    assert 10 == get_max_size_of_cache(reset_cache_settings)
+    set_max_size_of_cache(flowmachine_connect_with_cache_settings_reset, 10)
+    assert 10 == get_max_size_of_cache(flowmachine_connect_with_cache_settings_reset)
 
 
-def test_get_set_cache_half_life(reset_cache_settings):
+def test_get_set_cache_half_life(flowmachine_connect_with_cache_settings_reset):
     """
     Test that cache halflife can be got and set
     """
-    assert 1000 == get_cache_half_life(reset_cache_settings)
+    assert 1000 == get_cache_half_life(flowmachine_connect_with_cache_settings_reset)
     # Now set it to something
-    set_cache_half_life(reset_cache_settings, 10)
-    assert 10 == get_cache_half_life(reset_cache_settings)
+    set_cache_half_life(flowmachine_connect_with_cache_settings_reset, 10)
+    assert 10 == get_cache_half_life(flowmachine_connect_with_cache_settings_reset)
 
 
 def test_cache_table_exists(flowmachine_connect):

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -1,0 +1,321 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Tests for cache management utilities.
+"""
+from cachey import Scorer
+from unittest.mock import Mock
+
+import pytest
+
+from flowmachine.core import Table
+from flowmachine.core.cache import (
+    compute_time,
+    shrink_below_size,
+    shrink_one,
+    size_of_cache,
+    size_of_table,
+    score,
+    get_query_by_id,
+    get_cached_queries_by_score,
+    touch_cache,
+    get_max_size_of_cache,
+    set_max_size_of_cache,
+    get_cache_half_life,
+    set_cache_half_life,
+)
+from flowmachine.features import daily_location
+
+
+def test_scoring(flowmachine_connect):
+    """Test that score updating algorithm is correct by comparing to cachey as reference implementation"""
+    dl = daily_location("2016-01-01").store().result()
+    dl_time = compute_time(flowmachine_connect, dl.md5)
+    dl_size = size_of_table(flowmachine_connect, *dl.table_name.split(".")[::-1])
+    initial_score = score(flowmachine_connect, dl.md5)
+    cachey_scorer = Scorer(1000)
+    cache_score = cachey_scorer.touch("dl", dl_time / dl_size)
+    assert cache_score == pytest.approx(initial_score)
+    # Touch again
+    new_score = touch_cache(flowmachine_connect, dl.md5)
+    updated_cache_score = cachey_scorer.touch("dl")
+    assert updated_cache_score == pytest.approx(new_score)
+    # Add another unrelated cache record, which should have a higher initial score
+    dl_2 = daily_location("2016-01-02").store().result()
+    dl_time = compute_time(flowmachine_connect, dl_2.md5)
+    dl_size = size_of_table(flowmachine_connect, *dl_2.table_name.split(".")[::-1])
+    cache_score = cachey_scorer.touch("dl_2", dl_time / dl_size)
+    assert cache_score == pytest.approx(score(flowmachine_connect, dl_2.md5))
+
+
+def test_touch_cache_record_for_query(flowmachine_connect):
+    """Touching a cache record for a query should update access count, last accessed, & counter."""
+    table = daily_location("2016-01-01").store().result()
+
+    assert (
+        1
+        == flowmachine_connect.fetch(
+            f"SELECT access_count FROM cache.cached WHERE query_id='{table.md5}'"
+        )[0][0]
+    )
+    accessed_at = flowmachine_connect.fetch(
+        f"SELECT last_accessed FROM cache.cached WHERE query_id='{table.md5}'"
+    )[0][0]
+    touch_cache(flowmachine_connect, table.md5)
+    assert (
+        2
+        == flowmachine_connect.fetch(
+            f"SELECT access_count FROM cache.cached WHERE query_id='{table.md5}'"
+        )[0][0]
+    )
+    # Two cache touches should have been recorded
+    assert (
+        4 == flowmachine_connect.fetch("SELECT nextval('cache.cache_touches');")[0][0]
+    )
+    assert (
+        accessed_at
+        < flowmachine_connect.fetch(
+            f"SELECT last_accessed FROM cache.cached WHERE query_id='{table.md5}'"
+        )[0][0]
+    )
+
+
+def test_touch_cache_record_for_table(flowmachine_connect):
+    """Touching a cache record for a table should update access count and last accessed but not touch score, or counter."""
+    table = Table("events.calls_20160101")
+    flowmachine_connect.engine.execute(
+        f"UPDATE cache.cached SET compute_time = 1 WHERE query_id=%s", table.md5
+    )  # Compute time for tables is zero, so set to 1 to avoid zeroing out
+    assert 0 == score(flowmachine_connect, table.md5)
+    assert (
+        1
+        == flowmachine_connect.fetch(
+            f"SELECT access_count FROM cache.cached WHERE query_id='{table.md5}'"
+        )[0][0]
+    )
+    accessed_at = flowmachine_connect.fetch(
+        f"SELECT last_accessed FROM cache.cached WHERE query_id='{table.md5}'"
+    )[0][0]
+    touch_cache(flowmachine_connect, table.md5)
+    assert 0 == score(flowmachine_connect, table.md5)
+    assert (
+        2
+        == flowmachine_connect.fetch(
+            f"SELECT access_count FROM cache.cached WHERE query_id='{table.md5}'"
+        )[0][0]
+    )
+    # No cache touch should be recorded
+    assert (
+        2 == flowmachine_connect.fetch("SELECT nextval('cache.cache_touches');")[0][0]
+    )
+    assert (
+        accessed_at
+        < flowmachine_connect.fetch(
+            f"SELECT last_accessed FROM cache.cached WHERE query_id='{table.md5}'"
+        )[0][0]
+    )
+
+
+def test_compute_time():
+    """Compute time should take value returned in ms and turn it into seconds."""
+    connection_mock = Mock()
+    connection_mock.fetch.return_value = [[10]]
+    assert 10 / 1000 == compute_time(connection_mock, "DUMMY_ID")
+
+
+def test_get_cached_queries_by_score(flowmachine_connect):
+    """Test that all records which are queries are returned in correct order."""
+    dl = daily_location("2016-01-01").store().result()
+    dl_agg = dl.aggregate().store().result()
+    table = dl.get_table()
+    # Should prefer the larger, but slower to calculate and more used dl over the aggregation
+    cached_queries = get_cached_queries_by_score(flowmachine_connect)
+    assert 2 == len(cached_queries)
+    assert dl_agg.md5 == cached_queries[0][0].md5
+    assert dl.md5 == cached_queries[1][0].md5
+    assert 2 == len(cached_queries[0])
+
+
+def test_shrink_one(flowmachine_connect):
+    """Test that shrink_one removes a cache record."""
+    dl = daily_location("2016-01-01").store().result()
+    dl_aggregate = dl.aggregate().store().result()
+    flowmachine_connect.engine.execute(
+        f"UPDATE cache.cached SET cache_score_multiplier = 1 WHERE query_id='{dl_aggregate.md5}'"
+    )
+    flowmachine_connect.engine.execute(
+        f"UPDATE cache.cached SET cache_score_multiplier = 0.5 WHERE query_id='{dl.md5}'"
+    )
+    removed_query, table_size = shrink_one(flowmachine_connect)
+    assert dl.md5 == removed_query.md5
+    assert not dl.is_stored
+    assert dl_aggregate.is_stored
+
+
+def test_shrink_to_size_does_nothing_when_cache_ok(flowmachine_connect):
+    """Test that shrink_below_size doesn't remove anything if cache size is within limit."""
+    dl = daily_location("2016-01-01").store().result()
+    removed_queries = shrink_below_size(
+        flowmachine_connect, size_of_cache(flowmachine_connect)
+    )
+    assert 0 == len(removed_queries)
+    assert dl.is_stored
+
+
+def test_shrink_to_size_removes_queries(flowmachine_connect):
+    """Test that shrink_below_size removes queries when cache limit is breached."""
+    dl = daily_location("2016-01-01").store().result()
+    removed_queries = shrink_below_size(
+        flowmachine_connect, size_of_cache(flowmachine_connect) - 1
+    )
+    assert 1 == len(removed_queries)
+    assert not dl.is_stored
+
+
+def test_shrink_to_size_respects_dry_run(flowmachine_connect):
+    """Test that shrink_below_size doesn't remove anything during a dry run."""
+    dl = daily_location("2016-01-01").store().result()
+    dl2 = daily_location("2016-01-02").store().result()
+    removed_queries = shrink_below_size(flowmachine_connect, 0, dry_run=True)
+    assert 2 == len(removed_queries)
+    assert dl.is_stored
+    assert dl2.is_stored
+
+
+def test_shrink_to_size_dry_run_reflects_wet_run(flowmachine_connect):
+    """Test that shrink_below_size dry run is an accurate report."""
+    dl = daily_location("2016-01-01").store().result()
+    dl2 = daily_location("2016-01-02").store().result()
+    shrink_to = size_of_table(flowmachine_connect, *dl.table_name.split(".")[::-1])
+    queries_that_would_be_removed = shrink_below_size(
+        flowmachine_connect, shrink_to, dry_run=True
+    )
+    removed_queries = shrink_below_size(flowmachine_connect, shrink_to, dry_run=False)
+    assert [q.md5 for q in removed_queries] == [
+        q.md5 for q in queries_that_would_be_removed
+    ]
+
+
+def test_shrink_to_size_uses_score(flowmachine_connect):
+    """Test that shrink_below_size removes cache records in ascending score order."""
+    dl = daily_location("2016-01-01").store().result()
+    dl_aggregate = dl.aggregate().store().result()
+    flowmachine_connect.engine.execute(
+        f"UPDATE cache.cached SET cache_score_multiplier = 100 WHERE query_id='{dl_aggregate.md5}'"
+    )
+    flowmachine_connect.engine.execute(
+        f"UPDATE cache.cached SET cache_score_multiplier = 0.5 WHERE query_id='{dl.md5}'"
+    )
+    table_size = size_of_table(flowmachine_connect, *dl.table_name.split(".")[::-1])
+    removed_queries = shrink_below_size(flowmachine_connect, table_size)
+    assert 1 == len(removed_queries)
+    assert not dl.is_stored
+    assert dl_aggregate.is_stored
+
+
+def test_shrink_one(flowmachine_connect):
+    """Test that shrink_one removes a cache record."""
+    dl = daily_location("2016-01-01").store().result()
+    dl_aggregate = dl.aggregate().store().result()
+    flowmachine_connect.engine.execute(
+        f"UPDATE cache.cached SET cache_score_multiplier = 100 WHERE query_id='{dl_aggregate.md5}'"
+    )
+    flowmachine_connect.engine.execute(
+        f"UPDATE cache.cached SET cache_score_multiplier = 0.5 WHERE query_id='{dl.md5}'"
+    )
+    removed_query, table_size = shrink_one(flowmachine_connect)
+    assert dl.md5 == removed_query.md5
+    assert not dl.is_stored
+    assert dl_aggregate.is_stored
+
+
+def test_size_of_cache(flowmachine_connect):
+    """Test that cache size is reported correctly."""
+    dl = daily_location("2016-01-01").store().result()
+    dl_aggregate = dl.aggregate().store().result()
+    total_cache_size = size_of_cache(flowmachine_connect)
+    removed_query, table_size_a = shrink_one(flowmachine_connect)
+    removed_query, table_size_b = shrink_one(flowmachine_connect)
+    assert total_cache_size == table_size_a + table_size_b
+    assert 0 == size_of_cache(flowmachine_connect)
+
+
+def test_size_of_table(flowmachine_connect):
+    """Test that table size is reported correctly."""
+    dl = daily_location("2016-01-01").store().result()
+
+    total_cache_size = size_of_cache(flowmachine_connect)
+    table_size = size_of_table(flowmachine_connect, *dl.table_name.split(".")[::-1])
+    assert total_cache_size == table_size
+
+
+def test_cache_miss_value_error_rescore():
+    """ValueError should be raised if we try to rescore something not in cache."""
+    connection_mock = Mock()
+    connection_mock.fetch.return_value = []
+    with pytest.raises(ValueError):
+        touch_cache(connection_mock, "NOT_IN_CACHE")
+
+
+def test_cache_miss_value_error_size_of_table():
+    """ValueError should be raised if we try to get the size of something not in cache."""
+    connection_mock = Mock()
+    connection_mock.fetch.return_value = []
+    with pytest.raises(ValueError):
+        size_of_table(connection_mock, "DUMMY_SCHEMA", "DUMMY_NAME")
+
+
+def test_cache_miss_value_error_compute_time():
+    """ValueError should be raised if we try to get the compute time of something not in cache."""
+    connection_mock = Mock()
+    connection_mock.fetch.return_value = []
+    with pytest.raises(ValueError):
+        compute_time(connection_mock, "DUMMY_ID")
+
+
+def test_cache_miss_value_error_score():
+    """ValueError should be raised if we try to get the score of something not in cache."""
+    connection_mock = Mock()
+    connection_mock.fetch.return_value = []
+    with pytest.raises(ValueError):
+        score(connection_mock, "DUMMY_ID")
+
+
+def test_get_query_by_id(flowmachine_connect):
+    """Test that we can get a query object back out of the database by the md5 id"""
+    dl = daily_location("2016-01-01").store().result()
+    retrieved_query = get_query_by_id(flowmachine_connect, dl.md5)
+    assert dl.md5 == retrieved_query.md5
+    assert dl.get_query() == retrieved_query.get_query()
+
+
+@pytest.fixture
+def reset_cache_settings(flowmachine_connect):
+    """
+    Fixture which ensures cache settings go back to what they were after
+    they're manipulated.
+    """
+    max_cache_size = get_max_size_of_cache(flowmachine_connect)
+    cache_half_life = get_cache_half_life(flowmachine_connect)
+    yield flowmachine_connect
+    set_max_size_of_cache(flowmachine_connect, max_cache_size)
+    set_cache_half_life(flowmachine_connect, cache_half_life)
+
+
+def test_get_set_cache_size_limit(reset_cache_settings):
+    """Test that cache size can be got and set"""
+    # Initial setting depends on the disk space of the FlowDB container so just check it is nonzero
+    assert get_max_size_of_cache(reset_cache_settings) > 0
+    # Now set it to something
+    set_max_size_of_cache(reset_cache_settings, 10)
+    assert 10 == get_max_size_of_cache(reset_cache_settings)
+
+
+def test_get_set_cache_half_life(reset_cache_settings):
+    """Test that cache halflife can be got and set"""
+    assert 1000 == get_cache_half_life(reset_cache_settings)
+    # Now set it to something
+    set_cache_half_life(reset_cache_settings, 10)
+    assert 10 == get_cache_half_life(reset_cache_settings)

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -41,6 +41,7 @@ def test_scoring(flowmachine_connect):
     cachey_scorer = Scorer(1000)
     cache_score = cachey_scorer.touch("dl", dl_time / dl_size)
     assert cache_score == pytest.approx(initial_score)
+
     # Touch again
     new_score = touch_cache(flowmachine_connect, dl.md5)
     updated_cache_score = cachey_scorer.touch("dl")

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -128,7 +128,7 @@ def test_touch_cache_record_for_table(flowmachine_connect):
     )
 
 
-def test_compute_time():
+def test_get_compute_time():
     """
     Compute time should take value returned in ms and turn it into seconds."""
     connection_mock = Mock()

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -37,9 +37,7 @@ def test_scoring(flowmachine_connect):
     """
     dl = daily_location("2016-01-01").store().result()
     dl_time = get_compute_time(flowmachine_connect, dl.md5)
-    dl_size = get_size_of_table(
-        flowmachine_connect, *dl.fully_qualified_table_name.split(".")[::-1]
-    )
+    dl_size = get_size_of_table(flowmachine_connect, dl.table_name, "cache")
     initial_score = get_score(flowmachine_connect, dl.md5)
     cachey_scorer = Scorer(halflife=1000.0)
     cache_score = cachey_scorer.touch("dl", dl_time / dl_size)
@@ -53,9 +51,7 @@ def test_scoring(flowmachine_connect):
     # Add another unrelated cache record, which should have a higher initial score
     dl_2 = daily_location("2016-01-02").store().result()
     dl_time = get_compute_time(flowmachine_connect, dl_2.md5)
-    dl_size = get_size_of_table(
-        flowmachine_connect, *dl_2.fully_qualified_table_name.split(".")[::-1]
-    )
+    dl_size = get_size_of_table(flowmachine_connect, dl_2.table_name, "cache")
     cache_score = cachey_scorer.touch("dl_2", dl_time / dl_size)
     assert cache_score == pytest.approx(get_score(flowmachine_connect, dl_2.md5))
 
@@ -209,9 +205,7 @@ def test_shrink_to_size_dry_run_reflects_wet_run(flowmachine_connect):
     Test that shrink_below_size dry run is an accurate report."""
     dl = daily_location("2016-01-01").store().result()
     dl2 = daily_location("2016-01-02").store().result()
-    shrink_to = get_size_of_table(
-        flowmachine_connect, *dl.fully_qualified_table_name.split(".")[::-1]
-    )
+    shrink_to = get_size_of_table(flowmachine_connect, dl.table_name, "cache")
     queries_that_would_be_removed = shrink_below_size(
         flowmachine_connect, shrink_to, dry_run=True
     )
@@ -232,9 +226,7 @@ def test_shrink_to_size_uses_score(flowmachine_connect):
     flowmachine_connect.engine.execute(
         f"UPDATE cache.cached SET cache_score_multiplier = 0.5 WHERE query_id='{dl.md5}'"
     )
-    table_size = get_size_of_table(
-        flowmachine_connect, *dl.fully_qualified_table_name.split(".")[::-1]
-    )
+    table_size = get_size_of_table(flowmachine_connect, dl.table_name, "cache")
     removed_queries = shrink_below_size(flowmachine_connect, table_size)
     assert 1 == len(removed_queries)
     assert not dl.is_stored
@@ -276,9 +268,7 @@ def test_size_of_table(flowmachine_connect):
     dl = daily_location("2016-01-01").store().result()
 
     total_cache_size = get_size_of_cache(flowmachine_connect)
-    table_size = get_size_of_table(
-        flowmachine_connect, *dl.fully_qualified_table_name.split(".")[::-1]
-    )
+    table_size = get_size_of_table(flowmachine_connect, dl.table_name, "cache")
     assert total_cache_size == table_size
 
 

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -45,6 +45,7 @@ def test_scoring(flowmachine_connect):
     new_score = touch_cache(flowmachine_connect, dl.md5)
     updated_cache_score = cachey_scorer.touch("dl")
     assert updated_cache_score == pytest.approx(new_score)
+
     # Add another unrelated cache record, which should have a higher initial score
     dl_2 = daily_location("2016-01-02").store().result()
     dl_time = get_compute_time(flowmachine_connect, dl_2.md5)

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -39,7 +39,7 @@ def test_scoring(flowmachine_connect):
     dl_time = get_compute_time(flowmachine_connect, dl.md5)
     dl_size = get_size_of_table(flowmachine_connect, *dl.table_name.split(".")[::-1])
     initial_score = get_score(flowmachine_connect, dl.md5)
-    cachey_scorer = Scorer(1000)
+    cachey_scorer = Scorer(halflife=1000.0)
     cache_score = cachey_scorer.touch("dl", dl_time / dl_size)
     assert cache_score == pytest.approx(initial_score)
 

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -18,8 +18,8 @@ from flowmachine.core.cache import (
     size_of_cache,
     size_of_table,
     score,
-    get_query_by_id,
-    get_cached_queries_by_score,
+    get_query_object_by_id,
+    get_cached_query_objects_ordered_by_score,
     touch_cache,
     get_max_size_of_cache,
     set_max_size_of_cache,
@@ -126,13 +126,13 @@ def test_compute_time():
     assert 10 / 1000 == compute_time(connection_mock, "DUMMY_ID")
 
 
-def test_get_cached_queries_by_score(flowmachine_connect):
+def test_get_cached_query_objects_ordered_by_score(flowmachine_connect):
     """Test that all records which are queries are returned in correct order."""
     dl = daily_location("2016-01-01").store().result()
     dl_agg = dl.aggregate().store().result()
     table = dl.get_table()
     # Should prefer the larger, but slower to calculate and more used dl over the aggregation
-    cached_queries = get_cached_queries_by_score(flowmachine_connect)
+    cached_queries = get_cached_query_objects_ordered_by_score(flowmachine_connect)
     assert 2 == len(cached_queries)
     assert dl_agg.md5 == cached_queries[0][0].md5
     assert dl.md5 == cached_queries[1][0].md5
@@ -284,10 +284,10 @@ def test_cache_miss_value_error_score():
         score(connection_mock, "DUMMY_ID")
 
 
-def test_get_query_by_id(flowmachine_connect):
+def test_get_query_object_by_id(flowmachine_connect):
     """Test that we can get a query object back out of the database by the md5 id"""
     dl = daily_location("2016-01-01").store().result()
-    retrieved_query = get_query_by_id(flowmachine_connect, dl.md5)
+    retrieved_query = get_query_object_by_id(flowmachine_connect, dl.md5)
     assert dl.md5 == retrieved_query.md5
     assert dl.get_query() == retrieved_query.get_query()
 

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -31,7 +31,9 @@ from flowmachine.features import daily_location
 
 
 def test_scoring(flowmachine_connect):
-    """Test that score updating algorithm is correct by comparing to cachey as reference implementation"""
+    """
+    Test that score updating algorithm is correct by comparing to cachey as reference implementation
+    """
     dl = daily_location("2016-01-01").store().result()
     dl_time = compute_time(flowmachine_connect, dl.md5)
     dl_size = size_of_table(flowmachine_connect, *dl.table_name.split(".")[::-1])
@@ -52,7 +54,9 @@ def test_scoring(flowmachine_connect):
 
 
 def test_touch_cache_record_for_query(flowmachine_connect):
-    """Touching a cache record for a query should update access count, last accessed, & counter."""
+    """
+    Touching a cache record for a query should update access count, last accessed, & counter.
+    """
     table = daily_location("2016-01-01").store().result()
 
     assert (
@@ -84,7 +88,9 @@ def test_touch_cache_record_for_query(flowmachine_connect):
 
 
 def test_touch_cache_record_for_table(flowmachine_connect):
-    """Touching a cache record for a table should update access count and last accessed but not touch score, or counter."""
+    """
+    Touching a cache record for a table should update access count and last accessed but not touch score, or counter.
+    """
     table = Table("events.calls_20160101")
     flowmachine_connect.engine.execute(
         f"UPDATE cache.cached SET compute_time = 1 WHERE query_id=%s", table.md5
@@ -120,14 +126,16 @@ def test_touch_cache_record_for_table(flowmachine_connect):
 
 
 def test_compute_time():
-    """Compute time should take value returned in ms and turn it into seconds."""
+    """
+    Compute time should take value returned in ms and turn it into seconds."""
     connection_mock = Mock()
     connection_mock.fetch.return_value = [[10]]
     assert 10 / 1000 == compute_time(connection_mock, "DUMMY_ID")
 
 
 def test_get_cached_query_objects_ordered_by_score(flowmachine_connect):
-    """Test that all records which are queries are returned in correct order."""
+    """
+    Test that all records which are queries are returned in correct order."""
     dl = daily_location("2016-01-01").store().result()
     dl_agg = dl.aggregate().store().result()
     table = dl.get_table()
@@ -140,7 +148,8 @@ def test_get_cached_query_objects_ordered_by_score(flowmachine_connect):
 
 
 def test_shrink_one(flowmachine_connect):
-    """Test that shrink_one removes a cache record."""
+    """
+    Test that shrink_one removes a cache record."""
     dl = daily_location("2016-01-01").store().result()
     dl_aggregate = dl.aggregate().store().result()
     flowmachine_connect.engine.execute(
@@ -156,7 +165,8 @@ def test_shrink_one(flowmachine_connect):
 
 
 def test_shrink_to_size_does_nothing_when_cache_ok(flowmachine_connect):
-    """Test that shrink_below_size doesn't remove anything if cache size is within limit."""
+    """
+    Test that shrink_below_size doesn't remove anything if cache size is within limit."""
     dl = daily_location("2016-01-01").store().result()
     removed_queries = shrink_below_size(
         flowmachine_connect, size_of_cache(flowmachine_connect)
@@ -166,7 +176,8 @@ def test_shrink_to_size_does_nothing_when_cache_ok(flowmachine_connect):
 
 
 def test_shrink_to_size_removes_queries(flowmachine_connect):
-    """Test that shrink_below_size removes queries when cache limit is breached."""
+    """
+    Test that shrink_below_size removes queries when cache limit is breached."""
     dl = daily_location("2016-01-01").store().result()
     removed_queries = shrink_below_size(
         flowmachine_connect, size_of_cache(flowmachine_connect) - 1
@@ -176,7 +187,8 @@ def test_shrink_to_size_removes_queries(flowmachine_connect):
 
 
 def test_shrink_to_size_respects_dry_run(flowmachine_connect):
-    """Test that shrink_below_size doesn't remove anything during a dry run."""
+    """
+    Test that shrink_below_size doesn't remove anything during a dry run."""
     dl = daily_location("2016-01-01").store().result()
     dl2 = daily_location("2016-01-02").store().result()
     removed_queries = shrink_below_size(flowmachine_connect, 0, dry_run=True)
@@ -186,7 +198,8 @@ def test_shrink_to_size_respects_dry_run(flowmachine_connect):
 
 
 def test_shrink_to_size_dry_run_reflects_wet_run(flowmachine_connect):
-    """Test that shrink_below_size dry run is an accurate report."""
+    """
+    Test that shrink_below_size dry run is an accurate report."""
     dl = daily_location("2016-01-01").store().result()
     dl2 = daily_location("2016-01-02").store().result()
     shrink_to = size_of_table(flowmachine_connect, *dl.table_name.split(".")[::-1])
@@ -200,7 +213,8 @@ def test_shrink_to_size_dry_run_reflects_wet_run(flowmachine_connect):
 
 
 def test_shrink_to_size_uses_score(flowmachine_connect):
-    """Test that shrink_below_size removes cache records in ascending score order."""
+    """
+    Test that shrink_below_size removes cache records in ascending score order."""
     dl = daily_location("2016-01-01").store().result()
     dl_aggregate = dl.aggregate().store().result()
     flowmachine_connect.engine.execute(
@@ -217,7 +231,8 @@ def test_shrink_to_size_uses_score(flowmachine_connect):
 
 
 def test_shrink_one(flowmachine_connect):
-    """Test that shrink_one removes a cache record."""
+    """
+    Test that shrink_one removes a cache record."""
     dl = daily_location("2016-01-01").store().result()
     dl_aggregate = dl.aggregate().store().result()
     flowmachine_connect.engine.execute(
@@ -233,7 +248,8 @@ def test_shrink_one(flowmachine_connect):
 
 
 def test_size_of_cache(flowmachine_connect):
-    """Test that cache size is reported correctly."""
+    """
+    Test that cache size is reported correctly."""
     dl = daily_location("2016-01-01").store().result()
     dl_aggregate = dl.aggregate().store().result()
     total_cache_size = size_of_cache(flowmachine_connect)
@@ -244,7 +260,8 @@ def test_size_of_cache(flowmachine_connect):
 
 
 def test_size_of_table(flowmachine_connect):
-    """Test that table size is reported correctly."""
+    """
+    Test that table size is reported correctly."""
     dl = daily_location("2016-01-01").store().result()
 
     total_cache_size = size_of_cache(flowmachine_connect)
@@ -253,7 +270,8 @@ def test_size_of_table(flowmachine_connect):
 
 
 def test_cache_miss_value_error_rescore():
-    """ValueError should be raised if we try to rescore something not in cache."""
+    """
+    ValueError should be raised if we try to rescore something not in cache."""
     connection_mock = Mock()
     connection_mock.fetch.return_value = []
     with pytest.raises(ValueError):
@@ -261,7 +279,8 @@ def test_cache_miss_value_error_rescore():
 
 
 def test_cache_miss_value_error_size_of_table():
-    """ValueError should be raised if we try to get the size of something not in cache."""
+    """
+    ValueError should be raised if we try to get the size of something not in cache."""
     connection_mock = Mock()
     connection_mock.fetch.return_value = []
     with pytest.raises(ValueError):
@@ -269,7 +288,8 @@ def test_cache_miss_value_error_size_of_table():
 
 
 def test_cache_miss_value_error_compute_time():
-    """ValueError should be raised if we try to get the compute time of something not in cache."""
+    """
+    ValueError should be raised if we try to get the compute time of something not in cache."""
     connection_mock = Mock()
     connection_mock.fetch.return_value = []
     with pytest.raises(ValueError):
@@ -277,7 +297,8 @@ def test_cache_miss_value_error_compute_time():
 
 
 def test_cache_miss_value_error_score():
-    """ValueError should be raised if we try to get the score of something not in cache."""
+    """
+    ValueError should be raised if we try to get the score of something not in cache."""
     connection_mock = Mock()
     connection_mock.fetch.return_value = []
     with pytest.raises(ValueError):
@@ -285,7 +306,9 @@ def test_cache_miss_value_error_score():
 
 
 def test_get_query_object_by_id(flowmachine_connect):
-    """Test that we can get a query object back out of the database by the md5 id"""
+    """
+    Test that we can get a query object back out of the database by the md5 id
+    """
     dl = daily_location("2016-01-01").store().result()
     retrieved_query = get_query_object_by_id(flowmachine_connect, dl.md5)
     assert dl.md5 == retrieved_query.md5
@@ -293,7 +316,9 @@ def test_get_query_object_by_id(flowmachine_connect):
 
 
 def test_delete_query_by_id(flowmachine_connect):
-    """Test that we can remove a query from cache by the md5 id"""
+    """
+    Test that we can remove a query from cache by the md5 id
+    """
     dl = daily_location("2016-01-01").store().result()
     retrieved_query = invalidate_cache_by_id(flowmachine_connect, dl.md5)
     assert dl.md5 == retrieved_query.md5
@@ -301,7 +326,9 @@ def test_delete_query_by_id(flowmachine_connect):
 
 
 def test_delete_query_by_id_does_not_cascade_by_default(flowmachine_connect):
-    """Test that removing a query by id doesn't cascade by default"""
+    """
+    Test that removing a query by id doesn't cascade by default
+    """
     dl = daily_location("2016-01-01").store().result()
     dl_agg = dl.aggregate().store().result()
     retrieved_query = invalidate_cache_by_id(flowmachine_connect, dl.md5)
@@ -311,7 +338,9 @@ def test_delete_query_by_id_does_not_cascade_by_default(flowmachine_connect):
 
 
 def test_delete_query_by_id_can_cascade(flowmachine_connect):
-    """Test that removing a query by id can cascade"""
+    """
+    Test that removing a query by id can cascade
+    """
     dl = daily_location("2016-01-01").store().result()
     dl_agg = dl.aggregate().store().result()
     retrieved_query = invalidate_cache_by_id(flowmachine_connect, dl.md5, cascade=True)
@@ -334,7 +363,9 @@ def reset_cache_settings(flowmachine_connect):
 
 
 def test_get_set_cache_size_limit(reset_cache_settings):
-    """Test that cache size can be got and set"""
+    """
+    Test that cache size can be got and set
+    """
     # Initial setting depends on the disk space of the FlowDB container so just check it is nonzero
     assert get_max_size_of_cache(reset_cache_settings) > 0
     # Now set it to something
@@ -343,7 +374,9 @@ def test_get_set_cache_size_limit(reset_cache_settings):
 
 
 def test_get_set_cache_half_life(reset_cache_settings):
-    """Test that cache halflife can be got and set"""
+    """
+    Test that cache halflife can be got and set
+    """
     assert 1000 == get_cache_half_life(reset_cache_settings)
     # Now set it to something
     set_cache_half_life(reset_cache_settings, 10)

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -96,7 +96,7 @@ def test_touch_cache_record_for_table(flowmachine_connect):
     """
     table = Table("events.calls_20160101")
     flowmachine_connect.engine.execute(
-        f"UPDATE cache.cached SET get_compute_time = 1 WHERE query_id=%s", table.md5
+        f"UPDATE cache.cached SET compute_time = 1 WHERE query_id=%s", table.md5
     )  # Compute time for tables is zero, so set to 1 to avoid zeroing out
     assert 0 == get_score(flowmachine_connect, table.md5)
     assert (

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -130,7 +130,8 @@ def test_touch_cache_record_for_table(flowmachine_connect):
 
 def test_get_compute_time():
     """
-    Compute time should take value returned in ms and turn it into seconds."""
+    Compute time should take value returned in ms and turn it into seconds.
+    """
     connection_mock = Mock()
     connection_mock.fetch.return_value = [[10]]
     assert 10 / 1000 == get_compute_time(connection_mock, "DUMMY_ID")
@@ -138,10 +139,12 @@ def test_get_compute_time():
 
 def test_get_cached_query_objects_ordered_by_score(flowmachine_connect):
     """
-    Test that all records which are queries are returned in correct order."""
+    Test that all records which are queries are returned in correct order.
+    """
     dl = daily_location("2016-01-01").store().result()
     dl_agg = dl.aggregate().store().result()
     table = dl.get_table()
+
     # Should prefer the larger, but slower to calculate and more used dl over the aggregation
     cached_queries = get_cached_query_objects_ordered_by_score(flowmachine_connect)
     assert 2 == len(cached_queries)
@@ -152,7 +155,8 @@ def test_get_cached_query_objects_ordered_by_score(flowmachine_connect):
 
 def test_shrink_one(flowmachine_connect):
     """
-    Test that shrink_one removes a cache record."""
+    Test that shrink_one removes a cache record.
+    """
     dl = daily_location("2016-01-01").store().result()
     dl_aggregate = dl.aggregate().store().result()
     flowmachine_connect.engine.execute(
@@ -169,7 +173,8 @@ def test_shrink_one(flowmachine_connect):
 
 def test_shrink_to_size_does_nothing_when_cache_ok(flowmachine_connect):
     """
-    Test that shrink_below_size doesn't remove anything if cache size is within limit."""
+    Test that shrink_below_size doesn't remove anything if cache size is within limit.
+    """
     dl = daily_location("2016-01-01").store().result()
     removed_queries = shrink_below_size(
         flowmachine_connect, get_size_of_cache(flowmachine_connect)
@@ -180,7 +185,8 @@ def test_shrink_to_size_does_nothing_when_cache_ok(flowmachine_connect):
 
 def test_shrink_to_size_removes_queries(flowmachine_connect):
     """
-    Test that shrink_below_size removes queries when cache limit is breached."""
+    Test that shrink_below_size removes queries when cache limit is breached.
+    """
     dl = daily_location("2016-01-01").store().result()
     removed_queries = shrink_below_size(
         flowmachine_connect, get_size_of_cache(flowmachine_connect) - 1
@@ -191,7 +197,8 @@ def test_shrink_to_size_removes_queries(flowmachine_connect):
 
 def test_shrink_to_size_respects_dry_run(flowmachine_connect):
     """
-    Test that shrink_below_size doesn't remove anything during a dry run."""
+    Test that shrink_below_size doesn't remove anything during a dry run.
+    """
     dl = daily_location("2016-01-01").store().result()
     dl2 = daily_location("2016-01-02").store().result()
     removed_queries = shrink_below_size(flowmachine_connect, 0, dry_run=True)
@@ -202,7 +209,8 @@ def test_shrink_to_size_respects_dry_run(flowmachine_connect):
 
 def test_shrink_to_size_dry_run_reflects_wet_run(flowmachine_connect):
     """
-    Test that shrink_below_size dry run is an accurate report."""
+    Test that shrink_below_size dry run is an accurate report.
+    """
     dl = daily_location("2016-01-01").store().result()
     dl2 = daily_location("2016-01-02").store().result()
     shrink_to = get_size_of_table(flowmachine_connect, dl.table_name, "cache")
@@ -217,7 +225,8 @@ def test_shrink_to_size_dry_run_reflects_wet_run(flowmachine_connect):
 
 def test_shrink_to_size_uses_score(flowmachine_connect):
     """
-    Test that shrink_below_size removes cache records in ascending score order."""
+    Test that shrink_below_size removes cache records in ascending score order.
+    """
     dl = daily_location("2016-01-01").store().result()
     dl_aggregate = dl.aggregate().store().result()
     flowmachine_connect.engine.execute(
@@ -235,7 +244,8 @@ def test_shrink_to_size_uses_score(flowmachine_connect):
 
 def test_shrink_one(flowmachine_connect):
     """
-    Test that shrink_one removes a cache record."""
+    Test that shrink_one removes a cache record.
+    """
     dl = daily_location("2016-01-01").store().result()
     dl_aggregate = dl.aggregate().store().result()
     flowmachine_connect.engine.execute(
@@ -252,7 +262,8 @@ def test_shrink_one(flowmachine_connect):
 
 def test_size_of_cache(flowmachine_connect):
     """
-    Test that cache size is reported correctly."""
+    Test that cache size is reported correctly.
+    """
     dl = daily_location("2016-01-01").store().result()
     dl_aggregate = dl.aggregate().store().result()
     total_cache_size = get_size_of_cache(flowmachine_connect)
@@ -264,7 +275,8 @@ def test_size_of_cache(flowmachine_connect):
 
 def test_size_of_table(flowmachine_connect):
     """
-    Test that table size is reported correctly."""
+    Test that table size is reported correctly.
+    """
     dl = daily_location("2016-01-01").store().result()
 
     total_cache_size = get_size_of_cache(flowmachine_connect)
@@ -274,7 +286,8 @@ def test_size_of_table(flowmachine_connect):
 
 def test_cache_miss_value_error_rescore():
     """
-    ValueError should be raised if we try to rescore something not in cache."""
+    ValueError should be raised if we try to rescore something not in cache.
+    """
     connection_mock = Mock()
     connection_mock.fetch.return_value = []
     with pytest.raises(ValueError):
@@ -283,7 +296,8 @@ def test_cache_miss_value_error_rescore():
 
 def test_cache_miss_value_error_size_of_table():
     """
-    ValueError should be raised if we try to get the size of something not in cache."""
+    ValueError should be raised if we try to get the size of something not in cache.
+    """
     connection_mock = Mock()
     connection_mock.fetch.return_value = []
     with pytest.raises(ValueError):
@@ -292,7 +306,8 @@ def test_cache_miss_value_error_size_of_table():
 
 def test_cache_miss_value_error_compute_time():
     """
-    ValueError should be raised if we try to get the compute time of something not in cache."""
+    ValueError should be raised if we try to get the compute time of something not in cache.
+    """
     connection_mock = Mock()
     connection_mock.fetch.return_value = []
     with pytest.raises(ValueError):
@@ -301,7 +316,8 @@ def test_cache_miss_value_error_compute_time():
 
 def test_cache_miss_value_error_score():
     """
-    ValueError should be raised if we try to get the score of something not in cache."""
+    ValueError should be raised if we try to get the score of something not in cache.
+    """
     connection_mock = Mock()
     connection_mock.fetch.return_value = []
     with pytest.raises(ValueError):

--- a/flowmachine/tests/test_flow_addition.py
+++ b/flowmachine/tests/test_flow_addition.py
@@ -83,4 +83,6 @@ def test_flow_scalar_addition_store(flowmachine_connect):
     rel = 1 + fl
     rel.store().result()
 
-    assert flowmachine_connect.has_table(*rel.table_name.split(".")[::-1])
+    assert flowmachine_connect.has_table(
+        *rel.fully_qualified_table_name.split(".")[::-1]
+    )

--- a/flowmachine/tests/test_flow_math.py
+++ b/flowmachine/tests/test_flow_math.py
@@ -22,7 +22,9 @@ def test_flow_math_store(op, exemplar_level_param, flowmachine_connect):
     dl2 = daily_location("2016-01-02", **exemplar_level_param)
     fl = op(Flows(dl1, dl2), Flows(dl1, dl2))
     fl.store().result()
-    assert flowmachine_connect.has_table(*fl.table_name.split(".")[::-1])
+    assert flowmachine_connect.has_table(
+        *fl.fully_qualified_table_name.split(".")[::-1]
+    )
 
 
 def test_average_self(get_dataframe):

--- a/flowmachine/tests/test_indexes.py
+++ b/flowmachine/tests/test_indexes.py
@@ -27,6 +27,6 @@ def test_index_created(flowmachine_connect):
     dl = daily_location("2016-01-01", "2016-01-02")
     dl.store().result()
     ix_qur = "SELECT * FROM pg_indexes WHERE tablename='{}'".format(
-        dl.table_name.split(".")[1]
+        dl.fully_qualified_table_name.split(".")[1]
     )
     assert len(flowmachine_connect.fetch(ix_qur)) == 2

--- a/flowmachine/tests/test_models_pwo.py
+++ b/flowmachine/tests/test_models_pwo.py
@@ -119,7 +119,7 @@ def test_model_result_make_query():
     mr = p.run(departure_rate_vector={"0xqNDj": 0.9}, ignore_missing=True)
     qur = mr._make_query()
     assert mr.is_stored
-    assert mr.table_name in qur
+    assert mr.fully_qualified_table_name in qur
 
 
 def test_model_result_cols():

--- a/flowmachine/tests/test_subscriber_location_cluster.py
+++ b/flowmachine/tests/test_subscriber_location_cluster.py
@@ -144,7 +144,7 @@ def test_different_call_days_format(get_dataframe):
 
     cd.store().result()
 
-    har = HartiganCluster(Table(cd.table_name), 50).get_dataframe()
+    har = HartiganCluster(Table(cd.fully_qualified_table_name), 50).get_dataframe()
     assert isinstance(har, pd.DataFrame)
 
     cd_query = cd.get_query()

--- a/flowmachine/tests/test_to_sql.py
+++ b/flowmachine/tests/test_to_sql.py
@@ -28,17 +28,8 @@ def test_stores_table(flowmachine_connect):
     EventTableSubset().to_sql() can be stored as a TABLE.
     """
     query = EventTableSubset("2016-01-01", "2016-01-01 01:00:00")
-    query.to_sql(schema="tests", name="test_table")
+    query.to_sql(name="test_table", schema="tests").result()
     assert "test_table" in flowmachine_connect.inspector.get_table_names(schema="tests")
-
-
-def test_stores_view(flowmachine_connect):
-    """
-    EventTableSubset().to_sql() can be stored as a VIEW.
-    """
-    query = EventTableSubset("2016-01-01", "2016-01-01 01:00:00")
-    query.to_sql(schema="tests", name="test_view", as_view=True)
-    assert "test_view" in flowmachine_connect.inspector.get_view_names(schema="tests")
 
 
 def test_can_force_rewrite(flowmachine_connect, get_length):
@@ -46,11 +37,11 @@ def test_can_force_rewrite(flowmachine_connect, get_length):
     Test that we can force the rewrite of a test to the database.
     """
     query = EventTableSubset("2016-01-01", "2016-01-01 01:00:00")
-    query.to_sql(schema="tests", name="test_rewrite")
+    query.to_sql(name="test_rewrite", schema="tests").result()
     # We're going to delete everything from the table, then
     # force a rewrite, and check that the table now has data.
     sql = """DELETE FROM tests.test_rewrite"""
     flowmachine_connect.engine.execute(sql)
     assert 0 == get_length(Table("tests.test_rewrite"))
-    query.to_sql(schema="tests", name="test_rewrite", force=True)
+    query.to_sql(name="test_rewrite", schema="tests", force=True).result()
     assert 1 < get_length(Table("tests.test_rewrite"))

--- a/integration_tests/tests/flowmachine_server_tests/conftest.py
+++ b/integration_tests/tests/flowmachine_server_tests/conftest.py
@@ -1,10 +1,11 @@
 import logging
 import os
 import pytest
-from sqlalchemy import inspect
 
 import flowmachine
 from flowmachine.core import Connection, Query
+from flowmachine.core.cache import reset_cache
+
 
 from .helpers import (
     create_flowdb_version_table,
@@ -88,11 +89,5 @@ def reset_cache_schema(fm_conn):
     so that they are empty.
     """
     print("[DDD] Recreating cache schema... ", end="", flush=True)
-    insp = inspect(fm_conn.engine)
-    cache_tables = insp.get_table_names(schema="cache")
-    for table in cache_tables:
-        if table in ["dependencies", "cached"]:
-            fm_conn.engine.execute(f"TRUNCATE cache.{table} CASCADE")
-        else:
-            fm_conn.engine.execute(f"DROP TABLE cache.{table}")
+    reset_cache(fm_conn)
     print("Done.")

--- a/integration_tests/tests/flowmachine_server_tests/helpers.py
+++ b/integration_tests/tests/flowmachine_server_tests/helpers.py
@@ -66,6 +66,7 @@ def get_cache_tables(fm_conn, exclude_internal_tables=True):
     if exclude_internal_tables:
         cache_tables.remove("cached")
         cache_tables.remove("dependencies")
+        cache_tables.remove("cache_config")
     return sorted(cache_tables)
 
 
@@ -81,7 +82,7 @@ def cache_schema_is_empty(fm_conn, check_internal_tables_are_empty=True):
     cache_tables = insp.get_table_names(schema="cache")
 
     # Check that there are no cached tables except the flowdb-internal ones
-    if cache_tables != ["cached", "dependencies"]:
+    if cache_tables != ["cache_config", "cached", "dependencies"]:
         return False
 
     if check_internal_tables_are_empty:

--- a/integration_tests/tests/flowmachine_server_tests/test_action_get_sql.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_action_get_sql.py
@@ -45,9 +45,7 @@ async def test_get_sql(zmq_url):
     }
 
     reply = send_message_and_get_reply(zmq_url, msg_get_sql)
-    assert (
-        "SELECT pcod,total FROM cache.xddc61a04f608dee16fff0655f91c2057" == reply["sql"]
-    )
+    assert "SELECT * FROM cache.xddc61a04f608dee16fff0655f91c2057" == reply["sql"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #125

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [x] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate 

### Description

This adds additional cache metadata, and some functions for managing and inspecting the cache. Redux of #175 but much more workable.


### Changes to FlowDB

- Adds a new function, `touch_cache`, which takes a query_id updates cache metadata, calculating a cache 'heat' score similar to that from cachey: `score = (n_cache_reads+1)*(compute_time / num_bytes * (1 + half_life))` (from [cachey](https://github.com/dask/cachey))
- Adds a cache_config table, which holds settings for cache half-life, and maximum disk size (set by env vars)
   - These default to 1000, and a tenth of the space available on whatever disk the postgres data store lives on
- Adds cache_half_life and cache_max_size functions as a convenience for getting those values
- Adds a table_size function, which gets the on disk size of a table (including indexes)
- Adds a cache_touches sequence, which tracks the total number of cache retrievals (required for calculating cache score)

#### Changes to cache.cached

- Renames the ts field to last_accessed
- Adds a created field
- Adds an access_count field
- Adds a compute_time field
- Adds a cache_score_multiplier field

### Changes to FlowMachine

#### Changes to Query, Table, ModelResult

- Records the time taken to compute the result when storing
- Updates access_count, last_accessed, and cache_score_multiplier fields when `get_query` is called. Previously this happened when `is_stored` was called, but `get_query` is a better representation of cache reads.
- Removes the ability to store as a view, because explain can't be used and hence we can't calculate a runtime. (Not something that's ever been used to the best of my knowledge)

#### Cache Management Functions

- Creates a new `cache` submodule under `core`
- Adds a `get_query_by_id` function, which retrieves a query object from cache by the md5 id (similar to getting at the cache record by creating a `Table` pointing at it).
- Adds `size_of_table`, which gets the total size in bytes (i.e. data & indexes) of a table in the DB
- Adds `size_of_cache`, which gets the total size in bytes of all cache tables, excluding `Table` records
- Adds `compute_time`, which gets the recorded compute time of a cached table given query id
- Adds `score`, which gets the current cache score of a query given a query id and memory bandwidth
- Adds `shrink_one`, which removes the cache record with the lowest `cache_score`
- Adds `shrink_below_size`, which removes cache records until the size of the cache drops below a threshold
- Adds `get_cached_queries_by_score`, which returns cached queries ordered by cache score
- Adds get/set functions for cache half-life and cache size
- Adds `touch_cache` function, which updates a cache record's score and metadata
- Adds a `reset_cache` function, which wipes the cache clean

Collectively, these changes allow us to check what's being used from cache with much greater ease, and facilitate managing the cache - potentially in a fully automated way.

Because the cache size and half-life are of necessity going to be specific to a given instance of FlowDB, rather than FlowMachine, I've put all the config for them into that. I've also put the score calculation FlowDB-side, because the implementation was a little more elegant without needing to do a bunch of round trips back into python.

The cache_score_multiplier is actually calculated as `cache_score_multiplier + ((1 + ln(2) / half_life) ** total_cache_touches)`, which is equivalent to the implementation here: https://github.com/dask/cachey/blob/master/cachey/score.py and the actual cache score is then the `compute_time_in_seconds/number_of_bytes_used*cache_score_multiplier`.

The total number of cache touches is incremented on any use of `get_query` or a cache write, and obviously an individual cached query's cache multiplier is updated only when _that_ query is read or written.