### PR TITLE
Consistent params in FlowClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - The `period` argument to `TotalNetworkObjects` in FlowMachine has been renamed `total_by`
 - The `period` argument to `total_network_objects` in FlowClient has been renamed `total_by`
- - The `by` argument to `AggregateNetworkObjects` in FlowMachine has been renamed to `aggregate_by`
+- The `by` argument to `AggregateNetworkObjects` in FlowMachine has been renamed to `aggregate_by`
+- The `stop_date` argument to the `modal_location_from_dates` and `meaningful_locations_*` functions in FlowClient has been renamed `end_date` [#470](https://github.com/Flowminder/FlowKit/issues/470) 
 
 
 ### Changed

--- a/flowclient/flowclient/client.py
+++ b/flowclient/flowclient/client.py
@@ -564,7 +564,7 @@ def daily_location(
 def meaningful_locations_aggregate(
     *,
     start_date: str,
-    stop_date: str,
+    end_date: str,
     label: str,
     labels: Dict[str, Dict[str, dict]],
     tower_day_of_week_scores: Dict[str, float],
@@ -592,7 +592,7 @@ def meaningful_locations_aggregate(
     ----------
     start_date : str
         ISO format date that begins the period, e.g. "2016-01-01"
-    stop_date : str
+    end_date : str
         ISO format date that begins the period, e.g. "2016-01-07"
     label : str
         One of the labels specified in `labels`, or 'unknown'. Locations with this
@@ -646,7 +646,7 @@ def meaningful_locations_aggregate(
         "query_kind": "meaningful_locations_aggregate",
         "aggregation_unit": aggregation_unit,
         "start_date": start_date,
-        "stop_date": stop_date,
+        "end_date": end_date,
         "label": label,
         "labels": labels,
         "tower_day_of_week_scores": tower_day_of_week_scores,
@@ -660,7 +660,7 @@ def meaningful_locations_aggregate(
 def meaningful_locations_between_label_od_matrix(
     *,
     start_date: str,
-    stop_date: str,
+    end_date: str,
     label_a: str,
     label_b: str,
     labels: Dict[str, Dict[str, dict]],
@@ -690,7 +690,7 @@ def meaningful_locations_between_label_od_matrix(
     ----------
     start_date : str
         ISO format date that begins the period, e.g. "2016-01-01"
-    stop_date : str
+    end_date : str
         ISO format date that begins the period, e.g. "2016-01-07"
     label_a, label_b : str
         One of the labels specified in `labels`, or 'unknown'. Calculates the OD between these two labels.
@@ -743,7 +743,7 @@ def meaningful_locations_between_label_od_matrix(
         "query_kind": "meaningful_locations_between_label_od_matrix",
         "aggregation_unit": aggregation_unit,
         "start_date": start_date,
-        "stop_date": stop_date,
+        "end_date": end_date,
         "label_a": label_a,
         "label_b": label_b,
         "labels": labels,
@@ -758,9 +758,9 @@ def meaningful_locations_between_label_od_matrix(
 def meaningful_locations_between_dates_od_matrix(
     *,
     start_date_a: str,
-    stop_date_a: str,
+    end_date_a: str,
     start_date_b: str,
-    stop_date_b: str,
+    end_date_b: str,
     label: str,
     labels: Dict[str, Dict[str, dict]],
     tower_day_of_week_scores: Dict[str, float],
@@ -793,7 +793,7 @@ def meaningful_locations_between_dates_od_matrix(
     ----------
     start_date_a, start_date_b : str
         ISO format date that begins the period, e.g. "2016-01-01"
-    stop_date_a, stop_date_b : str
+    end_date_a, end_date_b : str
         ISO format date that begins the period, e.g. "2016-01-07"
     label : str
         One of the labels specified in `labels`, or 'unknown'. Locations with this
@@ -847,9 +847,9 @@ def meaningful_locations_between_dates_od_matrix(
         "query_kind": "meaningful_locations_between_dates_od_matrix",
         "aggregation_unit": aggregation_unit,
         "start_date_a": start_date_a,
-        "stop_date_a": stop_date_a,
+        "end_date_a": end_date_a,
         "start_date_b": start_date_b,
-        "stop_date_b": stop_date_b,
+        "end_date_b": end_date_b,
         "label": label,
         "labels": labels,
         "tower_day_of_week_scores": tower_day_of_week_scores,
@@ -890,7 +890,7 @@ def modal_location(
 def modal_location_from_dates(
     *,
     start_date: str,
-    stop_date: str,
+    end_date: str,
     aggregation_unit: str,
     method: str,
     subscriber_subset: Union[dict, None] = None,
@@ -903,8 +903,8 @@ def modal_location_from_dates(
     ----------
     start_date : str
         ISO format date that begins the period, e.g. "2016-01-01"
-    stop_date : str
-        ISO format date that begins the period, e.g. "2016-01-07"
+    end_date : str
+        ISO format date that ends the period, e.g. "2016-01-07"
     aggregation_unit : str
         Unit of aggregation, e.g. "admin3"
     method : str
@@ -921,7 +921,7 @@ def modal_location_from_dates(
 
     """
     dates = [
-        d.strftime("%Y-%m-%d") for d in pd.date_range(start_date, stop_date, freq="D")
+        d.strftime("%Y-%m-%d") for d in pd.date_range(start_date, end_date, freq="D")
     ]
     daily_locations = [
         daily_location(

--- a/flowmachine/flowmachine/core/server/query_schemas/meaningful_locations.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/meaningful_locations.py
@@ -36,7 +36,7 @@ __all__ = [
 class MeaningfulLocationsAggregateSchema(Schema):
     query_kind = fields.String(validate=OneOf(["meaningful_locations_aggregate"]))
     start_date = fields.Date(required=True)
-    stop_date = fields.Date(required=True)
+    end_date = fields.Date(required=True)
     aggregation_unit = AggregationUnit(required=True)
     label = fields.String(required=True)
     labels = fields.Dict(
@@ -56,7 +56,7 @@ class MeaningfulLocationsAggregateSchema(Schema):
 def _make_meaningful_locations_object(
     *,
     start_date,
-    stop_date,
+    end_date,
     label,
     labels,
     subscriber_subset,
@@ -67,7 +67,7 @@ def _make_meaningful_locations_object(
 ):
     q_subscriber_locations = subscriber_locations(
         start=start_date,
-        stop=stop_date,
+        stop=end_date,
         level="versioned-site",  # note this 'level' is not the same as the exposed parameter 'aggregation_unit'
         subscriber_subset=subscriber_subset,
     )
@@ -80,7 +80,7 @@ def _make_meaningful_locations_object(
     )
     q_event_score = EventScore(
         start=start_date,
-        stop=stop_date,
+        stop=end_date,
         score_hour=tower_hour_of_day_scores,
         score_dow=tower_day_of_week_scores,
         level="versioned-site",  # note this 'level' is not the same as the exposed parameter 'aggregation_unit'
@@ -97,7 +97,7 @@ class MeaningfulLocationsAggregateExposed(BaseExposedQuery):
         self,
         *,
         start_date: str,
-        stop_date: str,
+        end_date: str,
         aggregation_unit: str,
         label: str,
         labels: Dict[str, Dict[str, dict]],
@@ -110,7 +110,7 @@ class MeaningfulLocationsAggregateExposed(BaseExposedQuery):
         # Note: all input parameters need to be defined as attributes on `self`
         # so that marshmallow can serialise the object correctly.
         self.start_date = start_date
-        self.stop_date = stop_date
+        self.end_date = end_date
         self.aggregation_unit = aggregation_unit
         self.label = label
         self.labels = labels
@@ -124,7 +124,7 @@ class MeaningfulLocationsAggregateExposed(BaseExposedQuery):
             label=label,
             labels=labels,
             start_date=start_date,
-            stop_date=stop_date,
+            end_date=end_date,
             subscriber_subset=subscriber_subset,
             tower_cluster_call_threshold=tower_cluster_call_threshold,
             tower_cluster_radius=tower_cluster_radius,
@@ -152,7 +152,7 @@ class MeaningfulLocationsBetweenLabelODMatrixSchema(Schema):
         validate=OneOf(["meaningful_locations_between_label_od_matrix"])
     )
     start_date = fields.Date(required=True)
-    stop_date = fields.Date(required=True)
+    end_date = fields.Date(required=True)
     aggregation_unit = AggregationUnit(required=True)
     label_a = fields.String(required=True)
     label_b = fields.String(required=True)
@@ -175,7 +175,7 @@ class MeaningfulLocationsBetweenLabelODMatrixExposed(BaseExposedQuery):
         self,
         *,
         start_date: str,
-        stop_date: str,
+        end_date: str,
         aggregation_unit: str,
         label_a: str,
         label_b: str,
@@ -189,7 +189,7 @@ class MeaningfulLocationsBetweenLabelODMatrixExposed(BaseExposedQuery):
         # Note: all input parameters need to be defined as attributes on `self`
         # so that marshmallow can serialise the object correctly.
         self.start_date = start_date
-        self.stop_date = stop_date
+        self.end_date = end_date
         self.aggregation_unit = aggregation_unit
         self.label_a = label_a
         self.label_b = label_b
@@ -203,7 +203,7 @@ class MeaningfulLocationsBetweenLabelODMatrixExposed(BaseExposedQuery):
         common_params = dict(
             labels=labels,
             start_date=start_date,
-            stop_date=stop_date,
+            end_date=end_date,
             subscriber_subset=subscriber_subset,
             tower_cluster_call_threshold=tower_cluster_call_threshold,
             tower_cluster_radius=tower_cluster_radius,
@@ -236,9 +236,9 @@ class MeaningfulLocationsBetweenDatesODMatrixSchema(Schema):
         validate=OneOf(["meaningful_locations_between_dates_od_matrix"])
     )
     start_date_a = fields.Date(required=True)
-    stop_date_a = fields.Date(required=True)
+    end_date_a = fields.Date(required=True)
     start_date_b = fields.Date(required=True)
-    stop_date_b = fields.Date(required=True)
+    end_date_b = fields.Date(required=True)
     aggregation_unit = AggregationUnit(required=True)
     label = fields.String(required=True)
     labels = fields.Dict(
@@ -260,9 +260,9 @@ class MeaningfulLocationsBetweenDatesODMatrixExposed(BaseExposedQuery):
         self,
         *,
         start_date_a: str,
-        stop_date_a: str,
+        end_date_a: str,
         start_date_b: str,
-        stop_date_b: str,
+        end_date_b: str,
         aggregation_unit: str,
         label: str,
         labels: Dict[str, Dict[str, dict]],
@@ -276,8 +276,8 @@ class MeaningfulLocationsBetweenDatesODMatrixExposed(BaseExposedQuery):
         # so that marshmallow can serialise the object correctly.
         self.start_date_a = start_date_a
         self.start_date_b = start_date_b
-        self.stop_date_a = stop_date_a
-        self.stop_date_b = stop_date_b
+        self.end_date_a = end_date_a
+        self.end_date_b = end_date_b
         self.aggregation_unit = aggregation_unit
         self.label = label
         self.labels = labels
@@ -297,10 +297,10 @@ class MeaningfulLocationsBetweenDatesODMatrixExposed(BaseExposedQuery):
             tower_hour_of_day_scores=tower_hour_of_day_scores,
         )
         locs_a = _make_meaningful_locations_object(
-            start_date=start_date_a, stop_date=stop_date_a, **common_params
+            start_date=start_date_a, end_date=end_date_a, **common_params
         )
         locs_b = _make_meaningful_locations_object(
-            start_date=start_date_b, stop_date=stop_date_b, **common_params
+            start_date=start_date_b, end_date=end_date_b, **common_params
         )
 
         self.q_meaningful_locations_od = MeaningfulLocationsOD(

--- a/flowmachine/tests/test_query_object_construction.py
+++ b/flowmachine/tests/test_query_object_construction.py
@@ -73,7 +73,7 @@ from flowmachine.core.server.query_schemas import FlowmachineQuerySchema
                 "query_kind": "meaningful_locations_aggregate",
                 "aggregation_unit": "admin1",
                 "start_date": "2016-01-01",
-                "stop_date": "2016-01-02",
+                "end_date": "2016-01-02",
                 "label": "unknown",
                 "labels": {
                     "evening": {
@@ -135,7 +135,7 @@ from flowmachine.core.server.query_schemas import FlowmachineQuerySchema
                 "query_kind": "meaningful_locations_between_label_od_matrix",
                 "aggregation_unit": "admin1",
                 "start_date": "2016-01-01",
-                "stop_date": "2016-01-02",
+                "end_date": "2016-01-02",
                 "label_a": "day",
                 "label_b": "evening",
                 "labels": {
@@ -198,9 +198,9 @@ from flowmachine.core.server.query_schemas import FlowmachineQuerySchema
                 "query_kind": "meaningful_locations_between_dates_od_matrix",
                 "aggregation_unit": "admin1",
                 "start_date_a": "2016-01-01",
-                "stop_date_a": "2016-01-02",
+                "end_date_a": "2016-01-02",
                 "start_date_b": "2016-01-01",
-                "stop_date_b": "2016-01-05",
+                "end_date_b": "2016-01-05",
                 "label": "unknown",
                 "labels": {
                     "day": {

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_json_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_json_spec.approved.txt
@@ -523,7 +523,7 @@
             "format": "date",
             "type": "string"
           },
-          "stop_date": {
+          "end_date": {
             "format": "date",
             "type": "string"
           },
@@ -569,7 +569,7 @@
           "labels",
           "query_kind",
           "start_date",
-          "stop_date",
+          "end_date",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],
@@ -609,11 +609,11 @@
             "format": "date",
             "type": "string"
           },
-          "stop_date_a": {
+          "end_date_a": {
             "format": "date",
             "type": "string"
           },
-          "stop_date_b": {
+          "end_date_b": {
             "format": "date",
             "type": "string"
           },
@@ -659,8 +659,8 @@
           "query_kind",
           "start_date_a",
           "start_date_b",
-          "stop_date_a",
-          "stop_date_b",
+          "end_date_a",
+          "end_date_b",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],
@@ -699,7 +699,7 @@
             "format": "date",
             "type": "string"
           },
-          "stop_date": {
+          "end_date": {
             "format": "date",
             "type": "string"
           },
@@ -745,7 +745,7 @@
           "label_b",
           "query_kind",
           "start_date",
-          "stop_date",
+          "end_date",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_json_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_json_spec.approved.txt
@@ -504,6 +504,10 @@
             ],
             "type": "string"
           },
+          "end_date": {
+            "format": "date",
+            "type": "string"
+          },
           "label": {
             "type": "string"
           },
@@ -520,10 +524,6 @@
             "type": "string"
           },
           "start_date": {
-            "format": "date",
-            "type": "string"
-          },
-          "end_date": {
             "format": "date",
             "type": "string"
           },
@@ -565,11 +565,11 @@
         },
         "required": [
           "aggregation_unit",
+          "end_date",
           "label",
           "labels",
           "query_kind",
           "start_date",
-          "end_date",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],
@@ -584,6 +584,14 @@
               "admin2",
               "admin3"
             ],
+            "type": "string"
+          },
+          "end_date_a": {
+            "format": "date",
+            "type": "string"
+          },
+          "end_date_b": {
+            "format": "date",
             "type": "string"
           },
           "label": {
@@ -609,14 +617,6 @@
             "format": "date",
             "type": "string"
           },
-          "end_date_a": {
-            "format": "date",
-            "type": "string"
-          },
-          "end_date_b": {
-            "format": "date",
-            "type": "string"
-          },
           "subscriber_subset": {
             "enum": [
               null
@@ -655,12 +655,12 @@
         },
         "required": [
           "aggregation_unit",
+          "end_date_a",
+          "end_date_b",
           "label",
           "query_kind",
           "start_date_a",
           "start_date_b",
-          "end_date_a",
-          "end_date_b",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],
@@ -675,6 +675,10 @@
               "admin2",
               "admin3"
             ],
+            "type": "string"
+          },
+          "end_date": {
+            "format": "date",
             "type": "string"
           },
           "label_a": {
@@ -699,10 +703,6 @@
             "format": "date",
             "type": "string"
           },
-          "end_date": {
-            "format": "date",
-            "type": "string"
-          },
           "subscriber_subset": {
             "enum": [
               null
@@ -741,11 +741,11 @@
         },
         "required": [
           "aggregation_unit",
+          "end_date",
           "label_a",
           "label_b",
           "query_kind",
           "start_date",
-          "end_date",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_redoc_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_redoc_spec.approved.txt
@@ -453,6 +453,10 @@
             ],
             "type": "string"
           },
+          "end_date": {
+            "format": "date",
+            "type": "string"
+          },
           "label": {
             "type": "string"
           },
@@ -469,10 +473,6 @@
             "type": "string"
           },
           "start_date": {
-            "format": "date",
-            "type": "string"
-          },
-          "end_date": {
             "format": "date",
             "type": "string"
           },
@@ -514,11 +514,11 @@
         },
         "required": [
           "aggregation_unit",
+          "end_date",
           "label",
           "labels",
           "query_kind",
           "start_date",
-          "end_date",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],
@@ -533,6 +533,14 @@
               "admin2",
               "admin3"
             ],
+            "type": "string"
+          },
+          "end_date_a": {
+            "format": "date",
+            "type": "string"
+          },
+          "end_date_b": {
+            "format": "date",
             "type": "string"
           },
           "label": {
@@ -558,14 +566,6 @@
             "format": "date",
             "type": "string"
           },
-          "end_date_a": {
-            "format": "date",
-            "type": "string"
-          },
-          "end_date_b": {
-            "format": "date",
-            "type": "string"
-          },
           "subscriber_subset": {
             "enum": [
               null
@@ -604,12 +604,12 @@
         },
         "required": [
           "aggregation_unit",
+          "end_date_a",
+          "end_date_b",
           "label",
           "query_kind",
           "start_date_a",
           "start_date_b",
-          "end_date_a",
-          "end_date_b",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],
@@ -624,6 +624,10 @@
               "admin2",
               "admin3"
             ],
+            "type": "string"
+          },
+          "end_date": {
+            "format": "date",
             "type": "string"
           },
           "label_a": {
@@ -648,10 +652,6 @@
             "format": "date",
             "type": "string"
           },
-          "end_date": {
-            "format": "date",
-            "type": "string"
-          },
           "subscriber_subset": {
             "enum": [
               null
@@ -690,11 +690,11 @@
         },
         "required": [
           "aggregation_unit",
+          "end_date",
           "label_a",
           "label_b",
           "query_kind",
           "start_date",
-          "end_date",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_redoc_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_redoc_spec.approved.txt
@@ -472,7 +472,7 @@
             "format": "date",
             "type": "string"
           },
-          "stop_date": {
+          "end_date": {
             "format": "date",
             "type": "string"
           },
@@ -518,7 +518,7 @@
           "labels",
           "query_kind",
           "start_date",
-          "stop_date",
+          "end_date",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],
@@ -558,11 +558,11 @@
             "format": "date",
             "type": "string"
           },
-          "stop_date_a": {
+          "end_date_a": {
             "format": "date",
             "type": "string"
           },
-          "stop_date_b": {
+          "end_date_b": {
             "format": "date",
             "type": "string"
           },
@@ -608,8 +608,8 @@
           "query_kind",
           "start_date_a",
           "start_date_b",
-          "stop_date_a",
-          "stop_date_b",
+          "end_date_a",
+          "end_date_b",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],
@@ -648,7 +648,7 @@
             "format": "date",
             "type": "string"
           },
-          "stop_date": {
+          "end_date": {
             "format": "date",
             "type": "string"
           },
@@ -694,7 +694,7 @@
           "label_b",
           "query_kind",
           "start_date",
-          "stop_date",
+          "end_date",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_yaml_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_yaml_spec.approved.txt
@@ -523,7 +523,7 @@
             "format": "date",
             "type": "string"
           },
-          "stop_date": {
+          "end_date": {
             "format": "date",
             "type": "string"
           },
@@ -569,7 +569,7 @@
           "labels",
           "query_kind",
           "start_date",
-          "stop_date",
+          "end_date",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],
@@ -609,11 +609,11 @@
             "format": "date",
             "type": "string"
           },
-          "stop_date_a": {
+          "end_date_a": {
             "format": "date",
             "type": "string"
           },
-          "stop_date_b": {
+          "end_date_b": {
             "format": "date",
             "type": "string"
           },
@@ -659,8 +659,8 @@
           "query_kind",
           "start_date_a",
           "start_date_b",
-          "stop_date_a",
-          "stop_date_b",
+          "end_date_a",
+          "end_date_b",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],
@@ -699,7 +699,7 @@
             "format": "date",
             "type": "string"
           },
-          "stop_date": {
+          "end_date": {
             "format": "date",
             "type": "string"
           },
@@ -745,7 +745,7 @@
           "label_b",
           "query_kind",
           "start_date",
-          "stop_date",
+          "end_date",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_yaml_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_yaml_spec.approved.txt
@@ -504,6 +504,10 @@
             ],
             "type": "string"
           },
+          "end_date": {
+            "format": "date",
+            "type": "string"
+          },
           "label": {
             "type": "string"
           },
@@ -520,10 +524,6 @@
             "type": "string"
           },
           "start_date": {
-            "format": "date",
-            "type": "string"
-          },
-          "end_date": {
             "format": "date",
             "type": "string"
           },
@@ -565,11 +565,11 @@
         },
         "required": [
           "aggregation_unit",
+          "end_date",
           "label",
           "labels",
           "query_kind",
           "start_date",
-          "end_date",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],
@@ -584,6 +584,14 @@
               "admin2",
               "admin3"
             ],
+            "type": "string"
+          },
+          "end_date_a": {
+            "format": "date",
+            "type": "string"
+          },
+          "end_date_b": {
+            "format": "date",
             "type": "string"
           },
           "label": {
@@ -609,14 +617,6 @@
             "format": "date",
             "type": "string"
           },
-          "end_date_a": {
-            "format": "date",
-            "type": "string"
-          },
-          "end_date_b": {
-            "format": "date",
-            "type": "string"
-          },
           "subscriber_subset": {
             "enum": [
               null
@@ -655,12 +655,12 @@
         },
         "required": [
           "aggregation_unit",
+          "end_date_a",
+          "end_date_b",
           "label",
           "query_kind",
           "start_date_a",
           "start_date_b",
-          "end_date_a",
-          "end_date_b",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],
@@ -675,6 +675,10 @@
               "admin2",
               "admin3"
             ],
+            "type": "string"
+          },
+          "end_date": {
+            "format": "date",
             "type": "string"
           },
           "label_a": {
@@ -699,10 +703,6 @@
             "format": "date",
             "type": "string"
           },
-          "end_date": {
-            "format": "date",
-            "type": "string"
-          },
           "subscriber_subset": {
             "enum": [
               null
@@ -741,11 +741,11 @@
         },
         "required": [
           "aggregation_unit",
+          "end_date",
           "label_a",
           "label_b",
           "query_kind",
           "start_date",
-          "end_date",
           "tower_day_of_week_scores",
           "tower_hour_of_day_scores"
         ],

--- a/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
@@ -493,6 +493,10 @@
         ],
         "type": "string"
       },
+      "end_date": {
+        "format": "date",
+        "type": "string"
+      },
       "label": {
         "type": "string"
       },
@@ -509,10 +513,6 @@
         "type": "string"
       },
       "start_date": {
-        "format": "date",
-        "type": "string"
-      },
-      "end_date": {
         "format": "date",
         "type": "string"
       },
@@ -554,10 +554,10 @@
     },
     "required": [
       "aggregation_unit",
+      "end_date",
       "label",
       "labels",
       "start_date",
-      "end_date",
       "tower_day_of_week_scores",
       "tower_hour_of_day_scores"
     ],
@@ -572,6 +572,14 @@
           "admin2",
           "admin3"
         ],
+        "type": "string"
+      },
+      "end_date_a": {
+        "format": "date",
+        "type": "string"
+      },
+      "end_date_b": {
+        "format": "date",
         "type": "string"
       },
       "label": {
@@ -597,14 +605,6 @@
         "format": "date",
         "type": "string"
       },
-      "end_date_a": {
-        "format": "date",
-        "type": "string"
-      },
-      "end_date_b": {
-        "format": "date",
-        "type": "string"
-      },
       "subscriber_subset": {
         "enum": [
           null
@@ -643,11 +643,11 @@
     },
     "required": [
       "aggregation_unit",
+      "end_date_a",
+      "end_date_b",
       "label",
       "start_date_a",
       "start_date_b",
-      "end_date_a",
-      "end_date_b",
       "tower_day_of_week_scores",
       "tower_hour_of_day_scores"
     ],
@@ -662,6 +662,10 @@
           "admin2",
           "admin3"
         ],
+        "type": "string"
+      },
+      "end_date": {
+        "format": "date",
         "type": "string"
       },
       "label_a": {
@@ -686,10 +690,6 @@
         "format": "date",
         "type": "string"
       },
-      "end_date": {
-        "format": "date",
-        "type": "string"
-      },
       "subscriber_subset": {
         "enum": [
           null
@@ -728,10 +728,10 @@
     },
     "required": [
       "aggregation_unit",
+      "end_date",
       "label_a",
       "label_b",
       "start_date",
-      "end_date",
       "tower_day_of_week_scores",
       "tower_hour_of_day_scores"
     ],

--- a/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
@@ -512,7 +512,7 @@
         "format": "date",
         "type": "string"
       },
-      "stop_date": {
+      "end_date": {
         "format": "date",
         "type": "string"
       },
@@ -557,7 +557,7 @@
       "label",
       "labels",
       "start_date",
-      "stop_date",
+      "end_date",
       "tower_day_of_week_scores",
       "tower_hour_of_day_scores"
     ],
@@ -597,11 +597,11 @@
         "format": "date",
         "type": "string"
       },
-      "stop_date_a": {
+      "end_date_a": {
         "format": "date",
         "type": "string"
       },
-      "stop_date_b": {
+      "end_date_b": {
         "format": "date",
         "type": "string"
       },
@@ -646,8 +646,8 @@
       "label",
       "start_date_a",
       "start_date_b",
-      "stop_date_a",
-      "stop_date_b",
+      "end_date_a",
+      "end_date_b",
       "tower_day_of_week_scores",
       "tower_hour_of_day_scores"
     ],
@@ -686,7 +686,7 @@
         "format": "date",
         "type": "string"
       },
-      "stop_date": {
+      "end_date": {
         "format": "date",
         "type": "string"
       },
@@ -731,7 +731,7 @@
       "label_a",
       "label_b",
       "start_date",
-      "stop_date",
+      "end_date",
       "tower_day_of_week_scores",
       "tower_hour_of_day_scores"
     ],

--- a/integration_tests/tests/query_tests/test_queries.py
+++ b/integration_tests/tests/query_tests/test_queries.py
@@ -97,7 +97,7 @@ from tests.utils import permissions_types, aggregation_types
             {
                 "locations": flowclient.modal_location_from_dates(
                     start_date="2016-01-01",
-                    stop_date="2016-01-03",
+                    end_date="2016-01-03",
                     aggregation_unit="admin3",
                     method="last",
                 )
@@ -178,7 +178,7 @@ from tests.utils import permissions_types, aggregation_types
             "meaningful_locations_aggregate",
             {
                 "start_date": "2016-01-01",
-                "stop_date": "2016-01-02",
+                "end_date": "2016-01-02",
                 "aggregation_unit": "admin1",
                 "label": "unknown",
                 "tower_hour_of_day_scores": [
@@ -236,7 +236,7 @@ from tests.utils import permissions_types, aggregation_types
             "meaningful_locations_between_label_od_matrix",
             {
                 "start_date": "2016-01-01",
-                "stop_date": "2016-01-02",
+                "end_date": "2016-01-02",
                 "aggregation_unit": "admin1",
                 "label_a": "unknown",
                 "label_b": "evening",
@@ -295,9 +295,9 @@ from tests.utils import permissions_types, aggregation_types
             "meaningful_locations_between_dates_od_matrix",
             {
                 "start_date_a": "2016-01-01",
-                "stop_date_a": "2016-01-02",
+                "end_date_a": "2016-01-02",
                 "start_date_b": "2016-01-01",
-                "stop_date_b": "2016-01-05",
+                "end_date_b": "2016-01-05",
                 "aggregation_unit": "admin1",
                 "tower_hour_of_day_scores": [
                     -1,


### PR DESCRIPTION
Closes #470

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Changes the `stop_date` parameters of `modal_location_from_dates` and `meaningful_locations_*` functions to `end_date` in line with the other functions.