### PR TITLE
Fix pytest hook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
             docker images -a
       - run:
           name: Run tests
-          command: cd flowdb && pipenv run pytest --junit-xml=test_results/pytest/results.xml --ignore=tests/test_synthetic_data.py
+          command: cd flowdb && pipenv run pytest --pspec --junit-xml=test_results/pytest/results.xml --ignore=tests/test_synthetic_data.py
       - store_test_results:
           path: flowdb/test_results
       - run:
@@ -273,6 +273,7 @@ jobs:
           name: Run tests
           command: |
             pipenv run pytest \
+                      --pspec \
                       --junit-xml=test_results/pytest/results.xml \
                       --cov flowmachine/ \
                       --cov-report xml \
@@ -298,7 +299,7 @@ jobs:
       - run: *wait_for_flowdb
       - run:
           name: Run tests
-          command: pipenv run pytest --junit-xml=test_results/pytest/results.xml tests/test_synthetic_data.py
+          command: pipenv run pytest --pspec --junit-xml=test_results/pytest/results.xml tests/test_synthetic_data.py
       - store_test_results:
           path: test_results
 
@@ -313,7 +314,7 @@ jobs:
       - run:
           name: Run API unit tests
           command: |
-            pipenv run python -m pytest --junitxml=test_results/pytest/results.xml --cov=app/ \
+            pipenv run python -m pytest --pspec --junitxml=test_results/pytest/results.xml --cov=app/ \
              --cov-report term --cov-report xml --durations=10
       - store_test_results:
           path: test_results
@@ -330,7 +331,7 @@ jobs:
       - run:
           name: Run backend unit tests
           command: |
-            pipenv run pytest --junitxml=test_results/pytest/results.xml --cov=backend/flowauth/ \
+            pipenv run pytest --pspec --junitxml=test_results/pytest/results.xml --cov=backend/flowauth/ \
              --cov-report term --cov-report xml --durations=10
       - store_test_results:
           path: test_results
@@ -383,7 +384,7 @@ jobs:
       - run:
           name: Run API client unit tests
           command: |
-            pipenv run pytest --junitxml=test_results/pytest/results.xml --cov=flowclient/ \
+            pipenv run pytest --pspec --junitxml=test_results/pytest/results.xml --cov=flowclient/ \
             --cov-report term --cov-report xml --durations=10
       - store_test_results:
           path: test_results
@@ -514,7 +515,7 @@ jobs:
       - run:
           name: Run integration tests
           command: |
-            docker exec testrunner bash -c "cd /tests && FLOWDB_HOST=flowdb FLOWDB_PORT=5432 FLOWMACHINE_ZMQ_HOST=flowmachine REDIS_HOST=redis pipenv run pytest -sv --junitxml=test_results/pytest/results.xml --durations=10"
+            docker exec testrunner bash -c "cd /tests && FLOWDB_HOST=flowdb FLOWDB_PORT=5432 FLOWMACHINE_ZMQ_HOST=flowmachine REDIS_HOST=redis pipenv run pytest --pspec -sv --junitxml=test_results/pytest/results.xml --durations=10"
       - run:
           name: Extract test results
           command: docker cp testrunner:/tests/test_results .

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 before_install:
   - cd flowclient
 install:
-  - pip install .
+  - pip install .[test]
 # command to run tests
 script:
   - pytest

--- a/flowapi/Pipfile
+++ b/flowapi/Pipfile
@@ -18,6 +18,7 @@ pytest-asyncio = "*"
 "pytest-cov" = "*"
 asynctest = "*"
 black = "==18.9b0"
+pytest-pspec = "*"
 
 [requires]
 python_version = "3.7"

--- a/flowapi/Pipfile.lock
+++ b/flowapi/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dc73858d9842adeb996692c04d672e27239b8e3fcd880776632a278d0e0e1cbb"
+            "sha256": "9420aea133962d49f121eca5400adcd02798d9a11a294468ab5c05d26ded082f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -419,6 +419,14 @@
             ],
             "index": "pypi",
             "version": "==2.6.1"
