### PR TITLE
Add standard exclude pragma in .coveragerc files

### DIFF
--- a/flowapi/.coveragerc
+++ b/flowapi/.coveragerc
@@ -9,6 +9,10 @@ omit =
     *__init__*
 
 exclude_lines =
+    # Need to explicitly re-enable the standard pragma
+    pragma: no cover
+
     if __name__ == '__main__':
+    def __repr__
 
 show_missing = True

--- a/flowclient/.coveragerc
+++ b/flowclient/.coveragerc
@@ -9,6 +9,10 @@ omit =
     *__init__*
 
 exclude_lines =
+    # Need to explicitly re-enable the standard pragma
+    pragma: no cover
+
     if __name__ == '__main__':
+    def __repr__
 
 show_missing = True

--- a/flowmachine/.coveragerc
+++ b/flowmachine/.coveragerc
@@ -14,6 +14,10 @@ omit =
     flowmachine/core/server/server.py
 
 exclude_lines =
+    # Need to explicitly re-enable the standard pragma
+    pragma: no cover
+
     if __name__ == '__main__':
+    def __repr__
 
 show_missing = True

--- a/integration_tests/.coveragerc
+++ b/integration_tests/.coveragerc
@@ -16,6 +16,10 @@ omit =
     */setup.py
 
 exclude_lines =
+    # Need to explicitly re-enable the standard pragma
+    pragma: no cover
+
     if __name__ == '__main__':
+    def __repr__
 
 show_missing = True


### PR DESCRIPTION
Closes #490 

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Adds the standard `pragma: no cover` regex to the four `.coveragerc` files. I have also added a regex to exclude `__repr__` method because I don't see that we want to typically test them.