### PR TITLE
Topups balance fix

### DIFF
--- a/flowmachine/flowmachine/features/subscriber/topup_balance.py
+++ b/flowmachine/flowmachine/features/subscriber/topup_balance.py
@@ -180,7 +180,7 @@ class TopUpBalance(SubscriberFeature):
         weight_extraction_query = f"""
         WITH W AS (
             SELECT
-                msisdn AS subscriber,
+                subscriber,
                 (
                     pre_event_balance +
                     (LAG(post_event_balance, 1, pre_event_balance) OVER msisdn_by_datetime)
@@ -196,8 +196,8 @@ class TopUpBalance(SubscriberFeature):
                     ) OVER msisdn_by_datetime
                 ) AS weight,
                 CUME_DIST() OVER msisdn_by_datetime
-            FROM (select * from events.topups) AS U
-            WINDOW msisdn_by_datetime AS (PARTITION BY msisdn ORDER BY datetime)
+            FROM ({self.unioned_query.get_query()}) AS U
+            WINDOW msisdn_by_datetime AS (PARTITION BY subscriber ORDER BY datetime)
         )
         SELECT subscriber, balance, weight
         FROM W


### PR DESCRIPTION
### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

The `TopUpBalances` class had a bug in that it was selecting from the whole `events.topups` deep inside the query when it was supposed to be selecting from the unioned query. This PR fixes this bug.