### PR TITLE
Switch redis image to Bitnami redis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,9 @@ defaults:
       auth:
         username: $DOCKER_CLOUD_USER
         password: $DOCKER_CLOUD_PASSWORD
-    - image: redis
+    - image: bitnami/redis:latest
+      environment:
+        - REDIS_PASSWORD: "fm_redis"
   - &docs_build
     - image: circleci/python:3.7
       environment:
@@ -46,7 +48,9 @@ defaults:
       environment:
         FM_PASSWORD: foo
         API_PASSWORD: foo
-    - image: redis
+    - image: bitnami/redis:latest
+      environment:
+        - REDIS_PASSWORD: "fm_redis"
   - &flowdbsynth_docker
     - image: circleci/python:3.7
       environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for password protected redis
 
 ### Changed
-- Changed the default redis image to bitnami's redis 
+- Changed the default redis image to bitnami's redis (to enable password protection)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Support for password protected redis
 
 ### Changed
+- Changed the default redis image to bitnami's redis 
 
 ### Fixed
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -117,6 +117,7 @@ services:
       - DB_PORT=${DB_PORT:-5432}
       - DB_HOST=${DB_HOST:-flowdb}
       - REDIS_HOST=${REDIS_HOST:-redis}
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-fm_redis}
     restart: always
     networks:
       - zero
@@ -125,9 +126,11 @@ services:
 
   redis:
     container_name: redis_flowkit
-    image: redis
+    image: bitnami/redis
     ports:
       - ${REDIS_PORT:-6379}:6379
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-fm_redis}
     restart: always
     networks:
       redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
             - LOG_LEVEL=${LOG_LEVEL:-error}
             - DEBUG=${FM_DEBUG:-False}
             - REDIS_HOST=${REDIS_HOST:-redis}
+            - REDIS_PASSWORD={REDIS_PASSWORD:-fm_redis}
         tty: true
         stdin_open: true
         networks:
@@ -69,7 +70,9 @@ services:
           - api
     redis:
         container_name: redis_flowkit
-        image: redis
+        image: bitnami/redis:latest
+        environment:
+            - REDIS_PASSWORD={REDIS_PASSWORD:-fm_redis}
         restart: always
         networks:
             redis:

--- a/docs/.env
+++ b/docs/.env
@@ -11,3 +11,4 @@ DB_PASS=foo
 JWT_SECRET_KEY=secret
 QUART_APP="app.main:create_app()"
 QUART_DEBUG=1
+REDIS_PASSWORD=fm_redis

--- a/docs/docs-build-containers.yml
+++ b/docs/docs-build-containers.yml
@@ -22,6 +22,8 @@ services:
     restart: always
   query_locker:
     container_name: flowkit_docs_redis
-    image: redis
+    image: bitnami/redis:latest
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-fm_redis}
     ports:
       - "$REDIS_PORT:6379"

--- a/docs/source/README.md
+++ b/docs/source/README.md
@@ -109,6 +109,10 @@ The stack expects you to provide seven secrets:
  - JWT_SECRET_KEY
  
     The secret key used to sign API access tokens
+ 
+ - REDIS_PASSWORD_FILE
+ 
+    The password protecting the redis instance
     
 
 To make use of secrets you will need to use docker swarm. For testing purposes, you can set up a single node swarm by running `docker swarm init`.
