### PR TITLE
Decompose get_result_by_query_id into smaller functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - The `period` argument to `TotalNetworkObjects` in FlowMachine has been renamed `total_by`
 - The `period` argument to `total_network_objects` in FlowClient has been renamed `total_by`
- - The `by` argument to `AggregateNetworkObjects` in FlowMachine has been renamed to `aggregate_by`
+- The `by` argument to `AggregateNetworkObjects` in FlowMachine has been renamed to `aggregate_by`
+- `get_result_by_query_id` now accepts a `poll_interval` argument, which allows polling frequency to be changed
 
 
 ### Changed


### PR DESCRIPTION
Closes #276

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Splits `get_result_by_query_id` into three smaller functions, and makes polling interval configurable.