### PR TITLE
column_names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Added
 
-Dockerised development setup, with support for live reload of `flowmachine` and `flowapi` after source code changes.
+- Dockerised development setup, with support for live reload of `flowmachine` and `flowapi` after source code changes.
 
 ### Changed
+- `CustomQuery` now requires column names to be specified
+- Query classes are now required to declare the column names they return via the `column_names` property
 
 ### Fixed
 

--- a/flowmachine/flowmachine/__init__.py
+++ b/flowmachine/flowmachine/__init__.py
@@ -26,13 +26,13 @@ __flowdb_version__ = "0.2.0"
 del get_versions
 
 from .core.init import connect
-from .features.utilities import GroupValues, FeatureCollection
+from .features.utilities import GroupValues, feature_collection
 import flowmachine.models
 import flowmachine.features
 import flowmachine.utils
 import flowmachine.core
 
-methods = ["GroupValues", "FeatureCollection", "connect"]
+methods = ["GroupValues", "feature_collection", "connect"]
 
 sub_modules = ["core", "features", "utils", "models"]
 

--- a/flowmachine/flowmachine/core/custom_query.py
+++ b/flowmachine/flowmachine/core/custom_query.py
@@ -55,5 +55,8 @@ class CustomQuery(Query):
 
     def __getstate__(self):
         state = super().__getstate__()
-        del state["_column_names"]
+        try:
+            del state["_column_names"]
+        except KeyError:
+            pass
         return state

--- a/flowmachine/flowmachine/core/custom_query.py
+++ b/flowmachine/flowmachine/core/custom_query.py
@@ -7,6 +7,8 @@
 Simple utility class that allows the user to define their
 own custom query via a python string.
 """
+from typing import List
+
 from .utils import pretty_sql
 from .query import Query
 
@@ -20,11 +22,13 @@ class CustomQuery(Query):
     ----------
     sql : str
         An sql query string
+    column_names : list of str
+        The column names to return
     
     Examples
     --------
 
-    >>> CQ = CustomQuery('SELECT * FROM events.calls')
+    >>> CQ = CustomQuery('SELECT * FROM events.calls', ["msisdn"])
     >>> CQ.head()
 
 
@@ -33,13 +37,18 @@ class CustomQuery(Query):
     .table.Table for an equivalent that deals with simple table access
     """
 
-    def __init__(self, sql):
+    def __init__(self, sql: str, column_names: List[str]):
         """
 
         """
 
         self.sql = pretty_sql(sql)
+        self._column_names = column_names
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return self._column_names
 
     def _make_query(self):
         return self.sql

--- a/flowmachine/flowmachine/core/custom_query.py
+++ b/flowmachine/flowmachine/core/custom_query.py
@@ -52,3 +52,8 @@ class CustomQuery(Query):
 
     def _make_query(self):
         return self.sql
+
+    def __getstate__(self):
+        state = super().__getstate__()
+        del state["_column_names"]
+        return state

--- a/flowmachine/flowmachine/core/join.py
+++ b/flowmachine/flowmachine/core/join.py
@@ -61,6 +61,13 @@ class Join(Query):
 
         self.left = left
         self.right = right
+        if left_append == right_append and not set(left.column_names).isdisjoint(
+            right.column_names
+        ):
+            raise ValueError(
+                f"Columns {set(left.column_names).intersection(right.column_names)} are ambiguous. Pass left_append or right_append to disambiguate."
+            )
+
         # Always store the join columns as a list, even if there is only one of them
         if type(on_left) is str:
             self.on_left = [on_left]

--- a/flowmachine/flowmachine/core/join_to_location.py
+++ b/flowmachine/flowmachine/core/join_to_location.py
@@ -109,7 +109,7 @@ class JoinToLocation(Query):
         # then we'll simply turn this string into a flowmachine.Query object
         # and proceed as normal.
         if type(left) is str:
-            self.left = CustomQuery(left)
+            self.left = CustomQuery(left, left.column_names)
         else:
             self.left = left
         self.time_col = time_col
@@ -162,7 +162,16 @@ class JoinToLocation(Query):
                         ST_X(geom_point::geometry) AS lon,
                         ST_Y(geom_point::geometry) AS lat
                    FROM {self.location_table_fqn}"""
-            return CustomQuery(sql)
+            return CustomQuery(
+                sql,
+                [
+                    "location_id",
+                    "date_of_first_service",
+                    "date_of_last_service",
+                    "lon",
+                    "lat",
+                ],
+            )
         elif self.level == "versioned-site":
             if self.location_table_fqn == "infrastructure.sites":
                 sql = """
@@ -191,7 +200,18 @@ class JoinToLocation(Query):
                     infrastructure.cells AS c
                     ON s.id = c.site_id
                     """
-            return CustomQuery(sql)
+            return CustomQuery(
+                sql,
+                [
+                    "location_id",
+                    "site_id",
+                    "date_of_first_service",
+                    "date_of_last_service",
+                    "version",
+                    "lon",
+                    "lat",
+                ],
+            )
         elif self.level == "versioned-cell":
             if self.location_table_fqn == "infrastructure.cells":
                 sql = """
@@ -204,7 +224,17 @@ class JoinToLocation(Query):
                         ST_Y(geom_point::geometry) AS lat
                     FROM infrastructure.cells
                     """
-                return CustomQuery(sql)
+                return CustomQuery(
+                    sql,
+                    [
+                        "location_id",
+                        "version",
+                        "date_of_first_service",
+                        "date_of_last_service",
+                        "lon",
+                        "lat",
+                    ],
+                )
             else:
                 raise ValueError("Versioned cell level is unavailable.")
 

--- a/flowmachine/flowmachine/core/mixins/geodata_mixin.py
+++ b/flowmachine/flowmachine/core/mixins/geodata_mixin.py
@@ -199,7 +199,7 @@ class GeoDataMixin:
 
     def to_geojson_file(self, filename, crs=None):
         """
-        Export this query to a GeoJson FeatureCollection file.
+        Export this query to a GeoJson feature_collection file.
         
         Parameters
         ----------
@@ -221,7 +221,7 @@ class GeoDataMixin:
         Returns
         -------
         str
-            A string containing the this query as a GeoJson FeatureCollection. 
+            A string containing the this query as a GeoJson feature_collection.
         """
         return json.dumps(self.to_geojson(crs=crs))
 
@@ -248,7 +248,7 @@ class GeoDataMixin:
         ]
         js = {
             "properties": {"crs": proj4},
-            "type": "FeatureCollection",
+            "type": "feature_collection",
             "features": features,
         }
         return js
@@ -263,7 +263,7 @@ class GeoDataMixin:
         Returns
         -------
         dict
-            This query as a GeoJson FeatureCollection in dict form. 
+            This query as a GeoJson feature_collection in dict form.
         """
         proj4_string = proj4string(self.connection, crs)
         try:

--- a/flowmachine/flowmachine/core/mixins/geodata_mixin.py
+++ b/flowmachine/flowmachine/core/mixins/geodata_mixin.py
@@ -199,7 +199,7 @@ class GeoDataMixin:
 
     def to_geojson_file(self, filename, crs=None):
         """
-        Export this query to a GeoJson feature_collection file.
+        Export this query to a GeoJson FeatureCollection file.
         
         Parameters
         ----------
@@ -221,7 +221,7 @@ class GeoDataMixin:
         Returns
         -------
         str
-            A string containing the this query as a GeoJson feature_collection.
+            A string containing the this query as a GeoJson FeatureCollection.
         """
         return json.dumps(self.to_geojson(crs=crs))
 
@@ -248,7 +248,7 @@ class GeoDataMixin:
         ]
         js = {
             "properties": {"crs": proj4},
-            "type": "feature_collection",
+            "type": "FeatureCollection",
             "features": features,
         }
         return js
@@ -263,7 +263,7 @@ class GeoDataMixin:
         Returns
         -------
         dict
-            This query as a GeoJson feature_collection in dict form.
+            This query as a GeoJson FeatureCollection in dict form.
         """
         proj4_string = proj4string(self.connection, crs)
         try:

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -449,7 +449,7 @@ class Query(metaclass=ABCMeta):
             return []
 
         Q = f"""EXPLAIN (ANALYZE TRUE, TIMING FALSE, FORMAT JSON) CREATE TABLE {full_name} AS 
