### PR TITLE
Redis sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added new flowclient API entrypoint, `aggregate_network_objects`, to access equivalent flowmachine query [#601](https://github.com/Flowminder/FlowKit/issues/601)
 - FlowAPI now exposes the API spec at the `spec/openapi.json` endpoint, and an interactive version of the spec at the `spec/redoc` endpoint
 - Added Makefile target `make up-no_build`, to spin up all containers without building the images
+- Added `resync_redis_with_cache` function to cache utils, to allow administrators to align redis with FlowDB [#636](https://github.com/Flowminder/FlowKit/issues/636)
 
 ### Changed
 - The `period` argument to `TotalNetworkObjects` in FlowMachine has been renamed `total_by`
@@ -39,9 +40,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `POSTGRES_PASSWORD_FILE` -> `POSTGRES_PASSWORD`
   - `REDIS_PASSWORD_FILE` -> `REDIS_PASSWORD`
 - `status` enum in FlowDB renamed to `etl_status`
+- `reset_cache` now requires a redis client argument
 
 ### Fixed
 - Fixed being unable to add new users or servers when running FlowAuth with a Postgres database [#622](https://github.com/Flowminder/FlowKit/issues/622)
+- Resetting the cache using `reset_cache` will now reset the state of queries in redis as well [#650](https://github.com/Flowminder/FlowKit/issues/650)
 
 ### Removed
 - Removed `docker-compose-dev.yml`, and docker-compose files in `docs/`, `flowdb/tests/` and `integration_tests/`.

--- a/docs/source/administrator.md
+++ b/docs/source/administrator.md
@@ -56,7 +56,12 @@ There are two parameters which control FlowKit's cache, both of which are in the
 
 These values can be overridden when creating a new FlowDB container by setting the `CACHE_SIZE` and `CACHE_HALF_LIFE` environment variables for the container, set by updating the `cache.cache_config` table after connecting directly to FlowDB, or modified using the cache submodule.
 
-    
+#### Redis and the Query Cache
+
+FlowMachine also tracks the execution state of queries using redis. In some cases, it is possible for redis and the cache metadata table to get out of sync with one another (for example, if either redis or FlowDB has been manually edited). To deal with this, you can forcibly resync redis with FlowDB's cache table, using the `resync_redis_with_cache` function. This will reset redis, and repopulate it based _only_ on the contents of `cache.cached`.
+
+!!! warning
+    You _must_ ensure that no queries are currently running before using this function. Any queries that are currently running will become out of sync.    
 
 [^1]:By default, this uses the value set for `cache_size` in `cache.cache_config`.
 

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -23,7 +23,7 @@ from flowmachine.core.errors.flowmachine_errors import (
     QueryErroredException,
     StoreFailedException,
 )
-from flowmachine.core.query_state import QueryStateMachine
+from flowmachine.core.query_state import QueryStateMachine, QueryEvent
 
 if TYPE_CHECKING:
     from .query import Query
@@ -217,14 +217,21 @@ def touch_cache(connection: "Connection", query_id: str) -> float:
         raise ValueError(f"Query id '{query_id}' is not in cache on this connection.")
 
 
-def reset_cache(connection: "Connection") -> None:
+def reset_cache(connection: "Connection", redis: StrictRedis) -> None:
     """
-    Reset the query cache. Deletes any tables under cache schema, resets the cache count
-    and clears the cached and dependencies tables.
+    Reset the query cache. Deletes any tables under cache schema, resets the cache count,
+    clears the cached and dependencies tables.
 
     Parameters
     ----------
     connection : Connection
+    redis : StrictRedis
+
+    Notes
+    -----
+    You _must_ ensure that no queries are currently running when calling this function.
+    Any queries currently running will no longer be tracked by redis, and UNDEFINED BEHAVIOUR
+    will occur.
     """
     # For deletion purposes, we ignore Table objects. These either point to something
     # outside the cache schema and hence shouldn't be removed by calling this, or
@@ -239,6 +246,42 @@ def reset_cache(connection: "Connection") -> None:
             trans.execute(f"DROP TABLE IF EXISTS cache.{table[0]} CASCADE")
         trans.execute("TRUNCATE cache.cached CASCADE")
         trans.execute("TRUNCATE cache.dependencies CASCADE")
+    resync_redis_with_cache(connection=connection, redis=redis)
+
+
+def resync_redis_with_cache(connection: "Connection", redis: StrictRedis) -> None:
+    """
+    Reset redis to be in sync with the current contents of the cache.
+
+    Parameters
+    ----------
+    connection : Connection
+    redis : StrictRedis
+
+    Returns
+    -------
+    None
+
+    Notes
+    -----
+    You _must_ ensure that no queries are currently running when calling this function.
+    Any queries currently running will no longer be tracked by redis, and UNDEFINED BEHAVIOUR
+    will occur.
+    """
+    logger.debug("Redis resync")
+    qry = f"SELECT query_id FROM cache.cached"
+    queries_in_cache = connection.fetch(qry)
+    logger.debug("Redis resync", queries_in_cache=queries_in_cache)
+    redis.flushdb()
+    logger.debug("Flushing redis.")
+    for event in (QueryEvent.QUEUE, QueryEvent.EXECUTE, QueryEvent.FINISH):
+        for qid in queries_in_cache:
+
+            logger.debug(
+                "Redis resync",
+                fast_forwarded=qid[0],
+                new_state=QueryStateMachine(redis, qid[0]).trigger_event(event),
+            )
 
 
 def invalidate_cache_by_id(

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -186,6 +186,7 @@ class DummyRedis:
 
     def __init__(self):
         self._store = {}
+        self.flush = True
 
     def setnx(self, name, val):
         if name not in self._store:
@@ -213,6 +214,10 @@ class DummyRedis:
 
     def keys(self):
         return sorted(self._store.keys())
+
+    def flushdb(self):
+        if self.flush:
+            self._store = {}
 
 
 @pytest.fixture(scope="function")

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -186,7 +186,7 @@ class DummyRedis:
 
     def __init__(self):
         self._store = {}
-        self.flush = True
+        self.allow_flush = True
 
     def setnx(self, name, val):
         if name not in self._store:
@@ -216,7 +216,9 @@ class DummyRedis:
         return sorted(self._store.keys())
 
     def flushdb(self):
-        if self.flush:  # Set flush attribute to False to simulate concurrent writes
+        if (
+            self.allow_flush
+        ):  # Set allow_flush attribute to False to simulate concurrent writes
             self._store = {}
 
 

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -216,7 +216,7 @@ class DummyRedis:
         return sorted(self._store.keys())
 
     def flushdb(self):
-        if self.flush:
+        if self.flush:  # Set flush attribute to False to simulate concurrent writes
             self._store = {}
 
 

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -108,7 +108,7 @@ def skip_datecheck(request, monkeypatch):
 def flowmachine_connect():
     con = flowmachine.connect()
     yield con
-    reset_cache(con)
+    reset_cache(con, Query.redis)
     con.engine.dispose()  # Close the connection
     Query.redis.flushdb()  # Empty the redis
     del Query.connection  # Ensure we recreate everything at next use

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -223,5 +223,7 @@ class DummyRedis:
 
 
 @pytest.fixture(scope="function")
-def dummy_redis():
-    return DummyRedis()
+def dummy_redis(monkeypatch):
+    dummy_redis = DummyRedis()
+    monkeypatch.setattr(Query, "redis", dummy_redis)
+    return dummy_redis

--- a/flowmachine/tests/server/test_action_handlers.py
+++ b/flowmachine/tests/server/test_action_handlers.py
@@ -45,11 +45,10 @@ def test_run_query_type_error(monkeypatch):
     )
 
 
-def test_run_query_error_handled(monkeypatch, dummy_redis):
+def test_run_query_error_handled(dummy_redis):
     """
     Run query handler should return an error status if query construction failed.
     """
-    monkeypatch.setattr(Query, "redis", dummy_redis)
     msg = action_handler__run_query(
         query_kind="spatial_aggregate",
         locations=dict(
@@ -84,12 +83,11 @@ def test_get_query_bad_id():
 @pytest.mark.parametrize(
     "query_state", [state for state in QueryState if state is not QueryState.COMPLETED]
 )
-def test_get_sql_error_states(query_state, dummy_redis, monkeypatch):
+def test_get_sql_error_states(query_state, dummy_redis):
     """
     Test that get_sql handler replies with an error state when the query
     is not finished.
     """
-    monkeypatch.setattr(Query, "redis", dummy_redis)
     dummy_redis.set("DUMMY_QUERY_ID", "KNOWN")
     state_machine = QueryStateMachine(dummy_redis, "DUMMY_QUERY_ID")
     dummy_redis.set(state_machine.state_machine._name, query_state)

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -456,11 +456,10 @@ def test_cache_reset(flowmachine_connect):
     assert not stored_query.is_stored
 
 
-def test_redis_resync_runtimeerror(flowmachine_connect, dummy_redis, monkeypatch):
+def test_redis_resync_runtimeerror(flowmachine_connect, dummy_redis):
     """
     Test that a runtime error is raised if redis is being updated from multiple places when trying to resync.
     """
-    monkeypatch.setattr("flowmachine.core.query.Query.redis", dummy_redis)
     stored_query = daily_location("2016-01-01").store().result()
     assert (
         QueryStateMachine(Table.redis, stored_query.md5).current_query_state

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -466,6 +466,6 @@ def test_redis_resync_runtimeerror(flowmachine_connect, dummy_redis, monkeypatch
         QueryStateMachine(Table.redis, stored_query.md5).current_query_state
         == QueryState.COMPLETED
     )
-    dummy_redis.flush = False
+    dummy_redis.allow_flush = False
     with pytest.raises(RuntimeError):
         resync_redis_with_cache(flowmachine_connect, dummy_redis)

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -440,7 +440,7 @@ def test_redis_resync(flowmachine_connect):
 
 def test_cache_reset(flowmachine_connect):
     """
-    Test that cache and redis are reset.
+    Test that cache and redis are both reset.
     """
     stored_query = daily_location("2016-01-01").store().result()
     assert (

--- a/integration_tests/tests/conftest.py
+++ b/integration_tests/tests/conftest.py
@@ -272,7 +272,7 @@ def reset_flowdb_and_redis(fm_conn):
     test has a clean database to work with.
     """
     print("[DDD] Resetting flowdb and redis into a pristine state")
-    reset_cache_schema(fm_conn)
+    reset_cache_schema(fm_conn, redis_instance=Query.redis)
     delete_all_redis_keys(redis_instance=Query.redis)
 
 
@@ -283,14 +283,14 @@ def delete_all_redis_keys(redis_instance):
     redis_instance.flushall()
 
 
-def reset_cache_schema(fm_conn):
+def reset_cache_schema(fm_conn, redis_instance):
     """
     Reset the cache schema in flowdb by removing any tables for cached queries,
     and truncating the internal tables 'cache.cached' and 'cache.dependencies'
     so that they are empty.
     """
     print("[DDD] Recreating cache schema... ", end="", flush=True)
-    reset_cache(fm_conn)
+    reset_cache(fm_conn, redis_instance)
     print("Done.")
 
 


### PR DESCRIPTION
Closes #650 closes #636

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

- Adds a new `resync_redis_with_cache` function to cache utils, which resets redis and repopulates it with fast-forwarded state machines for queries in the cache
- Makes `reset_cache` reset state machines in redis as well