### PR TITLE
Fix integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- The number of threads used by FlowMachine to manage running queries is no longer the same as the number of database connections. It can instead be controlled using the `THREAD_POOL_SIZE` environment variable, and will default to `5*n_cores`.
-
 ### Fixed
 
 ### Removed

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,7 +13,7 @@ services:
 
   flowdb:
     container_name: flowdb
-    image: flowminder/flowdb:master
+    image: flowminder/flowdb:latest
     ports:
       - ${FLOWDB_PORT:-9000}:5432
     environment:
@@ -33,7 +33,7 @@ services:
 
   flowdb_testdata:
     container_name: flowdb_testdata
-    image: flowminder/flowdb:testdata-master
+    image: flowminder/flowdb:testdata-latest
     ports:
       - ${FLOWDB_TESTDATA_PORT:-9001}:5432
     environment:
@@ -75,7 +75,7 @@ services:
 
   flowapi:
     container_name: flowapi
-    image: flowminder/flowapi:master
+    image: flowminder/flowapi:latest
     build:
       context: ./flowapi
       dockerfile: Dockerfile
@@ -101,7 +101,7 @@ services:
 
   flowmachine:
     container_name: flowmachine
-    image: flowminder/flowmachine:master
+    image: flowminder/flowmachine:latest
     build:
       context: ./flowmachine
       dockerfile: Dockerfile

