### PR TITLE
Black pre commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Dockerised development setup, with support for live reload of `flowmachine` and `flowapi` after source code changes.
+- Pre-commit hook for Python formatting with black.
 
 ### Changed
 - `CustomQuery` now requires column names to be specified

--- a/docs/source/dev_environment_setup.md
+++ b/docs/source/dev_environment_setup.md
@@ -1,5 +1,51 @@
 # Setting up a development environment
 
+## Prerequisites
+
+### Pre-commit hook for Python formatting with black
+
+FlowKit's Python code is formatted with [black](https://black.readthedocs.io/en/stable/) (which is included in the
+FlowKit pipenv environments). There is also a [pre-commit](https://pre-commit.com/) hook which runs black on all Python
+files before each commit.
+
+To install the pre-commit hook run:
+```bash
+$ cd flowmachine && pipenv run pre-commit install
+```
+If you ever want to uninstall the hook you can do this by running `pipenv run pre-commit uninstall` (inside the
+`flowmachine/` directory).
+
+Note that if you run `git commit` and any files are modified by the re-formatting, the pre-commit hook will abort
+the commit (but leave the files re-formatted). Simply repeat the `git commit` command in order to complete the commit.
+
+Example:
+
+```bash
+# 1) First attempt to commit; this is aborted because one of the files
+#    is reformatted by the pre-commit hook.
+
+$ git commit -a -m "Some changes"
+black...................................................Failed
+hookid: black
+
+Files were modified by this hook. Additional output:
+
+reformatted flowmachine/__init__.py
+All done! ✨ 🍰 ✨
+1 file reformatted.
+
+
+# 2) Complete the commit by running the same 'git commit' command again.
+
+$ git commit -a -m "Some changes"
+black...................................................Passed
+[black-pre-commit-hook 8ebaace] Some changes
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+```
+
+
+
+
 ## Option 1: Starting up all FlowKit components inside a dockerised development environment
 
 For convenience, FlowKit comes with a dockerised development environment. You can start up a development version of all

--- a/docs/source/dev_environment_setup.md
+++ b/docs/source/dev_environment_setup.md
@@ -10,10 +10,18 @@ files before each commit.
 
 To install the pre-commit hook run:
 ```bash
-$ cd flowmachine && pipenv run pre-commit install
+$ pre-commit install
 ```
-If you ever want to uninstall the hook you can do this by running `pipenv run pre-commit uninstall` (inside the
-`flowmachine/` directory).
+If you ever want to uninstall the hook you can do this by running `pipenv run pre-commit uninstall`.
+
+The above command requires `pre-commit` to be installed on your system. For convenience, it is also
+included in the `flowmachine` pipenv environment, so if you don't want to install it system-wide you
+can run it as follows (it will still be installed and available for all FlowKit components, not just
+flowmachine).
+```bash
+$ cd flowmachine/
+$ pipenv run pre-commit install
+```
 
 Note that if you run `git commit` and any files are modified by the re-formatting, the pre-commit hook will abort
 the commit (but leave the files re-formatted). Simply repeat the `git commit` command in order to complete the commit.


### PR DESCRIPTION
Closes #425 

### I have:

- [X] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [X] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [X] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 
