### PR TITLE
Fix not being able to add users with a Postgres backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- Fixed being unable to add new users or servers when running FlowAuth with a Postgres database [#622](https://github.com/Flowminder/FlowKit/issues/622)
 
 ### Removed
 

--- a/flowauth/frontend/src/Listing.js
+++ b/flowauth/frontend/src/Listing.js
@@ -71,7 +71,7 @@ class Listing extends React.Component {
             <IconButton
               color="inherit"
               aria-label="New"
-              onClick={() => editAction(false)}
+              onClick={() => editAction(-1)}
               id="new"
             >
               <AddIcon />


### PR DESCRIPTION
Closes #622

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Changes calls to the backend where the user isn't created yet to user id of -1, instead of false. This fixes false causing a 500 error, because it is the string `'false'`, which a Postgres backend will reject as not an integer for looking up users, servers etc. by id.