-            ({self._make_query() if force else self.get_query()})"""
+            (SELECT {", ".join(self.column_names)} FROM ({self._make_query() if force else self.get_query()}) _)"""
         queries.append(Q)
         for ix in self.index_cols:
             queries.append(

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -255,6 +255,7 @@ class Query(metaclass=ABCMeta):
         return self.get_dataframe_async().result()
 
     @property
+    @abstractmethod
     def column_names(self) -> List[str]:
         """
         Returns the column names.

--- a/flowmachine/flowmachine/core/random.py
+++ b/flowmachine/flowmachine/core/random.py
@@ -8,6 +8,7 @@ random events, msisdns, sites or a given geographical boundary. All the samples
 can be subsetted by time.
 """
 import random
+from typing import List
 
 from .query import Query
 from .table import Table
@@ -311,7 +312,8 @@ def random_factory(parent_class):
                 return f"x{self.md5}"
 
         # Overwrite to call on parent instead
-        def get_column_names(self):
+        @property
+        def column_names(self) -> List[str]:
             return self.query.column_names
 
     return Random

--- a/flowmachine/flowmachine/core/subscriber_subsetter.py
+++ b/flowmachine/flowmachine/core/subscriber_subsetter.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -36,6 +37,9 @@ class SubscriberSubsetterBase(Query):
         raise NotImplementedError(
             f"Class {self.__class__.__name__} does not implement 'is_proper_subset'"
         )
+
+    def column_names(self) -> List[str]:
+        return []
 
     @abstractmethod
     def _make_query(self):

--- a/flowmachine/flowmachine/core/subset.py
+++ b/flowmachine/flowmachine/core/subset.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from typing import List
 
 from .query import Query
 import numbers
@@ -52,6 +53,10 @@ def subset_factory(parent_class):
             self.col = col
             self.subsetby = subsetby
             Query.__init__(self)
+
+        @property
+        def column_names(self) -> List[str]:
+            return self.parent.column_names
 
         # This voodoo incantation means that if we look for an attribute
         # in this class, and it is not found, we then look in the parent class

--- a/flowmachine/flowmachine/core/subset.py
+++ b/flowmachine/flowmachine/core/subset.py
@@ -138,6 +138,10 @@ def subset_numbers_factory(parent_class):
                 raise TypeError("Low and/or High not and integer or float")
             Query.__init__(self)
 
+        @property
+        def column_names(self) -> List[str]:
+            return self.parent.column_names
+
         def __getattr__(self, name):
             # Don't extend this to hidden variables, such as _df
             # and _len

--- a/flowmachine/flowmachine/features/__init__.py
+++ b/flowmachine/flowmachine/features/__init__.py
@@ -80,7 +80,7 @@ spat = [
 
 ut = [
     "GroupValues",
-    "FeatureCollection",
+    "feature_collection",
     "subscriber_locations",
     "EventTableSubset",
     "UniqueSubscribers",

--- a/flowmachine/flowmachine/features/network/total_network_objects.py
+++ b/flowmachine/flowmachine/features/network/total_network_objects.py
@@ -351,10 +351,9 @@ class AggregateNetworkObjects(GeoDataMixin, Query):
 
     @property
     def column_names(self) -> List[str]:
-        return get_columns_for_level(self.level, self.joined.column_name) + [
-            "stat",
-            "datetime",
-        ]
+        return get_columns_for_level(
+            self.total_objs.level, self.total_objs.joined.column_name
+        ) + [self.statistic, "datetime"]
 
     def _make_query(self):
         group_cols = ",".join(

--- a/flowmachine/flowmachine/features/network/total_network_objects.py
+++ b/flowmachine/flowmachine/features/network/total_network_objects.py
@@ -10,6 +10,8 @@ at the network level.
 
 
 """
+from typing import List
+
 from ...core.mixins import GeoDataMixin
 from ...core import JoinToLocation
 from ...utils.utils import get_columns_for_level
@@ -152,6 +154,13 @@ class TotalNetworkObjects(GeoDataMixin, Query):
         self.subscriber_identifier = subscriber_identifier
 
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return get_columns_for_level(self.level, self.joined.column_name) + [
+            "total",
+            "datetime",
+        ]
 
     def _make_query(self):
         cols = ",".join(get_columns_for_level(self.network_object))
@@ -339,6 +348,13 @@ class AggregateNetworkObjects(GeoDataMixin, Query):
             subscriber_subset=total_objs.subscriber_subset,
             subscriber_identifier=total_objs.subscriber_identifier,
         )
+
+    @property
+    def column_names(self) -> List[str]:
+        return get_columns_for_level(self.level, self.joined.column_name) + [
+            "stat",
+            "datetime",
+        ]
 
     def _make_query(self):
         group_cols = ",".join(

--- a/flowmachine/flowmachine/features/spatial/distance_matrix.py
+++ b/flowmachine/flowmachine/features/spatial/distance_matrix.py
@@ -7,6 +7,8 @@ Utility methods for calculating a distance
 matrix from a given point collection.
 
 """
+from typing import List
+
 from flowmachine.utils.utils import get_columns_for_level
 from ...core.query import Query
 from ...core.mixins import GraphMixin
@@ -70,6 +72,25 @@ class DistanceMatrix(GraphMixin, Query):
         self.return_geometry = return_geometry
 
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        cols = get_columns_for_level(self.level)
+
+        try:
+            cols.remove("lat")
+            cols.remove("lon")
+        except ValueError:
+            pass  # Nothing to remove
+
+        col_names = [f"{c}_from" for c in cols]
+        col_names += [f"{c}_to" for c in cols]
+        col_names += [f"{c}_from" for c in ("lon", "lat")]
+        col_names += [f"{c}_to" for c in ("lon", "lat")]
+        col_names += ["distance"]
+        if self.return_geometry:
+            col_names += ["geom_origin", "geom_destination"]
+        return col_names
 
     def _make_query(self):
         cols = get_columns_for_level(self.level)

--- a/flowmachine/flowmachine/features/spatial/location_area.py
+++ b/flowmachine/flowmachine/features/spatial/location_area.py
@@ -11,6 +11,7 @@ need to be point collections with geographic properties.
 
 """
 import logging
+from typing import List
 
 from ...core.query import Query
 from ...core.mixins import GeoDataMixin
@@ -53,6 +54,17 @@ class _viewshedSlopes(Query):
         self.above_ground_position = above_ground_position
 
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return [
+            "location_id",
+            "geom_point",
+            "od_line_identifier",
+            "geom",
+            "distance",
+            "slope",
+        ]
 
     def _make_query(self):
 
@@ -158,6 +170,10 @@ class _computeArea(Query):
         self.geom_area_column = geom_area_column
 
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["location_id", "geom_point", self.geom_area_column, "area"]
 
     def _make_query(self):
 
@@ -334,6 +350,10 @@ class LocationArea(GeoDataMixin, Query):
         self.computed_area = _computeArea(
             location_area_query=self.get_query(), geom_area_column=self.column_name
         )
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["location_id", "geom_point", self.column_name]
 
     def __get_point_statement(self):
         """

--- a/flowmachine/flowmachine/features/spatial/location_cluster.py
+++ b/flowmachine/flowmachine/features/spatial/location_cluster.py
@@ -11,6 +11,7 @@ be used to any other point collection.
 
 """
 import logging
+from typing import List
 
 from ...core.query import Query
 from ...core.mixins import GeoDataMixin
@@ -186,6 +187,13 @@ class LocationCluster(GeoDataMixin, Query):
             )
 
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        if self.aggregate:
+            return ["cluster_id", "location_id_members", "geom_cluster", "geom"]
+        else:
+            return ["location_id", "cluster_id", "geom"]
 
     def __create_aggregate_cluster_geometries(self, sql_points):
         """

--- a/flowmachine/flowmachine/features/spatial/versioned_infrastructure.py
+++ b/flowmachine/flowmachine/features/spatial/versioned_infrastructure.py
@@ -69,7 +69,7 @@ class VersionedInfrastructure(Query):
 
     @property
     def column_names(self) -> List[str]:
-        return self.table_name.column_names
+        return self.table.column_names
 
     def _make_query(self):
 

--- a/flowmachine/flowmachine/features/spatial/versioned_infrastructure.py
+++ b/flowmachine/flowmachine/features/spatial/versioned_infrastructure.py
@@ -9,7 +9,11 @@ Methods for fetching a set of versioned infrastructure elements.
 A version is selected based on the date in which that version is valid.
 
 """
+from typing import List
+
 from datetime import datetime
+
+from flowmachine.core import Table
 from ...core.query import Query
 
 
@@ -58,25 +62,25 @@ class VersionedInfrastructure(Query):
         if date == None:
             date = datetime.now().strftime("%Y-%m-%d")
 
-        self.table = table
+        self.table = Table(schema="infrastructure", name=table)
         self.date = date
 
         super().__init__()
 
+    @property
+    def column_names(self) -> List[str]:
+        return self.table_name.column_names
+
     def _make_query(self):
 
-        sql = """
-            SELECT
-                *
-            FROM infrastructure.{table}
-            WHERE date_of_first_service <= '{date}'::date AND
+        sql = f"""
+            {self.table.get_query()}
+            WHERE date_of_first_service <= '{self.date}'::date AND
                   (CASE
                       WHEN date_of_last_service IS NOT NULL
-                      THEN date_of_last_service > '{date}'::date
+                      THEN date_of_last_service > '{self.date}'::date
                       ELSE TRUE
                    END)
-        """.format(
-            table=self.table, date=self.date
-        )
+        """
 
         return sql

--- a/flowmachine/flowmachine/features/subscriber/contact_balance.py
+++ b/flowmachine/flowmachine/features/subscriber/contact_balance.py
@@ -10,6 +10,7 @@ that a given contact participates out of the
 subscriber's total event count.
 
 """
+from typing import List
 
 from .metaclasses import SubscriberFeature
 from ..utilities import EventsTablesUnion
@@ -145,3 +146,7 @@ class ContactBalance(GraphMixin, SubscriberFeature):
         """
 
         return sql
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "msisdn_counterpart", "events", "proportion"]

--- a/flowmachine/flowmachine/features/subscriber/day_trajectories.py
+++ b/flowmachine/flowmachine/features/subscriber/day_trajectories.py
@@ -11,15 +11,16 @@ of events see feature subscriber_locations.
 
 """
 
-import datetime
 from functools import reduce
 from typing import List
 
+from flowmachine.core import Query
+from flowmachine.features.utilities.subscriber_locations import BaseLocation
 from flowmachine.utils.utils import get_columns_for_level
 from ..utilities.multilocation import MultiLocation
 
 
-class DayTrajectories(MultiLocation):
+class DayTrajectories(MultiLocation, BaseLocation, Query):
     """
     Class that defines day-dated trajectories (list of time-sorted DailyLocations per subscriber).
     

--- a/flowmachine/flowmachine/features/subscriber/displacement.py
+++ b/flowmachine/flowmachine/features/subscriber/displacement.py
@@ -10,6 +10,8 @@ The maximum displacement of a user from its home location
 
 
 """
+from typing import List
+
 from flowmachine.features.subscriber import daily_location
 from .metaclasses import SubscriberFeature
 from . import ModalLocation
@@ -118,6 +120,10 @@ class Displacement(SubscriberFeature):
         self.unit = unit
 
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "statistic"]
 
     def _make_query(self):
 

--- a/flowmachine/flowmachine/features/subscriber/distance_counterparts.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_counterparts.py
@@ -6,6 +6,7 @@
 """
 Calculate metrics related with distance between caller and her/his counterparts.
 """
+from typing import List
 
 valid_stats = {"count", "sum", "avg", "max", "min", "median", "stddev", "variance"}
 
@@ -119,6 +120,10 @@ class DistanceCounterparts(SubscriberFeature):
         self.distance_matrix = DistanceMatrix()
 
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", f"distance_{self.statistic}"]
 
     def _make_query(self):
 

--- a/flowmachine/flowmachine/features/subscriber/entropy.py
+++ b/flowmachine/flowmachine/features/subscriber/entropy.py
@@ -9,6 +9,8 @@ period.
 """
 
 from abc import ABCMeta, abstractmethod
+from typing import List
+
 from .metaclasses import SubscriberFeature
 from .contact_balance import ContactBalance
 from ..utilities.sets import EventsTablesUnion
@@ -20,6 +22,10 @@ from ...utils.utils import verify_columns_exist_in_all_tables
 
 class BaseEntropy(SubscriberFeature, metaclass=ABCMeta):
     """ Base query for calculating entropy of subscriber features. """
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "entropy"]
 
     def _make_query(self):
 

--- a/flowmachine/flowmachine/features/subscriber/event_count.py
+++ b/flowmachine/flowmachine/features/subscriber/event_count.py
@@ -5,6 +5,7 @@
 # -*- coding: utf-8 -*-
 
 import warnings
+from typing import List
 
 from ...utils.utils import verify_columns_exist_in_all_tables
 from ..utilities.sets import EventsTablesUnion
@@ -89,6 +90,10 @@ class EventCount(SubscriberFeature):
             subscriber_subset=subscriber_subset,
         )
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "event_count"]
 
     def _make_query(self):
         where_clause = ""

--- a/flowmachine/flowmachine/features/subscriber/first_location.py
+++ b/flowmachine/flowmachine/features/subscriber/first_location.py
@@ -10,6 +10,8 @@ is seen within a specified time period.
 
 
 """
+from typing import List
+
 from ...utils.utils import get_columns_for_level
 from .metaclasses import SubscriberFeature
 from ..utilities.subscriber_locations import subscriber_locations
@@ -100,6 +102,10 @@ class FirstLocation(SubscriberFeature):
         self.subscriber_identifier = self.ul.subscriber_identifier
 
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "time"]
 
     def _make_query(self):
         """

--- a/flowmachine/flowmachine/features/subscriber/last_location.py
+++ b/flowmachine/flowmachine/features/subscriber/last_location.py
@@ -10,6 +10,8 @@ at during a specified time period.
 
 
 """
+from typing import List
+
 from ..utilities.subscriber_locations import BaseLocation
 from ..utilities.subscriber_locations import subscriber_locations
 from ...utils.utils import get_columns_for_level
@@ -125,6 +127,10 @@ class LastLocation(BaseLocation):
             radius=radius,
         )
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber"] + get_columns_for_level(self.level, self.column_name)
 
     def _make_query(self):
         """

--- a/flowmachine/flowmachine/features/subscriber/last_location.py
+++ b/flowmachine/flowmachine/features/subscriber/last_location.py
@@ -12,12 +12,13 @@ at during a specified time period.
 """
 from typing import List
 
+from flowmachine.core import Query
 from ..utilities.subscriber_locations import BaseLocation
 from ..utilities.subscriber_locations import subscriber_locations
 from ...utils.utils import get_columns_for_level
 
 
-class LastLocation(BaseLocation):
+class LastLocation(BaseLocation, Query):
     """
     Class representing a subscribers last location within a certain time
     frame

--- a/flowmachine/flowmachine/features/subscriber/modal_location.py
+++ b/flowmachine/flowmachine/features/subscriber/modal_location.py
@@ -14,6 +14,7 @@ from typing import List
 
 from functools import reduce
 
+from flowmachine.utils.utils import get_columns_for_level
 from ..utilities.multilocation import MultiLocation
 
 
@@ -27,7 +28,11 @@ class ModalLocation(MultiLocation):
 
     @property
     def column_names(self) -> List[str]:
-        return ["subscriber"] + super().column_names + ["date"]
+        return (
+            ["subscriber"]
+            + get_columns_for_level(self.level, self.column_name)
+            + ["date"]
+        )
 
     def _make_query(self):
         """
@@ -51,9 +56,9 @@ class ModalLocation(MultiLocation):
         )
 
         sql = """
-        SELECT ranked.subscriber, {rc}
+        SELECT ranked.subscriber, {rc}, date
         FROM
-             (SELECT times_visited.subscriber, {rc},
+             (SELECT times_visited.subscriber, {rc}, date,
              row_number() OVER (PARTITION BY times_visited.subscriber
                  ORDER BY total DESC, times_visited.date DESC) AS rank
              FROM ({times_visited}) AS times_visited) AS ranked

--- a/flowmachine/flowmachine/features/subscriber/modal_location.py
+++ b/flowmachine/flowmachine/features/subscriber/modal_location.py
@@ -14,11 +14,13 @@ from typing import List
 
 from functools import reduce
 
+from flowmachine.core import Query
+from flowmachine.features.utilities.subscriber_locations import BaseLocation
 from flowmachine.utils.utils import get_columns_for_level
 from ..utilities.multilocation import MultiLocation
 
 
-class ModalLocation(MultiLocation):
+class ModalLocation(MultiLocation, BaseLocation, Query):
     """
     ModalLocation is the mode of multiple DailyLocations (or other similar
     location like objects.) It can be instantiated with either a date range

