### PR TITLE
Support running FlowDB as arbitrary user via --user flag to docker run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,15 +178,6 @@ jobs:
             docker build --build-arg CODE_VERSION=$SAFE_TAG -t flowminder/flowdb:synthetic-data-$SAFE_TAG -t flowminder/flowdb:synthetic-data-$CIRCLE_WORKFLOW_ID \
               -f flowdb/testdata/Dockerfile.synthetic_data flowdb/testdata
       - run:
-          name: Create ingestion environment
-          command: |
-            echo "User ID ($POSTGRES_UID) and Group ID ($POSTGRES_GID)"
-            sudo groupadd --gid $POSTGRES_UID ingestion
-            sudo useradd -g ingestion -u $POSTGRES_GID ingestion
-            mkdir $FLOWDB_DATA_DIR
-            sudo chown -R ingestion:ingestion $FLOWDB_DATA_DIR $FLOWDB_INGESTION_DIR
-            sudo chmod -R a+rw $FLOWDB_INGESTION_DIR
-      - run:
          name: Test that not providing a superuser password causes the container to exit
          command: |
            if docker run flowminder/flowdb:$SAFE_TAG; then
@@ -197,7 +188,7 @@ jobs:
       - run:
           name: Launch flowdb
           command: |
-            docker run --name flowdb --publish $DB_PORT:5432 --shm-size=1G --volume=${FLOWDB_DATA_DIR}:/var/lib/postgresql/data \
+            docker run --name flowdb --publish $DB_PORT:5432 --user $(id -u):$(id -g) --shm-size=1G --volume=${FLOWDB_DATA_DIR}:/var/lib/postgresql/data \
               --volume=${FLOWDB_INGESTION_DIR}:/ingestion -e FM_PASSWORD=foo -e API_PASSWORD=foo \
               -e MAX_CPUS=2 -e MAX_WORKERS=2 -e MAX_WORKERS_PER_GATHER=2 \
               -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,8 +191,8 @@ jobs:
       - run:
           name: Launch flowdb
           command: |
-            docker run --name flowdb --publish $DB_PORT:5432 --shm-size=1G --volume=${FLOWDB_DATA_DIR}:/var/lib/postgresql/data \
-              --volume=${FLOWDB_INGESTION_DIR}:/ingestion -e FM_PASSWORD=foo -e API_PASSWORD=foo \
+            docker run --name flowdb --publish $DB_PORT:5432 --user $(id -u):$(id -g) --shm-size=1G --volume=${FLOWDB_DATA_DIR}:/var/lib/postgresql/data \
+              --volume=${FLOWDB_INGESTION_DIR}:/ingestion:ro -e FM_PASSWORD=foo -e API_PASSWORD=foo \
               -e MAX_CPUS=2 -e MAX_WORKERS=2 -e MAX_WORKERS_PER_GATHER=2 \
               -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
               --detach flowminder/flowdb:$SAFE_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
             docker run --name flowdb_oracle --shm-size=1G --publish $ORACLE_DB_PORT:5432 -e FM_PASSWORD=foo -e API_PASSWORD=foo \
             -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
              --detach flowminder/flowdb:oracle-$SAFE_TAG
-            docker exec flowdb bash -c 'i=0;until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432);do let i=i+1; echo Waiting 10s; sleep 10;done'
+            docker exec flowdb bash -c 'i=0;until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432 -U flowdb);do let i=i+1; echo Waiting 10s; sleep 10;done'
             echo "Waiting for flowdb with oracle_fdw to be ready.."
             docker exec flowdb_oracle bash -c 'i=0;until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432);do let i=i+1; echo Waiting 10s; sleep 10;done'
             docker ps -a

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,10 +184,9 @@ jobs:
                echo "Correctly failed with no superuser password"
            fi
       - run:
-          name: Create ingestion environment
+          name: Create data dir
           command: |
             mkdir $FLOWDB_DATA_DIR
