### PR TITLE
Clone using https in FlowDB Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed being unable to build if the port used by `git://` is not open
 
 ### Removed
-- Removed `-c http.sslVerify=false` option from the command to clone postgres pldebugger repository in flowdb Dockerfile
 
 ## [0.2.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
-Use `https://` protocol instead of `git://` to clone postgres pldebugger repository in flowdb Dockerfile
+- Use `https://` protocol instead of `git://` to clone postgres pldebugger repository in flowdb Dockerfile
 
 ### Fixed
 
 ### Removed
+- Removed `-c http.sslVerify=false` option from the command to clone postgres pldebugger repository in flowdb Dockerfile
 
 ## [0.1.2]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
-- Use `https://` protocol instead of `git://` to clone postgres pldebugger repository in flowdb Dockerfile
 
 ### Fixed
+- Fixed being unable to build if the port used by `git://` is not open
 
 ### Removed
 - Removed `-c http.sslVerify=false` option from the command to clone postgres pldebugger repository in flowdb Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+Use `https://` protocol instead of `git://` to clone postgres pldebugger repository in flowdb Dockerfile
 
 ### Fixed
 

--- a/flowdb/Dockerfile
+++ b/flowdb/Dockerfile
@@ -31,7 +31,7 @@ ENV LC_CTYPE=en_US.UTF-8
 
 RUN apt-get update \
         && apt-get install -y --no-install-recommends postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR postgis postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
-                postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts gdal-bin postgresql-$PG_MAJOR-pgrouting \
+        postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts gdal-bin postgresql-$PG_MAJOR-pgrouting \
         && rm -rf /var/lib/apt/lists/* \
         && apt-get purge -y --auto-remove
 
@@ -56,10 +56,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends locales locales
 #
 RUN apt-get update \
         && apt-get install -y --no-install-recommends \
-            unzip curl make postgresql-plpython-$PG_MAJOR \
-                postgresql-$PG_MAJOR-cron \
-                libaio1  \
-            parallel nano vim python3-pip wget python3-setuptools\
+        unzip curl make postgresql-plpython-$PG_MAJOR \
+        postgresql-$PG_MAJOR-cron \
+        libaio1  \
+        parallel nano vim python3-pip wget python3-setuptools\
         && apt purge -y --auto-remove \
         && rm -rf /var/lib/apt/lists/*
 
@@ -71,7 +71,7 @@ RUN apt-get update \
         postgresql-server-dev-$PG_MAJOR \
         build-essential \
         git \
-        && git -c http.sslVerify=false clone git://git.postgresql.org/git/pldebugger.git \
+        && git -c http.sslVerify=false clone https://git.postgresql.org/git/pldebugger.git \
         && mv pldebugger /usr/local/src \
         && make -C /usr/local/src/pldebugger \
         && make -C /usr/local/src/pldebugger install \
@@ -137,13 +137,13 @@ RUN chown $POSTGRES_UID:$POSTGRES_GID -R /var/run/postgresql
 #
 COPY ./Pipfile* /tmp/
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends python3-dev gcc m4 libxml2-dev libaio-dev \
-    && pip3 install pgxnclient \
-    && pip3 install pipenv \
-    && PIPENV_PIPFILE=/tmp/Pipfile pipenv install --system --deploy --three \
-    && apt-get remove -y python3-dev gcc m4 libxml2-dev libaio-dev \
-    && apt purge -y --auto-remove \
-    && rm -rf /var/lib/apt/lists/*
+        && apt-get install -y --no-install-recommends python3-dev gcc m4 libxml2-dev libaio-dev \
+        && pip3 install pgxnclient \
+        && pip3 install pipenv \
+        && PIPENV_PIPFILE=/tmp/Pipfile pipenv install --system --deploy --three \
+        && apt-get remove -y python3-dev gcc m4 libxml2-dev libaio-dev \
+        && apt purge -y --auto-remove \
+        && rm -rf /var/lib/apt/lists/*
 
 # Version Information
 # Set the version & release date

--- a/flowdb/Dockerfile
+++ b/flowdb/Dockerfile
@@ -71,7 +71,7 @@ RUN apt-get update \
         postgresql-server-dev-$PG_MAJOR \
         build-essential \
         git \
-        && git -c http.sslVerify=false clone https://git.postgresql.org/git/pldebugger.git \
+        && git clone https://git.postgresql.org/git/pldebugger.git \
         && mv pldebugger /usr/local/src \
         && make -C /usr/local/src/pldebugger \
         && make -C /usr/local/src/pldebugger install \


### PR DESCRIPTION
Closes #251

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Two changes to the command to clone `git.postgresql.org/git/pldebugger.git` in the FlowDB Dockerfile:
- Use `https://` protocol instead of `git://`
- Remove `-c http.sslVerify=false` option, since it appears to be unnecessary now.
