### PR TITLE
Rephrase docs to be more explicit about default logging level.

### DIFF
--- a/docs/source/5-administrator.md
+++ b/docs/source/5-administrator.md
@@ -239,7 +239,7 @@ Note that the `request_id` field is identical across the five log entries, which
 
 ### Error and Debugging Logs
 
-By default, FlowMachine and FlowAPI write error logs to stderr. For more verbose logging, set the `LOG_LEVEL` environment variable to `debug` when starting the docker container.
+FlowMachine and FlowAPI write logs to stderr. By default, the logging level is `error`. For more verbose logging, set the `LOG_LEVEL` environment variable to `info` or `debug` when starting the docker container.
 
 Log messages from FlowMachine will show the `logger` field of the log entry as `flowmachine.debug`, and the Python module that emitted the log entry in the `submodule` field (e.g. `{'logger':'flowmachine.debug', 'submodule':'flowmachine.core.query'}`. FlowAPI debugging messages set `logger` to `flowapi.debug`.
 


### PR DESCRIPTION
Closes #585 

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Tweaks the docs to mention the default logging level more explicitly.