--- a/flowmachine/flowmachine/core/init.py
+++ b/flowmachine/flowmachine/core/init.py
@@ -38,7 +38,6 @@ def connect(
     db_name: Union[str, None] = None,
     db_connection_pool_size: Union[int, None] = None,
     db_connection_pool_overflow: Union[int, None] = None,
-    thread_pool_size: Union[int, None] = None,
     redis_host: Union[str, None] = None,
     redis_port: Union[int, None] = None,
     redis_password: Union[str, None] = None,
@@ -69,8 +68,6 @@ def connect(
         Default number of database connections to use
     db_connection_pool_overflow : int, default 1
         Number of extra database connections to allow
-    thread_pool_size : int, default None
-        Number of threads to use for running queries. Defaults to 5*n_cores
     redis_host : str, default "localhost"
         Hostname for redis server.
     redis_port : int, default 6379
@@ -142,14 +139,6 @@ def connect(
         else db_connection_pool_overflow
     )
 
-    thread_pool_size = (
-        getsecret("THREAD_POOL_SIZE", os.getenv("THREAD_POOL_SIZE", None))
-        if thread_pool_size is None
-        else thread_pool_size
-    )
-    if thread_pool_size is not None:
-        thread_pool_size = int(thread_pool_size)
-
     redis_host = (
         getsecret("REDIS_HOST", os.getenv("REDIS_HOST", "localhost"))
         if redis_host is None
@@ -186,7 +175,7 @@ def connect(
         Query.redis = redis.StrictRedis(
             host=redis_host, port=redis_port, password=redis_pw
         )
-        _start_threadpool(thread_pool_size)
+        _start_threadpool(db_connection_pool_size)
 
         print(f"FlowMachine version: {flowmachine.__version__}")
 

--- a/flowmachine/tests/test_init.py
+++ b/flowmachine/tests/test_init.py
@@ -65,7 +65,6 @@ def test_param_priority(mocked_connections, monkeypatch):
     monkeypatch.setenv("DB_PW", "DUMMY_ENV_DB_PW")
     monkeypatch.setenv("DB_HOST", "DUMMY_ENV_DB_HOST")
     monkeypatch.setenv("DB_NAME", "DUMMY_ENV_DB_NAME")
-    monkeypatch.setenv("THREAD_POOL_SIZE", 99)
     monkeypatch.setenv("DB_CONNECTION_POOL_SIZE", 7777)
     monkeypatch.setenv("DB_CONNECTION_POOL_OVERFLOW", 7777)
     monkeypatch.setenv("REDIS_HOST", "DUMMY_ENV_REDIS_HOST")
@@ -87,7 +86,6 @@ def test_param_priority(mocked_connections, monkeypatch):
         redis_host="dummy_redis_host",
         redis_port=1213,
         redis_password="dummy_redis_password",
-        thread_pool_size=10,
     )
     core_init_logging_mock.assert_called_with("dummy_log_level", "dummy_log_file")
     core_init_Connection_mock.assert_called_with(
@@ -102,7 +100,9 @@ def test_param_priority(mocked_connections, monkeypatch):
     core_init_StrictRedis_mock.assert_called_with(
         host="dummy_redis_host", port=1213, password="dummy_redis_password"
     )
-    core_init_start_threadpool_mock.assert_called_with(10)
+    core_init_start_threadpool_mock.assert_called_with(
+        6789
+    )  # for the time being, we should have num_threads = num_db_connections
 
 
 def test_env_priority(mocked_connections, monkeypatch):
@@ -117,7 +117,6 @@ def test_env_priority(mocked_connections, monkeypatch):
     monkeypatch.setenv("DB_NAME", "DUMMY_ENV_DB_NAME")
     monkeypatch.setenv("DB_CONNECTION_POOL_SIZE", 7777)
     monkeypatch.setenv("DB_CONNECTION_POOL_OVERFLOW", 2020)
-    monkeypatch.setenv("THREAD_POOL_SIZE", 99)
     monkeypatch.setenv("REDIS_HOST", "DUMMY_ENV_REDIS_HOST")
     monkeypatch.setenv("REDIS_PORT", 5050)
     monkeypatch.setenv("REDIS_PASSWORD", "DUMMY_ENV_REDIS_PASSWORD")
@@ -140,7 +139,9 @@ def test_env_priority(mocked_connections, monkeypatch):
     core_init_StrictRedis_mock.assert_called_with(
         host="DUMMY_ENV_REDIS_HOST", port=5050, password="DUMMY_ENV_REDIS_PASSWORD"
     )
-    core_init_start_threadpool_mock.assert_called_with(99)
+    core_init_start_threadpool_mock.assert_called_with(
+        7777
+    )  # for the time being, we should have num_threads = num_db_connections
 
 
 @pytest.mark.usefixtures("clean_env")
@@ -157,4 +158,6 @@ def test_connect_defaults(mocked_connections, monkeypatch):
     core_init_StrictRedis_mock.assert_called_with(
         host="localhost", port=6379, password="fm_redis"
     )
-    core_init_start_threadpool_mock.assert_called_with(None)
+    core_init_start_threadpool_mock.assert_called_with(
+        5
+    )  # for the time being, we should have num_threads = num_db_connections

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -8,14 +8,13 @@ The integration test suite uses docker-compose, and pytest to respectively creat
 
 To run the tests, you should first run `docker-compose up`, in this directory. This will pull all necessary docker images, and start the containers. The API will start on port 9090 of localhost.
 
-We recommend using [Pipenv](https://docs.pipenv.org) to run the tests, and a Pipfile and Pipfile.lock are included in this directory. With Pipenv you can simply do:
+We recommend using [Pipenv](https://docs.pipenv.org) to run the tests, and a Pipfile and Pipfile.lock are included in this directory.
+With Pipenv you can run the test suite as follows.
 
 ```bash
 pipenv install
 pipenv run pytest
 ```
-
-to run the test suite.
 
 If you are using an alternative environment manager, you should install the small number of packages listed in the Pipfile before running pytest.
 


### PR DESCRIPTION
Closes #299 

### I have:

- [X] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [X] Added tests for any new additions
- [X] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [X] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This reverts (most of) the changes in #282. I have left the helper function `_start_threadpool()` in place (in `flowmachine/core/init.py`) but it is now called with the value of `db_connection_pool_size` instead of `thread_pool_size` (which has been removed again).


I have also kept the tests in `flowmachine/tests/test_init.py` but have tweaked them to verify that `_start_threadpool()` is indeed called with the number of db connections.