--- a/flowmachine/flowmachine/features/subscriber/modal_location.py
+++ b/flowmachine/flowmachine/features/subscriber/modal_location.py
@@ -28,11 +28,7 @@ class ModalLocation(MultiLocation):
 
     @property
     def column_names(self) -> List[str]:
-        return (
-            ["subscriber"]
-            + get_columns_for_level(self.level, self.column_name)
-            + ["date"]
-        )
+        return ["subscriber"] + get_columns_for_level(self.level, self.column_name)
 
     def _make_query(self):
         """
@@ -56,9 +52,9 @@ class ModalLocation(MultiLocation):
         )
 
         sql = """
-        SELECT ranked.subscriber, {rc}, date
+        SELECT ranked.subscriber, {rc}
         FROM
-             (SELECT times_visited.subscriber, {rc}, date,
+             (SELECT times_visited.subscriber, {rc},
              row_number() OVER (PARTITION BY times_visited.subscriber
                  ORDER BY total DESC, times_visited.date DESC) AS rank
              FROM ({times_visited}) AS times_visited) AS ranked

--- a/flowmachine/flowmachine/features/subscriber/modal_location.py
+++ b/flowmachine/flowmachine/features/subscriber/modal_location.py
@@ -10,6 +10,7 @@ The modal daily location of a subscriber.
 
 
 """
+from typing import List
 
 from functools import reduce
 
@@ -23,6 +24,10 @@ class ModalLocation(MultiLocation):
     or a list of DailyLocations (the former is more common). It gives each
     subscriber only one location.
     """
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber"] + super().column_names + ["date"]
 
     def _make_query(self):
         """

--- a/flowmachine/flowmachine/features/subscriber/most_frequent_location.py
+++ b/flowmachine/flowmachine/features/subscriber/most_frequent_location.py
@@ -133,11 +133,7 @@ class MostFrequentLocation(BaseLocation):
 
     @property
     def column_names(self) -> List[str]:
-        return (
-            ["subscriber"]
-            + get_columns_for_level(self.level, self.column_name)
-            + ["total"]
-        )
+        return ["subscriber"] + get_columns_for_level(self.level, self.column_name)
 
     def _make_query(self):
         """

--- a/flowmachine/flowmachine/features/subscriber/most_frequent_location.py
+++ b/flowmachine/flowmachine/features/subscriber/most_frequent_location.py
@@ -9,6 +9,8 @@ the most frequently.
 
 
 """
+from typing import List
+
 from ..utilities.subscriber_locations import BaseLocation, subscriber_locations
 from ...utils.utils import get_columns_for_level
 
@@ -128,6 +130,14 @@ class MostFrequentLocation(BaseLocation):
         )
 
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return (
+            ["subscriber"]
+            + get_columns_for_level(self.level, self.column_name)
+            + ["total"]
+        )
 
     def _make_query(self):
         """

--- a/flowmachine/flowmachine/features/subscriber/most_frequent_location.py
+++ b/flowmachine/flowmachine/features/subscriber/most_frequent_location.py
@@ -11,11 +11,12 @@ the most frequently.
 """
 from typing import List
 
+from flowmachine.core import Query
 from ..utilities.subscriber_locations import BaseLocation, subscriber_locations
 from ...utils.utils import get_columns_for_level
 
 
-class MostFrequentLocation(BaseLocation):
+class MostFrequentLocation(BaseLocation, Query):
     """
     Class representing the subscribers most frequent location within a
     certain time frame

--- a/flowmachine/flowmachine/features/subscriber/new_subscribers.py
+++ b/flowmachine/flowmachine/features/subscriber/new_subscribers.py
@@ -11,6 +11,8 @@ comparison time period.
 
 
 """
+from typing import List
+
 from ..utilities.sets import UniqueSubscribers
 from ...core.query import Query
 
@@ -90,3 +92,7 @@ class NewSubscribers(Query):
         )
 
         return sql
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber"]

--- a/flowmachine/flowmachine/features/subscriber/nocturnal_calls.py
+++ b/flowmachine/flowmachine/features/subscriber/nocturnal_calls.py
@@ -11,6 +11,8 @@ hour definitions can be specified.
 
 
 """
+from typing import List
+
 from .metaclasses import SubscriberFeature
 from ..utilities.subscriber_locations import subscriber_locations
 
@@ -56,6 +58,10 @@ class NocturnalCalls(SubscriberFeature):
         self.subscriber_identifier = self.ul.subscriber_identifier
 
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "percentage_nocturnal"]
 
     def _make_query(self):
         """

--- a/flowmachine/flowmachine/features/subscriber/pareto_interactions.py
+++ b/flowmachine/flowmachine/features/subscriber/pareto_interactions.py
@@ -10,6 +10,8 @@ that fraction of their contacts who account for 80% of their interactions.
 
 
 """
