### PR TITLE
Fix rog in top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fixed `TotalNetworkObjects` raising an error when run with a lat-long level [#108](https://github.com/Flowminder/FlowKit/issues/108)
+- Radius of gyration no longer incorrectly appears as a top level api query
 
 ### Removed
 

--- a/flowmachine/flowmachine/core/server/query_schemas/flowmachine_query.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/flowmachine_query.py
@@ -43,7 +43,6 @@ class FlowmachineQuerySchema(OneOfSchema):
         "location_introversion": LocationIntroversionSchema,
         "total_network_objects": TotalNetworkObjectsSchema,
         "aggregate_network_objects": AggregateNetworkObjectsSchema,
-        "radius_of_gyration": RadiusOfGyrationSchema,
         "dfs_metric_total_amount": DFSTotalMetricAmountSchema,
         "spatial_aggregate": SpatialAggregateSchema,
         "joined_spatial_aggregate": JoinedSpatialAggregateSchema,

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_json_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_json_spec.approved.txt
@@ -164,7 +164,6 @@
             "meaningful_locations_aggregate": "#/components/schemas/MeaningfulLocationsAggregate",
             "meaningful_locations_between_dates_od_matrix": "#/components/schemas/MeaningfulLocationsBetweenDatesODMatrix",
             "meaningful_locations_between_label_od_matrix": "#/components/schemas/MeaningfulLocationsBetweenLabelODMatrix",
-            "radius_of_gyration": "#/components/schemas/RadiusOfGyration",
             "spatial_aggregate": "#/components/schemas/SpatialAggregate",
             "total_network_objects": "#/components/schemas/TotalNetworkObjects",
             "unique_subscriber_counts": "#/components/schemas/UniqueSubscriberCounts"
@@ -204,9 +203,6 @@
           },
           {
             "$ref": "#/components/schemas/MeaningfulLocationsBetweenLabelODMatrix"
-          },
-          {
-            "$ref": "#/components/schemas/RadiusOfGyration"
           },
           {
             "$ref": "#/components/schemas/SpatialAggregate"

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_redoc_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_redoc_spec.approved.txt
@@ -186,9 +186,6 @@
             "$ref": "#/components/schemas/MeaningfulLocationsBetweenLabelODMatrix"
           },
           {
-            "$ref": "#/components/schemas/RadiusOfGyration"
-          },
-          {
             "$ref": "#/components/schemas/SpatialAggregate"
           },
           {

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_yaml_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_yaml_spec.approved.txt
@@ -164,7 +164,6 @@
             "meaningful_locations_aggregate": "#/components/schemas/MeaningfulLocationsAggregate",
             "meaningful_locations_between_dates_od_matrix": "#/components/schemas/MeaningfulLocationsBetweenDatesODMatrix",
             "meaningful_locations_between_label_od_matrix": "#/components/schemas/MeaningfulLocationsBetweenLabelODMatrix",
-            "radius_of_gyration": "#/components/schemas/RadiusOfGyration",
             "spatial_aggregate": "#/components/schemas/SpatialAggregate",
             "total_network_objects": "#/components/schemas/TotalNetworkObjects",
             "unique_subscriber_counts": "#/components/schemas/UniqueSubscriberCounts"
@@ -204,9 +203,6 @@
           },
           {
             "$ref": "#/components/schemas/MeaningfulLocationsBetweenLabelODMatrix"
-          },
-          {
-            "$ref": "#/components/schemas/RadiusOfGyration"
           },
           {
             "$ref": "#/components/schemas/SpatialAggregate"

--- a/integration_tests/tests/flowmachine_server_tests/test_server.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.py
@@ -58,7 +58,6 @@ def test_get_available_queries(send_zmq_message_and_receive_reply):
                 "location_introversion",
                 "total_network_objects",
                 "aggregate_network_objects",
-                "radius_of_gyration",
                 "dfs_metric_total_amount",
                 "spatial_aggregate",
                 "joined_spatial_aggregate",

--- a/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
@@ -158,7 +158,6 @@
         "meaningful_locations_aggregate": "#/components/schemas/MeaningfulLocationsAggregate",
         "meaningful_locations_between_dates_od_matrix": "#/components/schemas/MeaningfulLocationsBetweenDatesODMatrix",
         "meaningful_locations_between_label_od_matrix": "#/components/schemas/MeaningfulLocationsBetweenLabelODMatrix",
-        "radius_of_gyration": "#/components/schemas/RadiusOfGyration",
         "spatial_aggregate": "#/components/schemas/SpatialAggregate",
         "total_network_objects": "#/components/schemas/TotalNetworkObjects",
         "unique_subscriber_counts": "#/components/schemas/UniqueSubscriberCounts"
@@ -198,9 +197,6 @@
       },
       {
         "$ref": "#/components/schemas/MeaningfulLocationsBetweenLabelODMatrix"
-      },
-      {
-        "$ref": "#/components/schemas/RadiusOfGyration"
       },
       {
         "$ref": "#/components/schemas/SpatialAggregate"


### PR DESCRIPTION
Radius of gyration is incorrectly showing as available to use without being spatially aggregated. This fixes that.