+        },
+        "pytest-pspec": {
+            "hashes": [
+                "sha256:14274721d4b1ac500a7d133c7a84af26b921dbe942dbf175512ae16225647968",
+                "sha256:6302a692fe3ebd5ee6aea6e458f2455ba8768b57d4571118a28d8d5bbdbb57d0"
+            ],
+            "index": "pypi",
+            "version": "==0.0.3"
         },
         "six": {
             "hashes": [

--- a/flowauth/Pipfile
+++ b/flowauth/Pipfile
@@ -21,6 +21,7 @@ cryptography = "*"
 pytest = "*"
 pytest-cov = "*"
 "flowauth" = {editable = true, path = "./backend"}
+pytest-pspec = "*"
 
 [requires]
 python_version = "3.7"
@@ -33,5 +34,3 @@ start-frontend = "bash -c 'cd frontend && npm start'"
 test-frontend-with-record = "bash start.sh test --record"
 test-frontend = "bash start.sh test"
 test-backend = "pytest"
-
-

--- a/flowauth/Pipfile.lock
+++ b/flowauth/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "17584595e2e97a5f9167ccb829dfc7a01372b452b62ce8b07a66323473e88939"
+            "sha256": "9502661b32cc49fe2a7a0037cb9018e03dbe2aa3ca39f11dd546b11580f967c1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -625,6 +625,14 @@
             ],
             "index": "pypi",
             "version": "==2.6.1"
+        },
+        "pytest-pspec": {
+            "hashes": [
+                "sha256:14274721d4b1ac500a7d133c7a84af26b921dbe942dbf175512ae16225647968",
+                "sha256:6302a692fe3ebd5ee6aea6e458f2455ba8768b57d4571118a28d8d5bbdbb57d0"
+            ],
+            "index": "pypi",
+            "version": "==0.0.3"
         },
         "six": {
             "hashes": [

--- a/flowauth/backend/setup.cfg
+++ b/flowauth/backend/setup.cfg
@@ -15,3 +15,4 @@ parentdir_prefix =
 
 [tool:pytest]
 python_files = tests/*/test_*.py tests/test_*.py
+addopts = --pspec

--- a/flowauth/backend/setup.py
+++ b/flowauth/backend/setup.py
@@ -37,5 +37,5 @@ setup(
         "zxcvbn",
         "cryptography",
     ],
-    extras_require={"test": ["pytest", "coverage"], "postgres": ["psycopg2-binary"]},
+    extras_require={"test": ["pytest", "pytest-pspec", "coverage"], "postgres": ["psycopg2-binary"]},
 )

--- a/flowclient/Pipfile
+++ b/flowclient/Pipfile
@@ -14,6 +14,7 @@ pytest = "*"
 versioneer = "*"
 black = "==18.9b0"
 ipython = "*"
+pytest-pspec = "*"
 
 [requires]
 python_version = "3.7"

--- a/flowclient/Pipfile.lock
+++ b/flowclient/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6930f88b5eba82b4316e6f687803c45bcfc4d51f38da33e9ef145c4e92fa41a0"
+            "sha256": "803661054ecdac083e2bd4df06ec316782951e5f842ef1889a2a8079ba2a7e42"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -143,6 +143,14 @@
                 "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
             ],
             "version": "==1.4.3"
+        },
+        "appnope": {
+            "hashes": [
+                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
+                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.0"
         },
         "atomicwrites": {
             "hashes": [
@@ -326,6 +334,14 @@
             ],
             "index": "pypi",
             "version": "==2.6.1"
+        },
+        "pytest-pspec": {
+            "hashes": [
+                "sha256:14274721d4b1ac500a7d133c7a84af26b921dbe942dbf175512ae16225647968",
+                "sha256:6302a692fe3ebd5ee6aea6e458f2455ba8768b57d4571118a28d8d5bbdbb57d0"
+            ],
+            "index": "pypi",
+            "version": "==0.0.3"
         },
         "six": {
             "hashes": [

--- a/flowclient/setup.cfg
+++ b/flowclient/setup.cfg
@@ -8,3 +8,6 @@ parentdir_prefix =
 
 [aliases]
 test=pytest
+
+[tool:pytest]
+addopts = --pspec

--- a/flowclient/setup.py
+++ b/flowclient/setup.py
@@ -23,7 +23,7 @@ __email__ = "flowkit@flowminder.org"
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-test_requirements = ["pytest", "pytest-cov"]
+test_requirements = ["pytest", "pytest-cov", "pytest-pspec"]
 
 setup(
     name="flowclient",

--- a/flowdb/Pipfile
+++ b/flowdb/Pipfile
@@ -16,6 +16,7 @@ tohu = {file = "https://github.com/maxalbert/tohu/archive/v0.5.1.tar.gz"}
 "psycopg2-binary" = "*"
 descartes = "*"
 black = "==18.9b0"
+pytest-pspec = "*"
 
 [requires]
 python_version = "3.7"

--- a/flowdb/Pipfile.lock
+++ b/flowdb/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "befeb7c2a80920a039ca3e12d89d5613000106227fb3c590e5caa3682acaa0de"
+            "sha256": "ee567ebe19ce995c58a0f8e975e5c2e4a885241a64e29873648b9ab93c2c4fb2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -280,11 +280,19 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:41568ea7ecb4a68d7f63837cf65b92ce8d0105e43196ff2b26622995bb3dc4b2",
-                "sha256:c3c573a29d7c9547fb90217ece8a8843aa0c1328a797e200290dc3d0b4b823be"
+                "sha256:65aeaa77ae87c7fc95de56285282546cfa9c886dc8e5dc78313db1c25e21bc07",
+                "sha256:6ac6d467d9f053e95aaacd79f831dbecfe730f419c6c7022cb316b365cd9199d"
             ],
             "index": "pypi",
-            "version": "==4.1.1"
+            "version": "==4.2.0"
+        },
+        "pytest-pspec": {
+            "hashes": [
+                "sha256:14274721d4b1ac500a7d133c7a84af26b921dbe942dbf175512ae16225647968",
+                "sha256:6302a692fe3ebd5ee6aea6e458f2455ba8768b57d4571118a28d8d5bbdbb57d0"
+            ],
+            "index": "pypi",
+            "version": "==0.0.3"
         },
         "python-dateutil": {
             "hashes": [

--- a/flowdb/tests/conftest.py
+++ b/flowdb/tests/conftest.py
@@ -26,15 +26,6 @@ def pytest_configure(config):
     )
 
 
-def pytest_itemcollected(item):
-    # improve stdout logging from pytest's default which just prints the
-    # filename and no description of the test.
-    if item._obj.__doc__:
-        item._nodeid = "* " + " ".join(item.obj.__doc__.split())
-        if item._genid:
-            item._nodeid = item._nodeid.rstrip(".") + f" [{item._genid}]."
-
-
 class DBConn:
     """Manages a single database connection, creating and disposing of it.
 

--- a/flowmachine/Pipfile
+++ b/flowmachine/Pipfile
@@ -35,6 +35,7 @@ pytest-testmon = "*"
 asynctest = "*"
 flowmachine = {editable = true,path = "."}
 cachey = "*"
+pytest-pspec = "*"
 
 [requires]
 python_version = "3.7"

--- a/flowmachine/Pipfile.lock
+++ b/flowmachine/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ade862acae48894331ceaa243621f02582d0f815e3a015821482b5dc37524df4"
+            "sha256": "0a62a46979018736a18fa498e6245570022cbf97c1b8c087cc2de2e526e91f62"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -316,11 +316,11 @@
         },
         "cachetools": {
             "hashes": [
-                "sha256:0a258d82933a1dd18cb540aca4ac5d5690731e24d1239a08577b814998f49785",
-                "sha256:4621965b0d9d4c82a79a29edbad19946f5e7702df4afae7d1ed2df951559a8cc"
+                "sha256:219b7dc6024195b6f2bc3d3f884d1fef458745cd323b04165378622dcc823852",
+                "sha256:9efcc9fab3b49ab833475702b55edd5ae07af1af7a4c627678980b45e459c460"
             ],
             "index": "pypi",
-            "version": "==3.0.0"
+            "version": "==3.1.0"
         },
         "cachey": {
             "hashes": [
@@ -712,39 +712,39 @@
         },
         "psycopg2-binary": {
             "hashes": [
-                "sha256:036bcb198a7cc4ce0fe43344f8c2c9a8155aefa411633f426c8c6ed58a6c0426",
-                "sha256:1d770fcc02cdf628aebac7404d56b28a7e9ebec8cfc0e63260bd54d6edfa16d4",
-                "sha256:1fdc6f369dcf229de6c873522d54336af598b9470ccd5300e2f58ee506f5ca13",
-                "sha256:21f9ddc0ff6e07f7d7b6b484eb9da2c03bc9931dd13e36796b111d631f7135a3",
-                "sha256:247873cda726f7956f745a3e03158b00de79c4abea8776dc2f611d5ba368d72d",
-                "sha256:3aa31c42f29f1da6f4fd41433ad15052d5ff045f2214002e027a321f79d64e2c",
-                "sha256:475f694f87dbc619010b26de7d0fc575a4accf503f2200885cc21f526bffe2ad",
-                "sha256:4b5e332a24bf6e2fda1f51ca2a57ae1083352293a08eeea1fa1112dc7dd542d1",
-                "sha256:570d521660574aca40be7b4d532dfb6f156aad7b16b5ed62d1534f64f1ef72d8",
-                "sha256:59072de7def0690dd13112d2bdb453e20570a97297070f876fbbb7cbc1c26b05",
-                "sha256:5f0b658989e918ef187f8a08db0420528126f2c7da182a7b9f8bf7f85144d4e4",
-                "sha256:649199c84a966917d86cdc2046e03d536763576c0b2a756059ae0b3a9656bc20",
-                "sha256:6645fc9b4705ae8fbf1ef7674f416f89ae1559deec810f6dd15197dfa52893da",
-                "sha256:6872dd54d4e398d781efe8fe2e2d7eafe4450d61b5c4898aced7610109a6df75",
-                "sha256:6ce34fbc251fc0d691c8d131250ba6f42fd2b28ef28558d528ba8c558cb28804",
-                "sha256:73920d167a0a4d1006f5f3b9a3efce6f0e5e883a99599d38206d43f27697df00",
-                "sha256:8a671732b87ae423e34b51139628123bc0306c2cb85c226e71b28d3d57d7e42a",
-                "sha256:8d517e8fda2efebca27c2018e14c90ed7dc3f04d7098b3da2912e62a1a5585fe",
-                "sha256:9475a008eb7279e20d400c76471843c321b46acacc7ee3de0b47233a1e3fa2cf",
-                "sha256:96947b8cd7b3148fb0e6549fcb31258a736595d6f2a599f8cd450e9a80a14781",
-                "sha256:abf229f24daa93f67ac53e2e17c8798a71a01711eb9fcdd029abba8637164338",
-                "sha256:b1ab012f276df584beb74f81acb63905762c25803ece647016613c3d6ad4e432",
-                "sha256:b22b33f6f0071fe57cb4e9158f353c88d41e739a3ec0d76f7b704539e7076427",
-                "sha256:b3b2d53274858e50ad2ffdd6d97ce1d014e1e530f82ec8b307edd5d4c921badf",
-                "sha256:bab26a729befc7b9fab9ded1bba9c51b785188b79f8a2796ba03e7e734269e2e",
-                "sha256:daa1a593629aa49f506eddc9d23dc7f89b35693b90e1fbcd4480182d1203ea90",
-                "sha256:dd111280ce40e89fd17b19c1269fd1b74a30fce9d44a550840e86edb33924eb8",
-                "sha256:e0b86084f1e2e78c451994410de756deba206884d6bed68d5a3d7f39ff5fea1d",
-                "sha256:eb86520753560a7e89639500e2a254bb6f683342af598088cb72c73edcad21e6",
-                "sha256:ff18c5c40a38d41811c23e2480615425c97ea81fd7e9118b8b899c512d97c737"
+                "sha256:19a2d1f3567b30f6c2bb3baea23f74f69d51f0c06c2e2082d0d9c28b0733a4c2",
+                "sha256:2b69cf4b0fa2716fd977aa4e1fd39af6110eb47b2bb30b4e5a469d8fbecfc102",
+                "sha256:2e952fa17ba48cbc2dc063ddeec37d7dc4ea0ef7db0ac1eda8906365a8543f31",
+                "sha256:348b49dd737ff74cfb5e663e18cb069b44c64f77ec0523b5794efafbfa7df0b8",
+                "sha256:3d72a5fdc5f00ca85160915eb9a973cf9a0ab8148f6eda40708bf672c55ac1d1",
+                "sha256:4957452f7868f43f32c090dadb4188e9c74a4687323c87a882e943c2bd4780c3",
+                "sha256:5138cec2ee1e53a671e11cc519505eb08aaaaf390c508f25b09605763d48de4b",
+                "sha256:587098ca4fc46c95736459d171102336af12f0d415b3b865972a79c03f06259f",
+                "sha256:5b79368bcdb1da4a05f931b62760bea0955ee2c81531d8e84625df2defd3f709",
+                "sha256:5cf43807392247d9bc99737160da32d3fa619e0bfd85ba24d1c78db205f472a4",
+                "sha256:676d1a80b1eebc0cacae8dd09b2fde24213173bf65650d22b038c5ed4039f392",
+                "sha256:6b0211ecda389101a7d1d3df2eba0cf7ffbdd2480ca6f1d2257c7bd739e84110",
+                "sha256:79cde4660de6f0bb523c229763bd8ad9a93ac6760b72c369cf1213955c430934",
+                "sha256:7aba9786ac32c2a6d5fb446002ed936b47d5e1f10c466ef7e48f66eb9f9ebe3b",
+                "sha256:7c8159352244e11bdd422226aa17651110b600d175220c451a9acf795e7414e0",
+                "sha256:945f2eedf4fc6b2432697eb90bb98cc467de5147869e57405bfc31fa0b824741",
+                "sha256:96b4e902cde37a7fc6ab306b3ac089a3949e6ce3d824eeca5b19dc0bedb9f6e2",
+                "sha256:9a7bccb1212e63f309eb9fab47b6eaef796f59850f169a25695b248ca1bf681b",
+                "sha256:a3bfcac727538ec11af304b5eccadbac952d4cca1a551a29b8fe554e3ad535dc",
+                "sha256:b19e9f1b85c5d6136f5a0549abdc55dcbd63aba18b4f10d0d063eb65ef2c68b4",
+                "sha256:b664011bb14ca1f2287c17185e222f2098f7b4c857961dbcf9badb28786dbbf4",
+                "sha256:bde7959ef012b628868d69c474ec4920252656d0800835ed999ba5e4f57e3e2e",
+                "sha256:cb095a0657d792c8de9f7c9a0452385a309dfb1bbbb3357d6b1e216353ade6ca",
+                "sha256:d16d42a1b9772152c1fe606f679b2316551f7e1a1ce273e7f808e82a136cdb3d",
+                "sha256:d444b1545430ffc1e7a24ce5a9be122ccd3b135a7b7e695c5862c5aff0b11159",
+                "sha256:d93ccc7bf409ec0a23f2ac70977507e0b8a8d8c54e5ee46109af2f0ec9e411f3",
+                "sha256:df6444f952ca849016902662e1a47abf4fa0678d75f92fd9dd27f20525f809cd",
+                "sha256:e63850d8c52ba2b502662bf3c02603175c2397a9acc756090e444ce49508d41e",
+                "sha256:ec43358c105794bc2b6fd34c68d27f92bea7102393c01889e93f4b6a70975728",
+                "sha256:f4c6926d9c03dadce7a3b378b40d2fea912c1344ef9b29869f984fb3d2a2420b"
             ],
             "index": "pypi",
-            "version": "==2.7.6.1"
+            "version": "==2.7.7"
         },
         "ptyprocess": {
             "hashes": [
@@ -792,11 +792,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:41568ea7ecb4a68d7f63837cf65b92ce8d0105e43196ff2b26622995bb3dc4b2",
-                "sha256:c3c573a29d7c9547fb90217ece8a8843aa0c1328a797e200290dc3d0b4b823be"
+                "sha256:65aeaa77ae87c7fc95de56285282546cfa9c886dc8e5dc78313db1c25e21bc07",
+                "sha256:6ac6d467d9f053e95aaacd79f831dbecfe730f419c6c7022cb316b365cd9199d"
             ],
             "index": "pypi",
-            "version": "==4.1.1"
+            "version": "==4.2.0"
         },
         "pytest-asyncio": {
             "hashes": [
@@ -813,6 +813,14 @@
             ],
             "index": "pypi",
             "version": "==2.6.1"
+        },
+        "pytest-pspec": {
+            "hashes": [
+                "sha256:14274721d4b1ac500a7d133c7a84af26b921dbe942dbf175512ae16225647968",
+                "sha256:6302a692fe3ebd5ee6aea6e458f2455ba8768b57d4571118a28d8d5bbdbb57d0"
+            ],
+            "index": "pypi",
+            "version": "==0.0.3"
         },
         "pytest-testmon": {
             "hashes": [
@@ -901,10 +909,10 @@
         },
         "redis": {
             "hashes": [
-                "sha256:2100750629beff143b6a200a2ea8e719fcf26420adabb81402895e144c5083cf",
-                "sha256:8e0bdd2de02e829b6225b25646f9fb9daffea99a252610d040409a6738541f0a"
+                "sha256:74c892041cba46078ae1ef845241548baa3bd3634f9a6f0f952f006eb1619c71",
+                "sha256:7ba8612bbfd966dea8c62322543fed0095da2834dbd5a7c124afbc617a156aa7"
             ],
-            "version": "==3.0.1"
+            "version": "==3.1.0"
         },
         "scipy": {
             "hashes": [
@@ -967,10 +975,10 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:6af3ca2f7f00844465ab4fa78337d487b39e53f516c51328aed4ed3a719d4264"
+                "sha256:52a42dbf02d0562d6e90e7af59f177f1cc027e72833cc29c3a821eefa009c71d"
             ],
             "index": "pypi",
-            "version": "==1.2.16"
+            "version": "==1.2.17"
         },
         "toml": {
             "hashes": [

--- a/flowmachine/setup.cfg
+++ b/flowmachine/setup.cfg
@@ -11,3 +11,4 @@ parentdir_prefix =
 
 [tool:pytest]
 python_files = tests/*/test_*.py tests/test_*.py
+addopts = --pspec

--- a/flowmachine/setup.py
+++ b/flowmachine/setup.py
@@ -51,7 +51,7 @@ readme = read("README.md")
 
 # Test requirements
 
-test_requirements = ["pytest", "pytest-cov", "pytest-asyncio", "asynctest"]
+test_requirements = ["pytest", "pytest-cov", "pytest-pspec", "pytest-asyncio", "asynctest"]
 
 setup(
     name="flowmachine",

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -54,15 +54,6 @@ def exemplar_level_param(request):
     yield request.param
 
 
-def pytest_itemcollected(item):
-    # improve stdout logging from pytest's default which just prints the
-    # filename and no description of the test.
-    if item._obj.__doc__:
-        item._nodeid = "* " + " ".join(item.obj.__doc__.split())
-        if item._genid:
-            item._nodeid = item._nodeid.rstrip(".") + f" [{item._genid}]."
-
-
 @pytest.fixture(autouse=True)
 def skip_datecheck(request, monkeypatch):
     """

--- a/flowmachine/tests/test_init.py
+++ b/flowmachine/tests/test_init.py
@@ -60,15 +60,15 @@ def test_param_priority(mocked_connections, monkeypatch):
     # Use monkeypatch to set environment variable only for this test
     monkeypatch.setenv("LOG_LEVEL", "DUMMY_ENV_LOG_LEVEL")
     monkeypatch.setenv("LOG_FILE", "DUMMY_ENV_LOG_FILE")
-    monkeypatch.setenv("DB_PORT", 7777)
+    monkeypatch.setenv("DB_PORT", "7777")
     monkeypatch.setenv("DB_USER", "DUMMY_ENV_DB_USER")
     monkeypatch.setenv("DB_PW", "DUMMY_ENV_DB_PW")
     monkeypatch.setenv("DB_HOST", "DUMMY_ENV_DB_HOST")
     monkeypatch.setenv("DB_NAME", "DUMMY_ENV_DB_NAME")
-    monkeypatch.setenv("DB_CONNECTION_POOL_SIZE", 7777)
-    monkeypatch.setenv("DB_CONNECTION_POOL_OVERFLOW", 7777)
+    monkeypatch.setenv("DB_CONNECTION_POOL_SIZE", "7777")
+    monkeypatch.setenv("DB_CONNECTION_POOL_OVERFLOW", "7777")
     monkeypatch.setenv("REDIS_HOST", "DUMMY_ENV_REDIS_HOST")
-    monkeypatch.setenv("REDIS_PORT", 7777)
+    monkeypatch.setenv("REDIS_PORT", "7777")
     monkeypatch.setenv("REDIS_PASSWORD", "DUMMY_ENV_REDIS_PASSWORD")
     core_init_logging_mock, core_init_Connection_mock, core_init_StrictRedis_mock, core_init_start_threadpool_mock = (
         mocked_connections
@@ -110,15 +110,15 @@ def test_env_priority(mocked_connections, monkeypatch):
     # Use monkeypatch to set environment variable only for this test
     monkeypatch.setenv("LOG_LEVEL", "DUMMY_ENV_LOG_LEVEL")
     monkeypatch.setenv("LOG_FILE", "DUMMY_ENV_LOG_FILE")
-    monkeypatch.setenv("DB_PORT", 6969)
+    monkeypatch.setenv("DB_PORT", "6969")
     monkeypatch.setenv("DB_USER", "DUMMY_ENV_DB_USER")
     monkeypatch.setenv("DB_PW", "DUMMY_ENV_DB_PW")
     monkeypatch.setenv("DB_HOST", "DUMMY_ENV_DB_HOST")
     monkeypatch.setenv("DB_NAME", "DUMMY_ENV_DB_NAME")
-    monkeypatch.setenv("DB_CONNECTION_POOL_SIZE", 7777)
-    monkeypatch.setenv("DB_CONNECTION_POOL_OVERFLOW", 2020)
+    monkeypatch.setenv("DB_CONNECTION_POOL_SIZE", "7777")
+    monkeypatch.setenv("DB_CONNECTION_POOL_OVERFLOW", "2020")
     monkeypatch.setenv("REDIS_HOST", "DUMMY_ENV_REDIS_HOST")
-    monkeypatch.setenv("REDIS_PORT", 5050)
+    monkeypatch.setenv("REDIS_PORT", "5050")
     monkeypatch.setenv("REDIS_PASSWORD", "DUMMY_ENV_REDIS_PASSWORD")
     core_init_logging_mock, core_init_Connection_mock, core_init_StrictRedis_mock, core_init_start_threadpool_mock = (
         mocked_connections

--- a/integration_tests/Pipfile
+++ b/integration_tests/Pipfile
@@ -19,3 +19,4 @@ flowclient = {editable = true,path = "./../flowclient"}
 python_version = "3.7"
 
 [dev-packages]
+pytest-pspec = "*"

--- a/integration_tests/Pipfile.lock
+++ b/integration_tests/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "97cb68766a278b26fec09d06e7c77ac6a53aa61ca95cb4d7d26fd505e94c0a13"
+            "sha256": "53129a3c0ad952b91a2a188aabf77d2b3c5c45fafc615e22ed778d71d0fd6478"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -363,11 +363,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:41568ea7ecb4a68d7f63837cf65b92ce8d0105e43196ff2b26622995bb3dc4b2",
-                "sha256:c3c573a29d7c9547fb90217ece8a8843aa0c1328a797e200290dc3d0b4b823be"
+                "sha256:65aeaa77ae87c7fc95de56285282546cfa9c886dc8e5dc78313db1c25e21bc07",
+                "sha256:6ac6d467d9f053e95aaacd79f831dbecfe730f419c6c7022cb316b365cd9199d"
             ],
             "index": "pypi",
-            "version": "==4.1.1"
+            "version": "==4.2.0"
         },
         "pytest-asyncio": {
             "hashes": [
@@ -552,5 +552,65 @@
             "version": "==0.13.0"
         }
     },
-    "develop": {}
+    "develop": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
+                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
+            ],
+            "version": "==1.2.1"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+            ],
+            "version": "==18.2.0"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
+                "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
+                "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
+            ],
+            "version": "==5.0.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:8ddc32f03971bfdf900a81961a48ccf2fb677cf7715108f85295c67405798616",
+                "sha256:980710797ff6a041e9a73a5787804f848996ecaa6f8a1b1e08224a5894f2074a"
+            ],
+            "version": "==0.8.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
+                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
+            ],
+            "version": "==1.7.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:65aeaa77ae87c7fc95de56285282546cfa9c886dc8e5dc78313db1c25e21bc07",
+                "sha256:6ac6d467d9f053e95aaacd79f831dbecfe730f419c6c7022cb316b365cd9199d"
+            ],
+            "index": "pypi",
+            "version": "==4.2.0"
+        },
+        "pytest-pspec": {
+            "hashes": [
+                "sha256:14274721d4b1ac500a7d133c7a84af26b921dbe942dbf175512ae16225647968",
+                "sha256:6302a692fe3ebd5ee6aea6e458f2455ba8768b57d4571118a28d8d5bbdbb57d0"
+            ],
+            "index": "pypi",
+            "version": "==0.0.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        }
+    }
 }


### PR DESCRIPTION
Closes #317 

### I have:

- [X] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This PR removes the custom hook `pytest_itemcollected` in the flowmachine and flowdb tests, which was used to obtain nicer formatting of test results. Instead, it uses the [pytest-pspec](https://github.com/gowtham-sai/pytest-pspec) plugin so that the test logging output uses the test docstrings to display results.

Changes:
- Install `pytest-pspec` in the relevant Pipfiles in the repo
- Add `--pspec` as default option in any `setup.cfg` files
- Add `--pspec` to pytest calls in `.circleci/config.yml`

Unrelatedly, I also changed the monkeypatched env vars in `flowmachine/tests/test_init.py` to be strings (rather than integers) to avoid pytest warnings.