+from typing import List
+
 from .contact_balance import ContactBalance
 from .subscriber_degree import SubscriberDegree
 from ..utilities import EventsTablesUnion
@@ -140,3 +142,7 @@ class ParetoInteractions(SubscriberFeature):
         )
 
         return qur
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "pareto"]

--- a/flowmachine/flowmachine/features/subscriber/proportion_outgoing.py
+++ b/flowmachine/flowmachine/features/subscriber/proportion_outgoing.py
@@ -10,6 +10,8 @@ incoming per subscriber.
 
 
 """
+from typing import List
+
 from ..utilities import EventsTablesUnion
 from .metaclasses import SubscriberFeature
 
@@ -89,6 +91,10 @@ class ProportionOutgoing(SubscriberFeature):
             **kwargs
         )
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "proportion_outgoing", "proportion_incoming"]
 
     def _make_query(self):
 

--- a/flowmachine/flowmachine/features/subscriber/radius_of_gyration.py
+++ b/flowmachine/flowmachine/features/subscriber/radius_of_gyration.py
@@ -10,6 +10,8 @@ can be calculated in `km` or `m`.
 
 
 """
+from typing import List
+
 from .metaclasses import SubscriberFeature
 from ..utilities.subscriber_locations import subscriber_locations
 
@@ -92,6 +94,10 @@ class RadiusOfGyration(SubscriberFeature):
             lo1, la1, lo2, la2
         )
 
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "rog"]
+
     def _make_query(self):
         """
         Default query method implemented in the
@@ -137,7 +143,7 @@ class RadiusOfGyration(SubscriberFeature):
         RoG = """
         SELECT
             dist.subscriber,
-            sqrt( avg( distance_sqr ) )/{} AS RoG
+            sqrt( avg( distance_sqr ) )/{} AS rog
         FROM 
             ({dist}) AS dist
         GROUP BY dist.subscriber

--- a/flowmachine/flowmachine/features/subscriber/subscriber_degree.py
+++ b/flowmachine/flowmachine/features/subscriber/subscriber_degree.py
@@ -9,6 +9,8 @@ have done over a certain time period.
 
 
 """
+from typing import List
+
 from .metaclasses import SubscriberFeature
 from ..utilities import EventsTablesUnion
 
@@ -84,6 +86,10 @@ class SubscriberDegree(SubscriberFeature):
         )
         self._cols = ["subscriber", "degree"]
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "degree"]
 
     def _make_query(self):
 

--- a/flowmachine/flowmachine/features/subscriber/total_active_periods.py
+++ b/flowmachine/flowmachine/features/subscriber/total_active_periods.py
@@ -20,6 +20,7 @@ References
 ----------
 [1] Veronique Lefebvre, https://docs.google.com/document/d/1BVOAM8bVacen0U0wXbxRmEhxdRbW8J_lyaOcUtDGhx8/edit
 """