@@ -145,27 +149,10 @@ conn = flowclient.Connection("https://localhost:9090", "JWT_STRING", ssl_certifi
 
 ```bash
 cd secrets_quickstart
-docker login
-docker swarm init
-openssl rand -base64 16 | docker secret create FM_DB_PASS -
-echo "fm" | docker secret create FM_DB_USER -
-echo "api" | docker secret create API_DB_USER -
-openssl rand -base64 16 | docker secret create API_DB_PASS -
-openssl rand -base64 16 | docker secret create POSTGRES_PASSWORD_FILE -
-openssl req -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/CN=flow.api" \
-    -extensions SAN \
-    -config <( cat $( [[ "Darwin" -eq "$(uname -s)" ]]  && echo /System/Library/OpenSSL/openssl.cnf || echo /etc/ssl/openssl.cnf  ) \
-    <(printf "[SAN]\nsubjectAltName='DNS.1:localhost,DNS.2:flow.api'")) \
-    -keyout cert.key -out cert.pem
-cat client_cert.key cert.pem > cert-flowkit.pem
-docker secret create cert-flowkit.pem cert-flowkit.pem
-echo "secret" | docker secret create JWT_SECRET_KEY -
-docker stack deploy --with-registry-auth -c docker-stack.yml secrets_test
+pipenv run secrets_quickstart
 ```
 
 This will bring up a single node swarm, create random 16 character passwords for the database users, generate a certificate valid for the `flowkit.api` domain (and point that to `localhost` using `/etc/hosts`), pull all necessary containers, and bring up the API with `secret` as the JWT secret key.
-
-For convenience, you can also do `pipenv run secrets_quickstart` from the `secrets_quickstart` directory.
 
 Note that if you wish to deploy a branch other than master, you should set the `CIRCLE_BRANCH` environment variable before running, to ensure that Docker pulls the correct tags.
 

--- a/flowmachine/flowmachine/core/init.py
+++ b/flowmachine/flowmachine/core/init.py
@@ -141,8 +141,8 @@ def connect(
     )
     redis_pw = (
         getsecret("REDIS_PASSWORD_FILE", os.getenv("REDIS_PASSWORD", "fm_redis"))
-        if db_pw is None
-        else db_pw
+        if redis_password is None
+        else redis_password
     )
 
     try:

--- a/flowmachine/flowmachine/core/init.py
+++ b/flowmachine/flowmachine/core/init.py
@@ -39,6 +39,7 @@ def connect(
     pool_overflow=None,
     redis_host=None,
     redis_port=None,
+    redis_password=None,
     conn=None,
 ):
     """
@@ -138,6 +139,11 @@ def connect(
         if redis_port is None
         else redis_port
     )
+    redis_pw = (
+        getsecret("REDIS_PASSWORD_FILE", os.getenv("REDIS_PASSWORD", "fm_redis"))
+        if db_pw is None
+        else db_pw
+    )
 
     try:
         Query.connection
@@ -150,7 +156,9 @@ def connect(
             )
         Query.connection = conn
 
-        Query.redis = redis.StrictRedis(host=redis_host, port=redis_port)
+        Query.redis = redis.StrictRedis(
+            host=redis_host, port=redis_port, password=redis_pw
+        )
         _start_threadpool(pool_size)
 
         print(f"FlowMachine version: {flowmachine.__version__}")

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -124,6 +124,7 @@ def clean_env(monkeypatch):
     monkeypatch.delenv("POOL_OVERFLOW", raising=False)
     monkeypatch.delenv("REDIS_HOST", raising=False)
     monkeypatch.delenv("REDIS_PORT", raising=False)
+    monkeypatch.delenv("REDIS_PASSWORD", raising=False)
 
 
 @pytest.fixture

--- a/flowmachine/tests/test_init.py
+++ b/flowmachine/tests/test_init.py
@@ -69,6 +69,7 @@ def test_param_priority(mocked_connections, monkeypatch):
     monkeypatch.setenv("POOL_OVERFLOW", 7777)
     monkeypatch.setenv("REDIS_HOST", "DUMMY_ENV_REDIS_HOST")
     monkeypatch.setenv("REDIS_PORT", 7777)
+    monkeypatch.setenv("REDIS_PASSWORD", "DUMMY_ENV_REDIS_PASSWORD")
     core_init_logging_mock, core_init_Connection_mock, core_init_StrictRedis_mock, core_init_start_threadpool_mock = (
         mocked_connections
     )
@@ -84,6 +85,7 @@ def test_param_priority(mocked_connections, monkeypatch):
         pool_overflow=1011,
         redis_host="dummy_redis_host",
         redis_port=1213,
+        redis_password="dummy_redis_password",
     )
     core_init_logging_mock.assert_called_with("dummy_log_level", "dummy_log_file")
     core_init_Connection_mock.assert_called_with(
@@ -95,7 +97,9 @@ def test_param_priority(mocked_connections, monkeypatch):
         6789,
         1011,
     )
-    core_init_StrictRedis_mock.assert_called_with(host="dummy_redis_host", port=1213)
+    core_init_StrictRedis_mock.assert_called_with(
+        host="dummy_redis_host", port=1213, password="dummy_redis_password"
+    )
 
 
 def test_env_priority(mocked_connections, monkeypatch):
@@ -112,6 +116,7 @@ def test_env_priority(mocked_connections, monkeypatch):
     monkeypatch.setenv("POOL_OVERFLOW", 2020)
     monkeypatch.setenv("REDIS_HOST", "DUMMY_ENV_REDIS_HOST")
     monkeypatch.setenv("REDIS_PORT", 5050)
+    monkeypatch.setenv("REDIS_PASSWORD", "DUMMY_ENV_REDIS_PASSWORD")
     core_init_logging_mock, core_init_Connection_mock, core_init_StrictRedis_mock, core_init_start_threadpool_mock = (
         mocked_connections
     )
@@ -129,7 +134,7 @@ def test_env_priority(mocked_connections, monkeypatch):
         2020,
     )
     core_init_StrictRedis_mock.assert_called_with(
-        host="DUMMY_ENV_REDIS_HOST", port=5050
+        host="DUMMY_ENV_REDIS_HOST", port=5050, password="DUMMY_ENV_REDIS_PASSWORD"
     )
 
 
@@ -144,4 +149,6 @@ def test_connect_defaults(mocked_connections, monkeypatch):
     core_init_Connection_mock.assert_called_with(
         9000, "analyst", "foo", "localhost", "flowdb", 5, 1
     )
-    core_init_StrictRedis_mock.assert_called_with(host="localhost", port=6379)
+    core_init_StrictRedis_mock.assert_called_with(
+        host="localhost", port=6379, password="fm_redis"
+    )

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -37,6 +37,7 @@ services:
             - LOG_LEVEL=${LOG_LEVEL:-error}
             - DEBUG=${FM_DEBUG:-False}
             - REDIS_HOST=${REDIS_HOST:-redis}
+            - REDIS_PASSWORD=${REDIS_PASSWORD:-fm_redis}
         networks:
           - db
           - redis
@@ -61,7 +62,9 @@ services:
           - api
     query_locker:
         container_name: flowmachine_redis
-        image: redis
+        image: bitnami/redis:latest
+        environment:
+          - REDIS_PASSWORD=${REDIS_PASSWORD:-fm_redis}
         networks:
           redis:
             aliases:

--- a/secrets_quickstart/docker-stack.yml
+++ b/secrets_quickstart/docker-stack.yml
@@ -18,6 +18,8 @@ secrets:
     external: true
   JWT_SECRET_KEY: # Secret used to sign api tokens
     external: true
+  REDIS_PASSWORD_FILE: # Redis password
+    external: true
 networks:
   db:
   redis:
@@ -49,6 +51,7 @@ services:
         secrets:
           - FM_DB_USER
           - FM_DB_PASS
+          - REDIS_PASSWORD_FILE
         networks:
           - db
           - redis
@@ -71,7 +74,9 @@ services:
           - db
           - api
     query_locker:
-        image: redis
+        image: bitnami/redis:latest
+        secrets:
+          - REDIS_PASSWORD_FILE
         networks:
           redis:
             aliases:

--- a/secrets_quickstart/secrets-quickstart.sh
+++ b/secrets_quickstart/secrets-quickstart.sh
@@ -19,12 +19,14 @@ docker secret rm API_DB_USER
 docker secret rm POSTGRES_PASSWORD_FILE
 docker secret rm cert-flowkit.pem
 docker secret rm JWT_SECRET_KEY
+docker secret rm REDIS_PASSWORD_FILE
 echo "Adding secrets"
 openssl rand -base64 16 | docker secret create FM_DB_PASS -
 echo "fm" | docker secret create FM_DB_USER -
 echo "api" | docker secret create API_DB_USER -
 openssl rand -base64 16 | docker secret create API_DB_PASS -
 openssl rand -base64 16 | docker secret create POSTGRES_PASSWORD_FILE -
+openssl rand -base64 16 | docker secret create REDIS_PASSWORD_FILE -
 openssl req -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/CN=flow.api" \
     -extensions SAN \
     -config <( cat $( [[ "Darwin" -eq "$(uname -s)" ]]  && echo /System/Library/OpenSSL/openssl.cnf || echo /etc/ssl/openssl.cnf  ) \


### PR DESCRIPTION
Closes #223

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This changes the default redis image to the one provided by Bitnami, and adds support to FlowMachine for setting a password for the redis connection.