### PR TITLE
Error without superuser password

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
             mkdir $FLOWDB_DATA_DIR
             sudo chown -R ingestion:ingestion $FLOWDB_DATA_DIR $FLOWDB_INGESTION_DIR
             sudo chmod -R a+rw $FLOWDB_INGESTION_DIR
-      -run:
+      - run:
          name: Test that not providing a superuser password causes the container to exit
          command: |
            if docker run flowminder/flowdb:$SAFE_TAG; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ defaults:
       environment:
         FM_PASSWORD: foo
         API_PASSWORD: foo
+        POSTGRES_PASSWORD: flowflow
       auth:
         username: $DOCKER_CLOUD_USER
         password: $DOCKER_CLOUD_PASSWORD
@@ -46,6 +47,7 @@ defaults:
       environment:
         FM_PASSWORD: foo
         API_PASSWORD: foo
+        POSTGRES_PASSWORD: flowflow
     - image: redis
   - &flowdbsynth_docker
     - image: circleci/python:3.7
@@ -65,6 +67,7 @@ defaults:
         N_CALLS: 2000
         FM_PASSWORD: foo
         API_PASSWORD: foo
+        POSTGRES_PASSWORD: flowflow
   - &wait_for_flowdb
     name: Wait for flowdb to start
     command: |
@@ -179,16 +182,26 @@ jobs:
             mkdir $FLOWDB_DATA_DIR
             sudo chown -R ingestion:ingestion $FLOWDB_DATA_DIR $FLOWDB_INGESTION_DIR
             sudo chmod -R a+rw $FLOWDB_INGESTION_DIR
+      -run:
+         name: Test that not providing a superuser password causes the container to exit
+         command: |
+           if docker run flowminder/flowdb:$SAFE_TAG; then
+               exit 1
+           else
+               echo "Correctly failed with no superuser password"
+           fi
       - run:
           name: Launch flowdb
           command: |
             docker run --name flowdb --publish $DB_PORT:5432 --shm-size=1G --volume=${FLOWDB_DATA_DIR}:/var/lib/postgresql/data \
               --volume=${FLOWDB_INGESTION_DIR}:/ingestion -e FM_PASSWORD=foo -e API_PASSWORD=foo \
               -e MAX_CPUS=2 -e MAX_WORKERS=2 -e MAX_WORKERS_PER_GATHER=2 \
+              -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
               --detach flowminder/flowdb:$SAFE_TAG
 
             echo "Waiting for flowdb to be ready.."
             docker run --name flowdb_oracle --shm-size=1G --publish $ORACLE_DB_PORT:5432 -e FM_PASSWORD=foo -e API_PASSWORD=foo \
+            -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
              --detach flowminder/flowdb:oracle-$SAFE_TAG
             docker exec flowdb bash -c 'i=0;until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432);do let i=i+1; echo Waiting 10s; sleep 10;done'
             echo "Waiting for flowdb with oracle_fdw to be ready.."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- FlowDB now requires a password to be set for the flowdb superuser
 
 ### Fixed
 

--- a/flowdb/bin/build/last_create_roles.sh
+++ b/flowdb/bin/build/last_create_roles.sh
@@ -28,6 +28,13 @@
 #               for visualization applications.
 #
 
+if [ ! -e /run/secrets/POSTGRES_PASSWORD_FILE -a -z "$POSTGRES_PASSWORD" ];
+then
+    echo "No password supplied for superuser!"
+    echo "Set the POSTGRES_PASSWORD environment variable, or provide the POSTGRES_PASSWORD_FILE secret"
+    exit 1
+fi
+
 if [ -e /run/secrets/FM_DB_USER ];
 then
     echo "Using secrets for analyst user."


### PR DESCRIPTION
Closes #218

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This makes not providing either a `POSTGRES_PASSWORD` environment variable, or `POSTGRES_PASSWORD_FILE` secret to FlowDB an error that kills the container. (This is just a warning in the upstream Postgres image).