-            mkdir $FLOWDB_INGESTION_DIR
       - run:
           name: Launch flowdb
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,6 @@ defaults:
     DB_PORT: 9000
     ORACLE_DB_PORT: 9002
     SYNTHETIC_DATA_DB_PORT: 5432
-    POSTGRES_UID: 1180
-    POSTGRES_GID: 1180
     FLOWDB_DATA_DIR: /home/circleci/database_data
     FLOWDB_INGESTION_DIR: /home/circleci/project/flowdb/tests/data
     POSTGRES_PASSWORD: flowflow
@@ -186,9 +184,14 @@ jobs:
                echo "Correctly failed with no superuser password"
            fi
       - run:
+          name: Create ingestion environment
+          command: |
+            mkdir $FLOWDB_DATA_DIR
+            mkdir $FLOWDB_INGESTION_DIR
+      - run:
           name: Launch flowdb
           command: |
-            docker run --name flowdb --publish $DB_PORT:5432 --user $(id -u):$(id -g) --shm-size=1G --volume=${FLOWDB_DATA_DIR}:/var/lib/postgresql/data \
+            docker run --name flowdb --publish $DB_PORT:5432 --shm-size=1G --volume=${FLOWDB_DATA_DIR}:/var/lib/postgresql/data \
               --volume=${FLOWDB_INGESTION_DIR}:/ingestion -e FM_PASSWORD=foo -e API_PASSWORD=foo \
               -e MAX_CPUS=2 -e MAX_WORKERS=2 -e MAX_WORKERS_PER_GATHER=2 \
               -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Support for running FlowDB as an arbitrary user via docker's `--user` flag
 
 ### Changed
 
 ### Fixed
 
 ### Removed
+- Support for setting the uid and gid of the postgres user when building FlowDB
 
 ## [0.2.0]
 ### Added