+from typing import List
 
 from .metaclasses import SubscriberFeature
 from ...utils.utils import time_period_add
@@ -132,6 +133,10 @@ class TotalActivePeriodsSubscriber(SubscriberFeature):
             for start, stop in zip(self.starts, self.stops)
         ]
         return reduce(lambda x, y: x.union(y), all_subscribers)
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "active_periods", "inactive_periods"]
 
     def _make_query(self):
 

--- a/flowmachine/flowmachine/features/subscriber/total_subscriber_events.py
+++ b/flowmachine/flowmachine/features/subscriber/total_subscriber_events.py
@@ -9,6 +9,8 @@ have done over a certain time period.
 
 
 """
+from typing import List
+
 from ..utilities import EventsTablesUnion
 from .metaclasses import SubscriberFeature
 
@@ -131,3 +133,7 @@ class TotalSubscriberEvents(SubscriberFeature):
         )
 
         return sql
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "total"]

--- a/flowmachine/flowmachine/features/utilities/__init__.py
+++ b/flowmachine/flowmachine/features/utilities/__init__.py
@@ -7,7 +7,7 @@ Utilities for working with features.
 """
 from .group_values import GroupValues
 from .subscriber_locations import subscriber_locations
-from .feature_collection import FeatureCollection
+from .feature_collection import feature_collection
 
 
 from .sets import UniqueSubscribers, SubscriberLocationSubset

--- a/flowmachine/flowmachine/features/utilities/feature_collection.py
+++ b/flowmachine/flowmachine/features/utilities/feature_collection.py
@@ -73,6 +73,11 @@ def feature_collection(metrics, dropna=True) -> Join:
     But this requires that you want the same arguments for each class 
     (and are happy with the defaults).
 
+    Returns
+    -------
+    Join
+        A Join object combining all the features
+
     Notes
     -----
     Each column has the name of the class appended to it to distinguish
