### PR TITLE
Add alias "flowdb" for all flowdb services

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -56,7 +56,9 @@ services:
     stdin_open: true
     restart: always
     networks:
-      - db
+      db:
+        aliases:
+          - flowdb
 
   flowdb_synthetic_data:
     container_name: flowdb_synthetic_data
@@ -81,8 +83,9 @@ services:
     tty: true
     stdin_open: true
     restart: always
-    networks:
-      - db
+      db:
+        aliases:
+          - flowdb
 
   flowmachine:
     container_name: flowmachine

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -85,6 +85,7 @@ services:
     tty: true
     stdin_open: true
     restart: always
+    networks:
       db:
         aliases:
           - flowdb

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -33,7 +33,9 @@ services:
     stdin_open: true
     restart: always
     networks:
-      - db
+      db:
+        aliases:
+          - flowdb
 
   flowdb_testdata:
     container_name: flowdb_testdata

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,76 +9,78 @@ networks:
   redis:
   zero:
   api:
+
 services:
-    flowdb-testdata:
-        container_name: flowdb_testdata
-        image: flowminder/flowdb:testdata-latest
-        environment:
-            - POSTGRES_DB=${POSTGRES_DB:-flowdb}
-            - POSTGRES_USER=${POSTGRES_USER:-flowdb}
-            - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-flowflow}
-            - FM_PASSWORD=${FM_PASSWORD:-foo}
-            - API_PASSWORD=${API_PASSWORD:-foo}
-        tty: true
-        stdin_open: true
-        restart: always
-        shm_size: 1G
-        volumes:
-            - data_volume_flowdb:/var/lib/postgresql/data
-        networks:
-            db:
-                aliases:
-                    - flowdb
-    flowmachine:
-        container_name: flowmachine
-        image: flowminder/flowmachine:latest
-        restart: always
-        environment:
-            - DB_PORT=${DB_PORT:-5432}
-            - DB_HOST=${DB_HOST:-flowdb}
-            - LOG_LEVEL=${LOG_LEVEL:-error}
-            - DEBUG=${FM_DEBUG:-False}
-            - REDIS_HOST=${REDIS_HOST:-redis}
-            - REDIS_PASSWORD={REDIS_PASSWORD:-fm_redis}
-        tty: true
-        stdin_open: true
-        networks:
-            - db
-            - redis
-            - zero
-    flowapi:
-        container_name: flowapi
-        image: flowminder/flowapi:latest
-        restart: always
-        ports:
-          - 9090:9090
-        environment:
-            - SERVER=flowmachine
-            - LOG_LEVEL=${LOG_LEVEL:-error}
-            - DB_USER=reporter
-            - DB_PASS=${API_PASSWORD:-foo}
-            - DB_HOST=${DB_HOST:-flowdb}
-            - DB_PORT=${DB_PORT:-5432}
-            - JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY must be set}
-        volumes:
-            - data_volume_flowapi_logs:/var/logs/flowkit/
-        tty: true
-        stdin_open: true
-        networks:
-          - zero
-          - db
-          - api
-    redis:
-        container_name: redis_flowkit
-        image: bitnami/redis:latest
-        environment:
-            - REDIS_PASSWORD={REDIS_PASSWORD:-fm_redis}
-        restart: always
-        networks:
-            redis:
-                aliases:
-                    - redis
+  flowdb-testdata:
+    container_name: flowdb_testdata
+    image: flowminder/flowdb:testdata-latest
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB:-flowdb}
+      - POSTGRES_USER=${POSTGRES_USER:-flowdb}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-flowflow}
+      - FM_PASSWORD=${FM_PASSWORD:-foo}
+      - API_PASSWORD=${API_PASSWORD:-foo}
+    tty: true
+    stdin_open: true
+    restart: always
+    shm_size: 1G
+    volumes:
+      - data_volume_flowdb:/var/lib/postgresql/data
+    networks:
+      db:
+        aliases:
+          - flowdb
+  flowmachine:
+    container_name: flowmachine
+    image: flowminder/flowmachine:latest
+    restart: always
+    environment:
+      - DB_PORT=${DB_PORT:-5432}
+      - DB_HOST=${DB_HOST:-flowdb}
+      - LOG_LEVEL=${LOG_LEVEL:-error}
+      - DEBUG=${FM_DEBUG:-False}
+      - REDIS_HOST=${REDIS_HOST:-redis}
+      - REDIS_PASSWORD={REDIS_PASSWORD:-fm_redis}
+    tty: true
+    stdin_open: true
+    networks:
+      - db
+      - redis
+      - zero
+  flowapi:
+    container_name: flowapi
+    image: flowminder/flowapi:latest
+    restart: always
+    ports:
+      - 9090:9090
+    environment:
+      - SERVER=flowmachine
+      - LOG_LEVEL=${LOG_LEVEL:-error}
+      - DB_USER=reporter
+      - DB_PASS=${API_PASSWORD:-foo}
+      - DB_HOST=${DB_HOST:-flowdb}
+      - DB_PORT=${DB_PORT:-5432}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY must be set}
+    volumes:
+      - data_volume_flowapi_logs:/var/logs/flowkit/
+    tty: true
+    stdin_open: true
+    networks:
+      - zero
+      - db
+      - api
+  redis:
+    container_name: redis_flowkit
+    image: bitnami/redis:latest
+    environment:
+      - REDIS_PASSWORD={REDIS_PASSWORD:-fm_redis}
+    restart: always
+    networks:
+      redis:
+        aliases:
+          - redis
 
 volumes:
-    data_volume_flowdb:
-    data_volume_flowapi_logs:
+  data_volume_flowdb:
+  data_volume_flowapi_logs:
+


### PR DESCRIPTION
Closes #399 

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

- Adds the alias `flowdb` for the services `flowdb_testdata` and `flowdb_synthetic_data` in `docker-compose-dev.yml`
- Re-indent `docker-compose.yml` with 2 spaces instead of 4 (for consistency with the other docker-compose files).