--- a/docs/source/flowdb.md
+++ b/docs/source/flowdb.md
@@ -38,7 +38,10 @@ services:
           - /path/to/consume/data/from/host:/etl:ro
 ```
 
-This creates two bind mounts, the first is FlowDB's internal storage, and the second is a *read only* mount for loading new data. The user FlowDB runs as inside the container will also be changed to the uid specified, and if the bind mounted directories do no exist, docker will create them.
+This creates two bind mounts, the first is FlowDB's internal storage, and the second is a *read only* mount for loading new data. The user FlowDB runs as inside the container will also be changed to the uid specified. 
+
+!!! warning
+    If the bind mounted directories do not exist, docker will create them and you will need to `chown` them to the correct user.
 
 And similarly when using `docker run`:
 

--- a/docs/source/flowdb.md
+++ b/docs/source/flowdb.md
@@ -16,4 +16,47 @@ FlowDB is database designed for storing, serving, and analysing mobile operator 
 
 ## Caveats
 
-You will typically need to increase the default shared memory available to docker containers when running FlowDB. You can do this either by setting `shm_size` for the FlowDB container in your compose or stack file, or by passing the `--shm-size` argument to the `docker run` command.  
+### Shared Memory
+
+You will typically need to increase the default shared memory available to docker containers when running FlowDB. You can do this either by setting `shm_size` for the FlowDB container in your compose or stack file, or by passing the `--shm-size` argument to the `docker run` command.
+
+### Bind Mounts and User Permissions
+
+By default, FlowDB will create and attach a docker volume that contains all data. In some cases, this will be sufficient for use.
+
+However, you will often wish to set up bind mounts to hold the data and allow FlowDB to consume new data. To avoid sticky situations with permissions, you will want to specify the uid and gid that FlowDB runs with to match an existing user on the host system.
+
+Adding a bind mount using `docker-compose` is simple:
+
+```yaml
+services:
+    flowdb:
+    ...
+        user: HOST_USER_ID:HOST_GROUP_ID
+        volumes:
+          - /path/to/store/data/on/host:/var/lib/postgresql/data
+          - /path/to/consume/data/from/host:/etl:ro
+```
+
+This creates two bind mounts, the first is FlowDB's internal storage, and the second is a *read only* mount for loading new data. The user FlowDB runs as inside the container will also be changed to the uid specified, and if the bind mounted directories do no exist, docker will create them.
+
+And similarly when using `docker run`:
+
+```bash
+docker run --name flowdb_testdata -e FM_PASSWORD=foo -e API_PASSWORD=foo \
+ --publish 9000:5432 \
+ --user HOST_USER_ID:HOST_GROUP_ID \
+ -v /path/to/store/data/on/host:/var/lib/postgresql/data \
+ -v /path/to/consume/data/from/host:/etl:ro \
+ --detach flowminder/flowdb:latest
+```
+
+!!! tip
+    To run as the current user, you can simply replace `HOST_USER_ID:HOST_GROUP_ID` with `$(id -u):$(id -g)`.
+ 
+ 
+!!! warning
+    Using the `--user` flag without a bind mount specified will not work, and you will see an error
+    like this: `initdb: could not change permissions of directory "/var/lib/postgresql/data": Operation not permitted`.
+    
+    When using docker volumes, docker will manage the permissions for you.

--- a/flowdb/Dockerfile
+++ b/flowdb/Dockerfile
@@ -145,6 +145,8 @@ COPY --chown=postgres ./bin/build/* /docker-entrypoint-initdb.d/
 #
 ADD --chown=postgres ./sql/* /docker-entrypoint-initdb.d/
 ADD --chown=postgres ./data/* /docker-entrypoint-initdb.d/data/csv/
+# Need to make postgres owner
+RUN chown -R postgres /docker-entrypoint-initdb.d
 
 EXPOSE 5432
 

--- a/flowdb/Dockerfile
+++ b/flowdb/Dockerfile
@@ -12,7 +12,7 @@
 #  on the official Debian Stretch (9) image.
 #
 ARG POSTGRES_RELEASE=11
-ARG POSTGRES_DIGEST=40b48cf04185e69c5a9183a986fcbbfd105e5991a70b1980e9a641b53ba5ead7
+ARG POSTGRES_DIGEST=e33ab1e8a206c54f66913812f0edb524959917a2fb5f2cf233d46083394a99ef
 
 FROM postgres:$POSTGRES_RELEASE@sha256:$POSTGRES_DIGEST
 
@@ -95,36 +95,6 @@ RUN apt-get update \
 #  do that.
 #
 RUN mkdir -p /docker-entrypoint-initdb.d
-
-# Default uid & gid
-ARG POSTGRES_UID=1180
-ARG POSTGRES_GID=1180
-ENV POSTGRES_UID=$POSTGRES_UID
-ENV POSTGRES_GID=$POSTGRES_GID
-
-#
-#  The postgres image sets the UID and GID of the
-#  postgres user to 999, but they need to be changed in order
-#  to agree with the host system specifications
-#
-RUN groupmod -g $POSTGRES_GID postgres \
-        && usermod -u $POSTGRES_UID -g $POSTGRES_GID postgres
-
-RUN chown $POSTGRES_UID:$POSTGRES_GID -R /docker-entrypoint-initdb.d/
-
-#
-#  As per issue below we have to change the ownership
-#  of the postgres binaries directory because it
-#  uses that directory to create temporary *.lock
-#  files. The database will refuse to start without
-#  this line.
-#
-#    https://github.com/docker-library/postgres/issues/264
-#
-#  We should keep this line until that issue
-#  is solved.
-#
-RUN chown $POSTGRES_UID:$POSTGRES_GID -R /var/run/postgresql
 
 #
 #  Let's now install the `flowdb-cli` program

--- a/flowdb/Dockerfile
+++ b/flowdb/Dockerfile
@@ -136,15 +136,15 @@ ENV DEBUG=False
 #
 #  Copy file spinup build scripts to be execed.
 #
-COPY --chown postgres ./bin/build/* /docker-entrypoint-initdb.d/
+COPY --chown=postgres ./bin/build/* /docker-entrypoint-initdb.d/
 
 #
 #  Add local data to PostgreSQL data ingestion
 #  directory. Files in that directory will be
 #  ingested by PostgreSQL on build-time.
 #
-ADD --chown postgres ./sql/* /docker-entrypoint-initdb.d/
-ADD --chown postgres ./data/* /docker-entrypoint-initdb.d/data/csv/
+ADD --chown=postgres ./sql/* /docker-entrypoint-initdb.d/
+ADD --chown=postgres ./data/* /docker-entrypoint-initdb.d/data/csv/
 
 EXPOSE 5432
 

--- a/flowdb/Dockerfile
+++ b/flowdb/Dockerfile
@@ -136,15 +136,15 @@ ENV DEBUG=False
 #
 #  Copy file spinup build scripts to be execed.
 #
-COPY ./bin/build/* /docker-entrypoint-initdb.d/
+COPY --chown postgres ./bin/build/* /docker-entrypoint-initdb.d/
 
 #
 #  Add local data to PostgreSQL data ingestion
 #  directory. Files in that directory will be
 #  ingested by PostgreSQL on build-time.
 #
-ADD ./sql/* /docker-entrypoint-initdb.d/
-ADD ./data/* /docker-entrypoint-initdb.d/data/csv/
+ADD --chown postgres ./sql/* /docker-entrypoint-initdb.d/
+ADD --chown postgres ./data/* /docker-entrypoint-initdb.d/data/csv/
 
 EXPOSE 5432
 

--- a/flowdb/bin/build/001_check_environment.sh
+++ b/flowdb/bin/build/001_check_environment.sh
@@ -2,7 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+set -e
 
 
 for VAR in "$FLOWDB_VERSION" "$FLOWDB_RELEASE_DATE"; do

--- a/flowdb/bin/build/004_postgis_ingest_data.sh
+++ b/flowdb/bin/build/004_postgis_ingest_data.sh
@@ -6,7 +6,7 @@
 
 
 set -e
-
+export PGUSER="$POSTGRES_USER"
 #
 #  Ingest all files available in the data/sql
 #  folders. Those were created using PostGIS

--- a/flowdb/bin/build/005_flowdb_version.sh
+++ b/flowdb/bin/build/005_flowdb_version.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -12,6 +13,8 @@
 #  version table. This data is eventually
 #  used by the flowdb_version() function.
 #
+
+export PGUSER="$POSTGRES_USER"
 
 
 psql --dbname="$POSTGRES_DB" -c "

--- a/flowdb/bin/build/006_location_table.sh
+++ b/flowdb/bin/build/006_location_table.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -11,6 +12,8 @@
 #  Adds a table identifying which table the location_id column
 #  references. Used in get_location_table().
 #
+
+export PGUSER="$POSTGRES_USER"
 
 psql --dbname="$POSTGRES_DB" -c "
     BEGIN;

--- a/flowdb/bin/build/08_configure_cache.sh
+++ b/flowdb/bin/build/08_configure_cache.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+set -e
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/flowdb/bin/build/last_create_roles.sh
+++ b/flowdb/bin/build/last_create_roles.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -27,6 +28,8 @@
 #               data). This user is designed mainly 
 #               for visualization applications.
 #
+
+export PGUSER="$POSTGRES_USER"
 
 if [ ! -e /run/secrets/POSTGRES_PASSWORD_FILE -a -z "$POSTGRES_PASSWORD" ];
 then

--- a/flowdb/testdata/Dockerfile
+++ b/flowdb/testdata/Dockerfile
@@ -18,7 +18,7 @@ FROM flowminder/flowdb:${CODE_VERSION}
 #
 
 RUN mkdir -p /docker-entrypoint-initdb.d/sql/testdata/
-COPY --chown postgres ./bin/z_ingest_test_data.sh /docker-entrypoint-initdb.d/
-ADD --chown postgres ./test_data/sql/* /docker-entrypoint-initdb.d/sql/testdata/
-ADD --chown postgres ./test_data/data/ /docker-entrypoint-initdb.d/data/
-COPY  --chown postgres ./test_data/data/*.csv /docker-entrypoint-initdb.d/data/csv/
+COPY --chown=postgres ./bin/z_ingest_test_data.sh /docker-entrypoint-initdb.d/
+ADD --chown=postgres ./test_data/sql/* /docker-entrypoint-initdb.d/sql/testdata/
+ADD --chown=postgres ./test_data/data/ /docker-entrypoint-initdb.d/data/
+COPY  --chown=postgres ./test_data/data/*.csv /docker-entrypoint-initdb.d/data/csv/

--- a/flowdb/testdata/Dockerfile
+++ b/flowdb/testdata/Dockerfile
@@ -18,7 +18,7 @@ FROM flowminder/flowdb:${CODE_VERSION}
 #
 
 RUN mkdir -p /docker-entrypoint-initdb.d/sql/testdata/
-COPY ./bin/z_ingest_test_data.sh /docker-entrypoint-initdb.d/
-ADD ./test_data/sql/* /docker-entrypoint-initdb.d/sql/testdata/
-ADD ./test_data/data/ /docker-entrypoint-initdb.d/data/
-COPY ./test_data/data/*.csv /docker-entrypoint-initdb.d/data/csv/
+COPY --chown postgres ./bin/z_ingest_test_data.sh /docker-entrypoint-initdb.d/
+ADD --chown postgres ./test_data/sql/* /docker-entrypoint-initdb.d/sql/testdata/
+ADD --chown postgres ./test_data/data/ /docker-entrypoint-initdb.d/data/
+COPY  --chown postgres ./test_data/data/*.csv /docker-entrypoint-initdb.d/data/csv/

--- a/flowdb/testdata/Dockerfile
+++ b/flowdb/testdata/Dockerfile
@@ -22,5 +22,5 @@ COPY --chown=postgres ./bin/z_ingest_test_data.sh /docker-entrypoint-initdb.d/
 ADD --chown=postgres ./test_data/sql/* /docker-entrypoint-initdb.d/sql/testdata/
 ADD --chown=postgres ./test_data/data/ /docker-entrypoint-initdb.d/data/
 COPY  --chown=postgres ./test_data/data/*.csv /docker-entrypoint-initdb.d/data/csv/
-# Need to make postgres is owner of any subdirectrories
+# Need to make postgres owner of any subdirectories
 RUN chown -R postgres /docker-entrypoint-initdb.d

--- a/flowdb/testdata/Dockerfile
+++ b/flowdb/testdata/Dockerfile
@@ -22,3 +22,5 @@ COPY --chown=postgres ./bin/z_ingest_test_data.sh /docker-entrypoint-initdb.d/
 ADD --chown=postgres ./test_data/sql/* /docker-entrypoint-initdb.d/sql/testdata/
 ADD --chown=postgres ./test_data/data/ /docker-entrypoint-initdb.d/data/
 COPY  --chown=postgres ./test_data/data/*.csv /docker-entrypoint-initdb.d/data/csv/
+# Need to make postgres is owner of any subdirectrories
+RUN chown -R postgres /docker-entrypoint-initdb.d

--- a/flowdb/testdata/Dockerfile.synthetic_data
+++ b/flowdb/testdata/Dockerfile.synthetic_data
@@ -42,11 +42,6 @@ ADD ./synthetic_data/sql/* /docker-entrypoint-initdb.d/sql/syntheticdata/
 ADD ./test_data/sql/admin*.sql /docker-entrypoint-initdb.d/sql/syntheticdata/
 ADD ./synthetic_data/data/NPL_admbnda_adm3_Districts_simplified.geojson /opt/synthetic_data/
 
-RUN chown $POSTGRES_UID:$POSTGRES_GID -R \
-        /docker-entrypoint-initdb.d/sql/syntheticdata \
-        /docker-entrypoint-initdb.d/data/records/calls \
-        /opt/synthetic_data/ \
-        /docker-entrypoint-initdb.d/data/infrastructure
 
 ENV N_DAYS=7
 ENV N_SUBSCRIBERS=4000

--- a/flowdb/testdata/Dockerfile.synthetic_data
+++ b/flowdb/testdata/Dockerfile.synthetic_data
@@ -41,6 +41,8 @@ COPY --chown=postgres bin/generate_synthetic_data.py /opt/synthetic_data/
 ADD --chown=postgres ./synthetic_data/sql/* /docker-entrypoint-initdb.d/sql/syntheticdata/
 ADD --chown=postgres ./test_data/sql/admin*.sql /docker-entrypoint-initdb.d/sql/syntheticdata/
 ADD --chown=postgres ./synthetic_data/data/NPL_admbnda_adm3_Districts_simplified.geojson /opt/synthetic_data/
+# Need to make postgres is owner of any subdirectrories
+RUN chown -R postgres /docker-entrypoint-initdb.d
 
 ENV N_DAYS=7
 ENV N_SUBSCRIBERS=4000

--- a/flowdb/testdata/Dockerfile.synthetic_data
+++ b/flowdb/testdata/Dockerfile.synthetic_data
@@ -23,7 +23,7 @@ RUN echo "deb http://ftp.de.debian.org/debian testing main" > /etc/apt/sources.l
         && rm -rf /var/lib/apt/lists/*
 
 # Install python dependencies
-COPY ./Pipfile* /tmp/
+COPY --chown postgres ./Pipfile* /tmp/
 RUN PIPENV_PIPFILE=/tmp/Pipfile pipenv install --system --deploy --three \
     && rm /tmp/Pipfile*
 
@@ -35,13 +35,12 @@ RUN mkdir -p /docker-entrypoint-initdb.d/sql/syntheticdata/ && \
     mkdir -p /docker-entrypoint-initdb.d/data/records/calls && \
     mkdir -p /docker-entrypoint-initdb.d/data/infrastructure
 
-COPY ./bin/z_ingest_synthetic_data.sh /docker-entrypoint-initdb.d/
+COPY --chown postgres ./bin/z_ingest_synthetic_data.sh /docker-entrypoint-initdb.d/
 
-COPY bin/generate_synthetic_data.py /opt/synthetic_data/
-ADD ./synthetic_data/sql/* /docker-entrypoint-initdb.d/sql/syntheticdata/
-ADD ./test_data/sql/admin*.sql /docker-entrypoint-initdb.d/sql/syntheticdata/
-ADD ./synthetic_data/data/NPL_admbnda_adm3_Districts_simplified.geojson /opt/synthetic_data/
-
+COPY --chown postgres bin/generate_synthetic_data.py /opt/synthetic_data/
+ADD --chown postgres ./synthetic_data/sql/* /docker-entrypoint-initdb.d/sql/syntheticdata/
+ADD --chown postgres ./test_data/sql/admin*.sql /docker-entrypoint-initdb.d/sql/syntheticdata/
+ADD --chown postgres ./synthetic_data/data/NPL_admbnda_adm3_Districts_simplified.geojson /opt/synthetic_data/
 
 ENV N_DAYS=7
 ENV N_SUBSCRIBERS=4000

--- a/flowdb/testdata/Dockerfile.synthetic_data
+++ b/flowdb/testdata/Dockerfile.synthetic_data
@@ -43,6 +43,8 @@ ADD --chown=postgres ./test_data/sql/admin*.sql /docker-entrypoint-initdb.d/sql/
 ADD --chown=postgres ./synthetic_data/data/NPL_admbnda_adm3_Districts_simplified.geojson /opt/synthetic_data/
 # Need to make postgres is owner of any subdirectrories
 RUN chown -R postgres /docker-entrypoint-initdb.d
+# Need to relax the permissions in case the container is running as an arbitrary user with a bind mount
+RUN chmod -R 777 /docker-entrypoint-initdb.d
 
 ENV N_DAYS=7
 ENV N_SUBSCRIBERS=4000

--- a/flowdb/testdata/Dockerfile.synthetic_data
+++ b/flowdb/testdata/Dockerfile.synthetic_data
@@ -23,7 +23,7 @@ RUN echo "deb http://ftp.de.debian.org/debian testing main" > /etc/apt/sources.l
         && rm -rf /var/lib/apt/lists/*
 
 # Install python dependencies
-COPY --chown postgres ./Pipfile* /tmp/
+COPY --chown=postgres ./Pipfile* /tmp/
 RUN PIPENV_PIPFILE=/tmp/Pipfile pipenv install --system --deploy --three \
     && rm /tmp/Pipfile*
 
@@ -35,12 +35,12 @@ RUN mkdir -p /docker-entrypoint-initdb.d/sql/syntheticdata/ && \
     mkdir -p /docker-entrypoint-initdb.d/data/records/calls && \
     mkdir -p /docker-entrypoint-initdb.d/data/infrastructure
 
-COPY --chown postgres ./bin/z_ingest_synthetic_data.sh /docker-entrypoint-initdb.d/
+COPY --chown=postgres ./bin/z_ingest_synthetic_data.sh /docker-entrypoint-initdb.d/
 
-COPY --chown postgres bin/generate_synthetic_data.py /opt/synthetic_data/
-ADD --chown postgres ./synthetic_data/sql/* /docker-entrypoint-initdb.d/sql/syntheticdata/
-ADD --chown postgres ./test_data/sql/admin*.sql /docker-entrypoint-initdb.d/sql/syntheticdata/
-ADD --chown postgres ./synthetic_data/data/NPL_admbnda_adm3_Districts_simplified.geojson /opt/synthetic_data/
+COPY --chown=postgres bin/generate_synthetic_data.py /opt/synthetic_data/
+ADD --chown=postgres ./synthetic_data/sql/* /docker-entrypoint-initdb.d/sql/syntheticdata/
+ADD --chown=postgres ./test_data/sql/admin*.sql /docker-entrypoint-initdb.d/sql/syntheticdata/
+ADD --chown=postgres ./synthetic_data/data/NPL_admbnda_adm3_Districts_simplified.geojson /opt/synthetic_data/
 
 ENV N_DAYS=7
 ENV N_SUBSCRIBERS=4000

--- a/flowdb/testdata/bin/z_ingest_synthetic_data.sh
+++ b/flowdb/testdata/bin/z_ingest_synthetic_data.sh
@@ -6,6 +6,7 @@
 
 
 set -e
+export PGUSER="$POSTGRES_USER"
 
 #
 #  Generate synthetic data

--- a/flowdb/testdata/bin/z_ingest_test_data.sh
+++ b/flowdb/testdata/bin/z_ingest_test_data.sh
@@ -6,6 +6,7 @@
 
 
 set -e
+export PGUSER="$POSTGRES_USER"
 
 #
 #  Ingest test data.


### PR DESCRIPTION
Closes #247

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This deprecates setting the uid and gid used by FlowDB during the image build, in favour of setting it by passing `--user uid:gid` to `docker run` or the `user` key in a compose file.

Removes a bunch of legacy workarounds in the Dockerfiles, and updates the upstream Postgres image to the most current one.

This change is primarily important in scenarios where you are persisting FlowDB via a bind mount, or want to run ETL by bind mounting a directory on the host. Previously, one had to ensure that you'd either built the image with the Postgres uid and gid matching an existing user on the host, or that you could create a new user matching the uid and gid expected. You can now use any user that exists on the host, and specify that at runtime.

(Unrelatedly, I've also fixed the GitHub readme, which had diverged from the docs one)