### PR TITLE
Allows for directed proportion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - `API_DB_PASS` -> `FLOWAPI_DB_PASS`
     - `FM_DB_USER` -> `FLOWMACHINE_DB_USER`
     - `FM_DB_PASS` -> `FLOWMACHINE_DB_PASS`
-- Adds `numerator_direction` to `ProportionEventType` to allow for proportion of directed events.
+- Added `numerator_direction` to `ProportionEventType` to allow for proportion of directed events.
 
 ### Fixed
 - Server no longer loses track of queries under heavy load

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - `API_DB_PASS` -> `FLOWAPI_DB_PASS`
     - `FM_DB_USER` -> `FLOWMACHINE_DB_USER`
     - `FM_DB_PASS` -> `FLOWMACHINE_DB_PASS`
+- Adds `numerator_direction` to `ProportionEventType` to allow for proportion of directed events.
 
 ### Fixed
 - Server no longer loses track of queries under heavy load

--- a/flowmachine/flowmachine/features/subscriber/event_type_proportion.py
+++ b/flowmachine/flowmachine/features/subscriber/event_type_proportion.py
@@ -24,6 +24,8 @@ class ProportionEventType(SubscriberFeature):
     numerator: str or list of strings
         The event tables for which we are seeking as the proportion of the
         total events observed in all tables specified in `tables`.
+    numerator_direction : {'in', 'out', 'both'}, default 'out'
+        Whether to consider calls made, received, or both. Defaults to 'out'.
     hours : 2-tuple of floats, default 'all'
         Restrict the analysis to only a certain set
         of hours within each day.
@@ -61,6 +63,7 @@ class ProportionEventType(SubscriberFeature):
         stop,
         numerator,
         *,
+        numerator_direction="both",
         subscriber_identifier="msisdn",
         direction="both",
         hours="all",
@@ -71,6 +74,7 @@ class ProportionEventType(SubscriberFeature):
         self.stop = stop
         self.subscriber_identifier = subscriber_identifier
         self.direction = direction
+        self.numerator_direction = numerator_direction
         self.hours = hours
         self.tables = tables
         self.numerator = numerator if isinstance(numerator, list) else [numerator]
@@ -79,7 +83,7 @@ class ProportionEventType(SubscriberFeature):
             self.start,
             self.stop,
             subscriber_identifier=self.subscriber_identifier,
-            direction=self.direction,
+            direction=self.numerator_direction,
             hours=self.hours,
             subscriber_subset=subscriber_subset,
             tables=self.numerator,

--- a/flowmachine/flowmachine/features/subscriber/event_type_proportion.py
+++ b/flowmachine/flowmachine/features/subscriber/event_type_proportion.py
@@ -24,7 +24,7 @@ class ProportionEventType(SubscriberFeature):
     numerator: str or list of strings
         The event tables for which we are seeking as the proportion of the
         total events observed in all tables specified in `tables`.
-    numerator_direction : {'in', 'out', 'both'}, default 'out'
+    numerator_direction : {'in', 'out', 'both'}, default 'both'
         Whether to consider events made, received, or both in the numerator. Defaults to 'both'.
     hours : 2-tuple of floats, default 'all'
         Restrict the analysis to only a certain set

--- a/flowmachine/flowmachine/features/subscriber/event_type_proportion.py
+++ b/flowmachine/flowmachine/features/subscriber/event_type_proportion.py
@@ -25,7 +25,7 @@ class ProportionEventType(SubscriberFeature):
         The event tables for which we are seeking as the proportion of the
         total events observed in all tables specified in `tables`.
     numerator_direction : {'in', 'out', 'both'}, default 'out'
-        Whether to consider calls made, received, or both. Defaults to 'out'.
+        Whether to consider events made, received, or both in the numerator. Defaults to 'both'.
     hours : 2-tuple of floats, default 'all'
         Restrict the analysis to only a certain set
         of hours within each day.
@@ -35,8 +35,8 @@ class ProportionEventType(SubscriberFeature):
         If provided, string or list of string which are msisdn or imeis to limit
         results to; or, a query or table which has a column with a name matching
         subscriber_identifier (typically, msisdn), to limit results to.
-    direction : {'in', 'out', 'both'}, default 'out'
-        Whether to consider calls made, received, or both. Defaults to 'out'.
+    direction : {'in', 'out', 'both'}, default 'both'
+        Whether to consider events made, received, or both. Defaults to 'both'.
     tables : str or list of strings, default 'all'
         Can be a string of a single table (with the schema)
         or a list of these. The keyword all is to select all

--- a/flowmachine/tests/test_subscriber_event_type_proportion.py
+++ b/flowmachine/tests/test_subscriber_event_type_proportion.py
@@ -8,16 +8,19 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "numerator, msisdn, want",
+    "numerator, numerator_direction, msisdn, want",
     [
-        ("events.calls", "AgB6KR3Levd9Z1vJ", 0.351_852),
-        ("events.sms", "7ra3xZakjEqB1Al5", 0.362_069),
-        ("events.mds", "QrAlXqDbXDkNJe3E", 0.236_363_63),
-        ("events.topups", "bKZLwjrMQG7z468y", 0.183_098_5),
-        (["events.calls", "events.sms"], "AgB6KR3Levd9Z1vJ", 0.648_148_1),
+        ("events.calls", "both", "AgB6KR3Levd9Z1vJ", 0.351_852),
+        ("events.calls", "in", "AgB6KR3Levd9Z1vJ", 0.203_703_703_7),
+        ("events.sms", "both", "7ra3xZakjEqB1Al5", 0.362_069),
+        ("events.mds", "both", "QrAlXqDbXDkNJe3E", 0.236_363_63),
+        ("events.topups", "both", "bKZLwjrMQG7z468y", 0.183_098_5),
+        (["events.calls", "events.sms"], "both", "AgB6KR3Levd9Z1vJ", 0.648_148_1),
     ],
 )
-def test_proportion_event_type(get_dataframe, numerator, msisdn, want):
+def test_proportion_event_type(
+    get_dataframe, numerator, numerator_direction, msisdn, want
+):
     """
     Test some hand picked periods and tables
     """
@@ -25,6 +28,7 @@ def test_proportion_event_type(get_dataframe, numerator, msisdn, want):
         "2016-01-01",
         "2016-01-08",
         numerator,
+        numerator_direction=numerator_direction,
         tables=[
             "events.calls",
             "events.sms",
@@ -36,6 +40,13 @@ def test_proportion_event_type(get_dataframe, numerator, msisdn, want):
     df = get_dataframe(query).set_index("subscriber")
     assert df.value[msisdn] == pytest.approx(want)
 
-    query = ProportionEventType("2016-01-02", "2016-01-04", numerator, tables=numerator)
+    query = ProportionEventType(
+        "2016-01-02",
+        "2016-01-04",
+        numerator,
+        numerator_direction=numerator_direction,
+        tables=numerator,
+        direction=numerator_direction,
+    )
     df = get_dataframe(query).set_index("subscriber")
     assert df.value.unique() == [1]


### PR DESCRIPTION
### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [X] Added tests for any new additions
- [X] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [X] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

`ProportionEventType` does not allow to calculate the proportion of incoming or outgoing events for instance. This is because the numerator and denominator directions must be different. In case of incoming events we need that the direction of the numerator be `in` and the direction of the denominator be `both`.

This PR adds a new parameter to the class called `numerator_direction` to allow proportion of directed events.