@@ -94,6 +99,11 @@ def feature_collection_from_list_of_classes(
     See Also
     --------
     feature_collection
+
+    Returns
+    -------
+    Join
+        A Join object combining all the features
     """
 
     metrics = [c(*args, **kwargs) for c in classes]

--- a/flowmachine/flowmachine/features/utilities/feature_collection.py
+++ b/flowmachine/flowmachine/features/utilities/feature_collection.py
@@ -87,7 +87,7 @@ def feature_collection(metrics, dropna=True) -> Join:
 
     """
 
-    return __join_queries(metrics, dropna)
+    return _join_queries(metrics, dropna)
 
 
 def feature_collection_from_list_of_classes(
@@ -110,9 +110,9 @@ def feature_collection_from_list_of_classes(
     return feature_collection(metrics, dropna=dropna)
 
 
-# Private method that joins multiple queries together
+# Private function that joins multiple queries together
 # and returns a joined query.
-def __join_queries(queries, dropna):
+def _join_queries(queries, dropna):
 
     # We want to handle the first case as a special case, as we
     # need to give the left object a name on the first join, but

--- a/flowmachine/flowmachine/features/utilities/feature_collection.py
+++ b/flowmachine/flowmachine/features/utilities/feature_collection.py
@@ -108,8 +108,8 @@ def __join_queries(queries, dropna):
     # need to give the left object a name on the first join, but
     # not in any subsequent joins.
     col = queries[0].column_names[0]
-    left_append = "_" + queries[0].__class__.__name__ + "_0"
-    right_append = "_" + queries[1].__class__.__name__ + "_1"
+    left_append = "_" + queries[0].__class__.__name__.lower() + "_0"
+    right_append = "_" + queries[1].__class__.__name__.lower() + "_1"
     how = "inner" if dropna else "full outer"
     running_join = queries[0].join(
         queries[1],
@@ -121,7 +121,7 @@ def __join_queries(queries, dropna):
 
     for i, q in enumerate(queries[2:]):
         col = q.column_names[0]
-        append = "_" + q.__class__.__name__ + "_{}".format(i + 2)
+        append = "_" + q.__class__.__name__.lower() + "_{}".format(i + 2)
         running_join = running_join.join(q, on_left=col, right_append=append, how=how)
         # Trigger memoization
         _ = q.md5

--- a/flowmachine/flowmachine/features/utilities/group_values.py
+++ b/flowmachine/flowmachine/features/utilities/group_values.py
@@ -7,6 +7,8 @@
 Utility class that allows the subscriber to iterate through arbitrary groups of fields
 and apply a python function to the results.
 """
+from typing import List
+
 from ...core.query import Query
 from .event_table_subset import EventTableSubset
 
@@ -65,6 +67,10 @@ class GroupValues(Query):
         self.subset = EventTableSubset(start, stop, **kwargs)
 
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return self.groups + self.value
 
     def _make_query(self):
 

--- a/flowmachine/flowmachine/features/utilities/multilocation.py
+++ b/flowmachine/flowmachine/features/utilities/multilocation.py
@@ -87,15 +87,13 @@ class MultiLocation(BaseLocation):
 
         date_string = f"to_date('{dl.start}','YYYY-MM-DD') AS date"
         sql = f"SELECT *, {date_string} FROM ({dl.get_query()}) AS dl"
-        return CustomQuery(sql, self.column_names + ["date"])
-
-    @property
-    def column_names(self) -> List[str]:
-        return get_columns_for_level(self.level, self.column_name)
+        return CustomQuery(
+            sql, get_columns_for_level(self.level, self.column_name) + ["date"]
+        )
 
     def _get_relevant_columns(self):
         """
         Get a string of the location related columns
         """
 
-        return ", ".join(self.column_names)
+        return ", ".join(get_columns_for_level(self.level, self.column_name))

--- a/flowmachine/flowmachine/features/utilities/multilocation.py
+++ b/flowmachine/flowmachine/features/utilities/multilocation.py
@@ -27,7 +27,7 @@ from ...core import CustomQuery
 logger = logging.getLogger("flowmachine").getChild(__name__)
 
 
-class MultiLocation(BaseLocation):
+class MultiLocation:
     """
     Abstract base class for any class that involves stitching together
     multiple daily locations (or similar).

--- a/flowmachine/flowmachine/features/utilities/multilocation.py
+++ b/flowmachine/flowmachine/features/utilities/multilocation.py
@@ -13,6 +13,7 @@ dailylocations objects, although they can be.
 
 import logging
 import warnings
+from typing import List
 
 from ..utilities.subscriber_locations import BaseLocation
 from ..subscriber.daily_location import daily_location
@@ -73,8 +74,7 @@ class MultiLocation(BaseLocation):
         self.column_name = self._all_dls[0].column_name
         super().__init__()
 
-    @classmethod
-    def _append_date(cls, dl):
+    def _append_date(self, dl):
         """
         Takes a daily location object and returns a query representing that
         daily location, but with an additional (constant) column with the
@@ -87,11 +87,15 @@ class MultiLocation(BaseLocation):
 
         date_string = f"to_date('{dl.start}','YYYY-MM-DD') AS date"
         sql = f"SELECT *, {date_string} FROM ({dl.get_query()}) AS dl"
-        return CustomQuery(sql)
+        return CustomQuery(sql, self.column_names + ["date"])
+
+    @property
+    def column_names(self) -> List[str]:
+        return get_columns_for_level(self.level, self.column_name)
 
     def _get_relevant_columns(self):
         """
         Get a string of the location related columns
         """
 
-        return ", ".join(get_columns_for_level(self.level, self.column_name))
+        return ", ".join(self.column_names)

--- a/flowmachine/flowmachine/features/utilities/spatial_aggregates.py
+++ b/flowmachine/flowmachine/features/utilities/spatial_aggregates.py
@@ -7,6 +7,7 @@ Utility classes for performing spatial aggregate
 operations in CDRs.
 """
 import warnings
+from typing import List
 
 from ...core.query import Query
 from ...core.mixins import GeoDataMixin
@@ -31,6 +32,10 @@ class SpatialAggregate(GeoDataMixin, Query):
         self.level = locations.level
         self.column_name = locations.column_name
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return self.locations.column_names[1:] + ["total"]
 
     def _make_query(self):
 

--- a/flowmachine/flowmachine/features/utilities/spatial_aggregates.py
+++ b/flowmachine/flowmachine/features/utilities/spatial_aggregates.py
@@ -188,3 +188,9 @@ class JoinedSpatialAggregate(GeoDataMixin, Query):
         )
 
         return grouped
+
+    @property
+    def column_names(self) -> List[str]:
+        return [
+            cn for cn in self.locations.column_names if cn != "subscriber"
+        ] + self.metric.column_names[1:]

--- a/flowmachine/flowmachine/features/utilities/subscriber_locations.py
+++ b/flowmachine/flowmachine/features/utilities/subscriber_locations.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from abc import ABCMeta
 
 from typing import List
 
@@ -79,7 +80,7 @@ class _SubscriberCells(Query):
         return sql
 
 
-class BaseLocation(Query):
+class BaseLocation(Query, metaclass=ABCMeta):
     """
     Base Class for all daily and home location methods.
     Provides the method to aggregate spatially.

--- a/flowmachine/flowmachine/features/utilities/subscriber_locations.py
+++ b/flowmachine/flowmachine/features/utilities/subscriber_locations.py
@@ -80,9 +80,9 @@ class _SubscriberCells(Query):
         return sql
 
 
-class BaseLocation(Query, metaclass=ABCMeta):
+class BaseLocation:
     """
-    Base Class for all daily and home location methods.
+    Mixin for all daily and home location methods.
     Provides the method to aggregate spatially.
     """
 

--- a/flowmachine/flowmachine/models/pwo.py
+++ b/flowmachine/flowmachine/models/pwo.py
@@ -26,6 +26,7 @@ References
 """
 import logging
 import warnings
+from typing import List
 
 import pandas as pd
 
@@ -113,6 +114,17 @@ class _populationBuffer(Query):
         )
 
         return sql
+
+    @property
+    def column_names(self) -> List[str]:
+        cols = get_columns_for_level(self.level)
+
+        return (
+            ["id"]
+            + [f"{c}_from" for c in cols]
+            + [f"{c}_to" for c in cols]
+            + ["distance", "geom_buffer", "buffer_population", "n_sites"]
+        )
 
     def _make_query(self):
         """

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -162,7 +162,8 @@ def clean_env(monkeypatch):
 @pytest.fixture
 def get_dataframe(flowmachine_connect):
     yield lambda query: pd.read_sql_query(
-        query.get_query(), con=flowmachine_connect.engine
+        f"SELECT {', '.join(query.column_names)} FROM ({query.get_query()}) _",
+        con=flowmachine_connect.engine,
     )
 
 

--- a/flowmachine/tests/functional_tests/conftest.py
+++ b/flowmachine/tests/functional_tests/conftest.py
@@ -1,30 +1,8 @@
-import pandas as pd
 import pytest
 
 from approvaltests.reporters.generic_diff_reporter_factory import (
     GenericDiffReporterFactory,
 )
-
-import flowmachine
-from flowmachine.core import Query
-from flowmachine.core.cache import reset_cache
-
-
-@pytest.fixture(autouse=True)
-def flowmachine_connect():
-    con = flowmachine.connect()
-    yield con
-    reset_cache(con)
-    con.engine.dispose()  # Close the connection
-    Query.redis.flushdb()  # Empty the redis
-    del Query.connection  # Ensure we recreate everything at next use
-
-
-@pytest.fixture
-def get_dataframe(flowmachine_connect):
-    yield lambda query: pd.read_sql_query(
-        query.get_query(), con=flowmachine_connect.engine
-    )
 
 
 @pytest.fixture(scope="session")

--- a/flowmachine/tests/functional_tests/test_sql_strings_and_results.py
+++ b/flowmachine/tests/functional_tests/test_sql_strings_and_results.py
@@ -78,7 +78,8 @@ def test_daily_location_3_sql(diff_reporter):
     Daily location query with non-default parameters returns the expected data.
     """
     subset_query = CustomQuery(
-        "SELECT DISTINCT msisdn AS subscriber FROM events.calls WHERE msisdn in ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')"
+        "SELECT DISTINCT msisdn AS subscriber FROM events.calls WHERE msisdn in ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')",
+        column_names=["subscriber"],
     )
     dl = daily_location(
         "2016-01-05",
@@ -99,7 +100,8 @@ def test_daily_location_3_df(get_dataframe, diff_reporter):
     Daily location query with non-default parameters returns the expected data.
     """
     subset_query = CustomQuery(
-        "SELECT DISTINCT msisdn AS subscriber FROM events.calls WHERE msisdn in ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')"
+        "SELECT DISTINCT msisdn AS subscriber FROM events.calls WHERE msisdn in ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')",
+        column_names=["subscriber"],
     )
     dl = daily_location(
         "2016-01-05",

--- a/flowmachine/tests/functional_tests/test_sql_strings_and_results.py
+++ b/flowmachine/tests/functional_tests/test_sql_strings_and_results.py
@@ -120,7 +120,8 @@ def test_daily_location_4_sql(diff_reporter):
     Regression test; this verifies the SQL statement for the test below (which checks the resulting dataframe)
     """
     subset_query = CustomQuery(
-        "SELECT * FROM (VALUES ('dr9xNYK006wykgXj')) as tmp (subscriber)"
+        "SELECT * FROM (VALUES ('dr9xNYK006wykgXj')) as tmp (subscriber)",
+        column_names=["subscriber"],
     )
     dl = daily_location(
         "2016-01-05",

--- a/flowmachine/tests/functional_tests/test_sql_strings_and_results.py
+++ b/flowmachine/tests/functional_tests/test_sql_strings_and_results.py
@@ -137,7 +137,8 @@ def test_daily_location_4_df(get_dataframe, diff_reporter):
     Regression test; the expected result is empty because the given subscriber does not make any calls on the given date.
     """
     subset_query = CustomQuery(
-        "SELECT * FROM (VALUES ('dr9xNYK006wykgXj')) as tmp (subscriber)"
+        "SELECT * FROM (VALUES ('dr9xNYK006wykgXj')) as tmp (subscriber)",
+        ["subscriber"],
     )
     dl = daily_location(
         "2016-01-05",
@@ -154,7 +155,8 @@ def test_daily_location_5_sql(diff_reporter):
     Daily location query with non-default parameters returns the expected data.
     """
     subset_query = CustomQuery(
-        "SELECT DISTINCT msisdn AS subscriber FROM events.calls WHERE msisdn in ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')"
+        "SELECT DISTINCT msisdn AS subscriber FROM events.calls WHERE msisdn in ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')",
+        ["subscriber"],
     )
     dl = daily_location(
         "2016-01-05",
@@ -180,7 +182,8 @@ def test_daily_location_5_df(get_dataframe, diff_reporter):
         FROM events.calls
         WHERE (   (datetime >= '2016-01-01 08:00:00' AND datetime <= '2016-01-01 20:00:00' AND substring(tac::TEXT, 0, 2) = '68')
                OR (datetime >= '2016-01-07 14:00:00' AND datetime <= '2016-01-07 15:00:00' AND duration < 400))
-        """
+        """,
+        ["subscriber"],
     )
 
     dl = daily_location(
@@ -206,7 +209,8 @@ def test_daily_location_6_sql(diff_reporter):
         SELECT outgoing, datetime, duration, msisdn AS subscriber
         FROM events.calls
         WHERE datetime::date = '2016-01-01' AND duration > 2000
-        """
+        """,
+        ["subscriber"],
     )
     dl = daily_location(
         "2016-01-03", table="events.calls", subscriber_subset=subset_query
@@ -224,7 +228,8 @@ def test_daily_location_6_df(get_dataframe, diff_reporter):
         SELECT outgoing, datetime, duration, msisdn AS subscriber
         FROM events.calls
         WHERE datetime::date = '2016-01-01' AND duration > 2000
-        """
+        """,
+        ["outgoing", "datetime", "duration", "subscriber"],
     )
     dl = daily_location(
         "2016-01-03", table="events.calls", subscriber_subset=subset_query

--- a/flowmachine/tests/test_circles.py
+++ b/flowmachine/tests/test_circles.py
@@ -114,7 +114,7 @@ geojson = {
         },
     ],
     "properties": {"crs": "+proj=longlat +datum=WGS84 +no_defs"},
-    "type": "FeatureCollection",
+    "type": "feature_collection",
 }
 
 

--- a/flowmachine/tests/test_circles.py
+++ b/flowmachine/tests/test_circles.py
@@ -114,7 +114,7 @@ geojson = {
         },
     ],
     "properties": {"crs": "+proj=longlat +datum=WGS84 +no_defs"},
-    "type": "feature_collection",
+    "type": "FeatureCollection",
 }
 
 

--- a/flowmachine/tests/test_construct_query_object.py
+++ b/flowmachine/tests/test_construct_query_object.py
@@ -77,7 +77,7 @@ from flowmachine.features import LastLocation, ModalLocation, Flows, TotalLocati
             {"query_kind": "geography", "params": {"aggregation_unit": "admin3"}},
         ),
         (
-            "195311061636d0716112fda6f85e87e4",
+            "b40a542fa6e8ed06bb09fd859ad487d5",
             {
                 "query_kind": "meaningful_locations_aggregate",
                 "params": {
@@ -182,7 +182,7 @@ from flowmachine.features import LastLocation, ModalLocation, Flows, TotalLocati
             },
         ),
         (
-            "6a39f4802690d98dc701dd91e0e700ee",
+            "d08d04cb54eb4b7e4220d9a7129ff584",
             {
                 "query_kind": "meaningful_locations_od_matrix",
                 "params": {
@@ -383,7 +383,7 @@ from flowmachine.features import LastLocation, ModalLocation, Flows, TotalLocati
             },
         ),
         (
-            "5589073987023d3f9bd97128aab08401",
+            "0d8dec7386242823fad1a68914d95513",
             {
                 "query_kind": "meaningful_locations_od_matrix",
                 "params": {

--- a/flowmachine/tests/test_contact_balance.py
+++ b/flowmachine/tests/test_contact_balance.py
@@ -12,7 +12,7 @@ from flowmachine.features.subscriber import ContactBalance
 
 def test_some_results(get_dataframe):
     """
-    TotalSubscriberEvents() returns a dataframe that contains hand-picked results.
+    ContactBalance() returns a dataframe that contains hand-picked results.
     """
     df = get_dataframe(ContactBalance("2016-01-01", "2016-01-07"))
     set_df = df.set_index("subscriber")

--- a/flowmachine/tests/test_custom_query.py
+++ b/flowmachine/tests/test_custom_query.py
@@ -3,11 +3,12 @@ from flowmachine.core import CustomQuery
 
 def test_custom_query_hash():
     """Test that CustomQuery hashing is same with case & space differences."""
-    base = CustomQuery("SELECT * from foo")
-    case_mismatch = CustomQuery("select * FROM foo")
+    base = CustomQuery("SELECT * from foo", [])
+    case_mismatch = CustomQuery("select * FROM foo", [])
     space_mismatch = CustomQuery(
         """select    *
-                                 FROM foo"""
+                                 FROM foo""",
+        [],
     )
     assert base.md5 == case_mismatch.md5
     assert base.md5 == space_mismatch.md5

--- a/flowmachine/tests/test_feature_collection.py
+++ b/flowmachine/tests/test_feature_collection.py
@@ -3,17 +3,20 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
-Tests for flowmachine.FeatureCollection
+Tests for flowmachine.feature_collection
 """
 
-from flowmachine import FeatureCollection
+from flowmachine import feature_collection
 from flowmachine.core import CustomQuery
 from flowmachine.features import RadiusOfGyration, NocturnalCalls, SubscriberDegree
+from flowmachine.features.utilities.feature_collection import (
+    feature_collection_from_list_of_classes,
+)
 
 
 def test_collects_metrics():
     """
-    Test that we can instantiate flowmachine.FeatureCollection with list of
+    Test that we can instantiate flowmachine.feature_collection with list of
     objects.
     """
 
@@ -29,14 +32,14 @@ def test_collects_metrics():
         "percentage_nocturnal_nocturnalcalls_1",
         "degree_subscriberdegree_2",
     ]
-    fc = FeatureCollection(metrics)
+    fc = feature_collection(metrics)
     column_names = fc.column_names
     assert expected_columns == column_names
 
 
 def test_from_list_of_classes():
     """
-    Test that we can instantiate flowmachine.FeatureCollection with list of
+    Test that we can instantiate flowmachine.feature_collection with list of
     classes.
     """
 
@@ -48,7 +51,7 @@ def test_from_list_of_classes():
         "percentage_nocturnal_nocturnalcalls_1",
         "degree_subscriberdegree_2",
     ]
-    fc = FeatureCollection.from_list_of_classes(metrics, start=start, stop=stop)
+    fc = feature_collection_from_list_of_classes(metrics, start=start, stop=stop)
     column_names = fc.column_names
     assert expected_columns == column_names
 
@@ -73,8 +76,8 @@ def test_dropna(get_length):
         msisdn
     )
 
-    metrics = [CustomQuery(sql), RadiusOfGyration(start, stop)]
-    fc = FeatureCollection(metrics, dropna=False)
+    metrics = [CustomQuery(sql, ["subscriber"]), RadiusOfGyration(start, stop)]
+    fc = feature_collection(metrics, dropna=False)
 
     # usully without dropna=False this query would only return
     # a single row. We check that this is not the case.

--- a/flowmachine/tests/test_geomixin.py
+++ b/flowmachine/tests/test_geomixin.py
@@ -7,6 +7,7 @@ Tests for the GeoDataMixin mixin.
 """
 import os
 import json
+from typing import List
 
 import geojson
 
@@ -42,6 +43,10 @@ def test_massive_geojson():
 
         def _make_query(self):
             pass
+
+        @property
+        def column_names(self) -> List[str]:
+            return ["gid", "id", "geom", "junk_data"]
 
         def _geo_augmented_query(self):
             return (

--- a/flowmachine/tests/test_networkx_export.py
+++ b/flowmachine/tests/test_networkx_export.py
@@ -5,6 +5,8 @@
 """
 Unit tests for networkx export.
 """
+from typing import List
+
 import pytest
 
 from flowmachine.core import Query
@@ -50,6 +52,10 @@ def test_directed_dupe():
         def __init__(self, flow):
             self.union = flow.union(flow)
             super().__init__()
+
+        @property
+        def column_names(self) -> List[str]:
+            return self.union.column_names
 
         def _make_query(self):
             return self.union.get_query()

--- a/flowmachine/tests/test_query.py
+++ b/flowmachine/tests/test_query.py
@@ -6,6 +6,7 @@
 Tests for the basic functionality of the base classes that do not
 pertain to any one particular query
 """
+from typing import List
 
 import pytest
 from sqlalchemy.exc import ProgrammingError
@@ -54,6 +55,10 @@ def test_object_representation_is_correct():
         def _make_query(self):
             pass
 
+        @property
+        def column_names(self) -> List[str]:
+            return []
+
     o = inherits_object_representation()
     r = o.__repr__()
     assert "Query object of type" in r
@@ -76,6 +81,10 @@ def test_is_stored():
     class storable_query(Query):
         def _make_query(self):
             return """SELECT 1"""
+
+        @property
+        def column_names(self) -> List[str]:
+            return ["1"]
 
     sq = storable_query()
     sq.invalidate_db_cache()

--- a/flowmachine/tests/test_query_join.py
+++ b/flowmachine/tests/test_query_join.py
@@ -121,7 +121,9 @@ def test_using_join_to_subset(get_dataframe):
     Should be able to use the join method to subset one query by another
     """
     dl1 = daily_location("2016-01-01")
-    subset_q = CustomQuery("SELECT msisdn FROM events.calls LIMIT 10")
+    subset_q = CustomQuery(
+        "SELECT msisdn FROM events.calls LIMIT 10", column_names=["msisdn"]
+    )
     sub = dl1.join(subset_q, on_left=["subscriber"], on_right=["msisdn"])
     value_set = set(get_dataframe(sub).subscriber)
     assert set(get_dataframe(subset_q).msisdn) == value_set

--- a/flowmachine/tests/test_query_join.py
+++ b/flowmachine/tests/test_query_join.py
@@ -5,7 +5,7 @@
 """
 Tests for our custom join API
 """
-
+from typing import List
 
 import pytest
 
@@ -22,8 +22,13 @@ class TruncatedAndOffsetDailyLocation(Query):
         self.date = date
         self.size = size
         self.offset = offset
+        self.dl_obj = daily_location(self.date)
 
         super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return self.dl_obj.column_names
 
     def _make_query(self):
 
@@ -31,7 +36,7 @@ class TruncatedAndOffsetDailyLocation(Query):
         SELECT * FROM
             ( SELECT * FROM ({dl}) AS dl LIMIT {size} OFFSET {offset} ) l
         """.format(
-            dl=daily_location(self.date).get_query(), size=self.size, offset=self.offset
+            dl=self.dl_obj.get_query(), size=self.size, offset=self.offset
         )
 
         return sql

--- a/flowmachine/tests/test_query_union.py
+++ b/flowmachine/tests/test_query_union.py
@@ -16,7 +16,7 @@ def test_union_all(get_dataframe):
     """
     Test default union behaviour keeps duplicates.
     """
-    q1 = CustomQuery("SELECT * FROM events.calls LIMIT 10")
+    q1 = Table(schema="events", name="calls")
     union_all = q1.union(q1)
     union_all_df = get_dataframe(union_all)
     single_id = union_all_df[union_all_df.id == "5wNJA-PdRJ4-jxEdG-yOXpZ"]
@@ -27,7 +27,7 @@ def test_union(get_dataframe):
     """
     Test union with all set to false dedupes.
     """
-    q1 = CustomQuery("SELECT * FROM events.calls LIMIT 10")
+    q1 = Table(schema="events", name="calls")
     union = q1.union(q1, all=False)
     union_df = get_dataframe(union)
     single_id = union_df[union_df.id == "5wNJA-PdRJ4-jxEdG-yOXpZ"]

--- a/flowmachine/tests/test_random.py
+++ b/flowmachine/tests/test_random.py
@@ -129,7 +129,9 @@ def test_random_from_query(get_dataframe):
     """
     Tests whether class selects random rows from query.
     """
-    custom_query = CustomQuery("SELECT id, version FROM infrastructure.sites")
+    custom_query = CustomQuery(
+        "SELECT id, version FROM infrastructure.sites", column_names=["id", "version"]
+    )
     df = get_dataframe(custom_query.random_sample(size=7))
     assert len(df) == 7
 

--- a/flowmachine/tests/test_random.py
+++ b/flowmachine/tests/test_random.py
@@ -238,7 +238,9 @@ def test_random_sample(get_dataframe):
     """
     Test whether the random_sample method in the Query object works.
     """
-    custom_query = CustomQuery("SELECT id, version FROM infrastructure.sites")
+    custom_query = CustomQuery(
+        "SELECT id, version FROM infrastructure.sites", ["id", "version"]
+    )
     df = get_dataframe(custom_query.random_sample(size=6))
     assert list(df.columns) == ["id", "version"]
     assert len(df) == 6

--- a/flowmachine/tests/test_subscriber_entropy.py
+++ b/flowmachine/tests/test_subscriber_entropy.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from flowmachine.features.subscriber.entropy import *
-from flowmachine.core import CustomQuery
-from flowmachine.core.errors.flowmachine_errors import MissingColumnsError
 
 import numpy as np
 import pytest

--- a/flowmachine/tests/test_subscriber_location_cluster.py
+++ b/flowmachine/tests/test_subscriber_location_cluster.py
@@ -172,7 +172,7 @@ def test_different_call_days_format(get_dataframe):
 
     cd_query = cd.get_query()
     har = get_dataframe(
-        HartiganCluster(calldays=CustomQuery(cd_query, cd.column_name), radius=50)
+        HartiganCluster(calldays=CustomQuery(cd_query, cd.column_names), radius=50)
     )
     assert isinstance(har, pd.DataFrame)
 

--- a/flowmachine/tests/test_subscriber_location_cluster.py
+++ b/flowmachine/tests/test_subscriber_location_cluster.py
@@ -171,7 +171,9 @@ def test_different_call_days_format(get_dataframe):
     assert isinstance(har, pd.DataFrame)
 
     cd_query = cd.get_query()
-    har = get_dataframe(HartiganCluster(calldays=CustomQuery(cd_query), radius=50))
+    har = get_dataframe(
+        HartiganCluster(calldays=CustomQuery(cd_query, cd.column_name), radius=50)
+    )
     assert isinstance(har, pd.DataFrame)
 
 

--- a/flowmachine/tests/test_subscriber_location_cluster.py
+++ b/flowmachine/tests/test_subscriber_location_cluster.py
@@ -7,6 +7,8 @@ Tests for Subscriber Location Clustering methods. Those methods cluster
 location based on different methods, offering good options for
 reducing the dimensionality of the problem.
 """
+from typing import List
+
 import pandas as pd
 
 
@@ -69,6 +71,10 @@ class Sites(GeoDataMixin, Query):
     """
     Selects the geometric coordinates of the versioned-sites.
     """
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["site_id", "version", "geom_point"]
 
     def _make_query(self):
 

--- a/flowmachine/tests/test_subscriber_subsetter.py
+++ b/flowmachine/tests/test_subscriber_subsetter.py
@@ -38,7 +38,8 @@ flowmachine.connect()
         ),
         (
             CustomQuery(
-                "SELECT duration, msisdn as subscriber FROM events.calls WHERE duration < 200"
+                "SELECT duration, msisdn as subscriber FROM events.calls WHERE duration < 200",
+                ["duration", "subscriber"],
             ),
             SubscriberSubsetterForFlowmachineQuery,
         ),
@@ -58,6 +59,8 @@ def test_raises_error_if_flowmachine_query_does_not_contain_subscriber_column():
     """
     An error is raised when creating a subsetter from a flowmachine query that doesn't contain a column named 'subscriber'.
     """
-    flowmachine_query = CustomQuery("SELECT msisdn, duration FROM events.calls")
+    flowmachine_query = CustomQuery(
+        "SELECT msisdn, duration FROM events.calls", ["msisdn", "duration"]
+    )
     with pytest.raises(ValueError):
         _ = make_subscriber_subsetter(flowmachine_query)

--- a/integration_tests/tests/flowmachine_tests/test_daily_location_results.py
+++ b/integration_tests/tests/flowmachine_tests/test_daily_location_results.py
@@ -14,7 +14,8 @@ def test_daily_location_1_sql(diff_reporter):
     Daily location query with non-default parameters returns the expected data.
     """
     subset_query = CustomQuery(
-        "SELECT DISTINCT msisdn AS subscriber FROM events.calls WHERE msisdn in ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')"
+        "SELECT DISTINCT msisdn AS subscriber FROM events.calls WHERE msisdn in ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')",
+        column_names=["subscriber"],
     )
     dl = daily_location(
         "2016-01-05",
@@ -34,7 +35,8 @@ def test_daily_location_1_df(get_dataframe, diff_reporter):
     # Note that subscriber `1vGR8kp342yxEpwY` should be missing from the result
     # because they have no event on 2016-01-05 after 11pm or before 5am.
     subset_query = CustomQuery(
-        "SELECT DISTINCT msisdn AS subscriber FROM events.calls WHERE msisdn in ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')"
+        "SELECT DISTINCT msisdn AS subscriber FROM events.calls WHERE msisdn in ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')",
+        column_names=["subscriber"],
     )
     dl = daily_location(
         "2016-01-05",


### PR DESCRIPTION
Closes #419 

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [x] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This adds a `column_names` property to those query types which had been missing it up until now, and mandates that classes inheriting from `Query` implement one. I've also turned the two `FeatureCollection` classes into functions, because there was nothing in them to warrant being classes really.