### PR TITLE
Remove args to available dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- FlowAPI's `available_dates` endpoint now always returns available dates for all event types and does not accept JSON 
 
 ### Fixed
 - FlowDB synthetic data container no longer silently fails to generate data if data generator is not set [#654](https://github.com/Flowminder/FlowKit/issues/654)

--- a/flowapi/flowapi/query_endpoints.py
+++ b/flowapi/flowapi/query_endpoints.py
@@ -312,17 +312,8 @@ async def get_available_dates():
     """
     current_user.can_get_available_dates()
 
-    json_data = await request.json
-    if json_data is None:
-        event_types = None
-    else:
-        event_types = json_data.get("event_types", None)
     request.socket.send_json(
-        {
-            "request_id": request.request_id,
-            "action": "get_available_dates",
-            "params": {"event_types": event_types},
-        }
+        {"request_id": request.request_id, "action": "get_available_dates"}
     )
     reply = await request.socket.recv_json()
 

--- a/flowclient/flowclient/client.py
+++ b/flowclient/flowclient/client.py
@@ -504,9 +504,7 @@ def get_available_dates(
     logger.info(
         f"Getting {connection.url}/api/{connection.api_version}/available_dates"
     )
-    response = connection.get_url(
-        route=f"available_dates", data={"event_types": event_types}
-    )
+    response = connection.get_url(route=f"available_dates")
     if response.status_code != 200:
         try:
             msg = response.json()["msg"]
@@ -518,7 +516,10 @@ def get_available_dates(
         )
     result = response.json()["available_dates"]
     logger.info(f"Got {connection.url}/api/{connection.api_version}/available_dates")
-    return result
+    if event_types is None:
+        return result
+    else:
+        return {k: v for k, v in result.items() if k in event_types}
 
 
 def run_query(*, connection: Connection, query: dict) -> str:

--- a/flowmachine/flowmachine/core/server/action_handlers.py
+++ b/flowmachine/flowmachine/core/server/action_handlers.py
@@ -276,18 +276,11 @@ def action_handler__get_geography(aggregation_unit: str) -> ZMQReply:
     return ZMQReply(status="success", payload=payload)
 
 
-def action_handler__get_available_dates(
-    event_types: Optional[List[str]] = None
-) -> ZMQReply:
+def action_handler__get_available_dates() -> ZMQReply:
     """
     Handler for the 'get_available_dates' action.
 
     Returns a dict of the form {"calls": [...], "sms": [...], ...}.
-
-    Parameters
-    ----------
-    event_types: list of str, optional
-        List of event types for which to return available dates.
 
     Returns
     -------
@@ -295,16 +288,9 @@ def action_handler__get_available_dates(
         The reply from the action handler.
     """
     conn = Query.connection
-    if event_types is None:
-        event_types = tuple(
-            sorted([table_name for table_name, _, _, _ in conn.available_tables])
-        )
-    elif isinstance(event_types, (list, tuple)):
-        event_types = tuple(event_types)
-    else:
-        return ZMQReply(
-            status="error", msg=f"Invalid value for argument `event_types`."
-        )
+    event_types = tuple(
+        sorted([table_name for table_name, _, _, _ in conn.available_tables])
+    )
 
     available_dates = {
         event_type: [date.strftime("%Y-%m-%d") for date in dates]

--- a/integration_tests/tests/flowmachine_server_tests/test_action_get_available_dates.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_action_get_available_dates.py
@@ -5,7 +5,6 @@
 import pytest
 
 from flowmachine.core.server.utils import send_zmq_message_and_receive_reply
-from .helpers import poll_until_done
 
 
 # TODO: add test for code path that raises QueryProxyError with the 'get_params' action
@@ -65,20 +64,3 @@ async def test_get_available_dates(zmq_port, zmq_host):
         },
     }
     assert expected_reply == reply
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("event_types", ["not_a_list_of_event_types"])
-async def test_invalid_event_types(event_types, zmq_port, zmq_host):
-    """
-    Action 'get_available_dates' returns an error if invalid event types are passed.
-    """
-    msg = {
-        "action": "get_available_dates",
-        "request_id": "DUMMY_ID",
-        "params": {"event_types": event_types},
-    }
-
-    reply = send_zmq_message_and_receive_reply(msg, port=zmq_port, host=zmq_host)
-    assert reply["status"] == "error"
-    assert reply["msg"] == "Invalid value for argument `event_types`."


### PR DESCRIPTION
Closes #553

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Per the [OpenAPI](https://swagger.io/specification/#operationObject) and [HTTP 1.1](https://tools.ietf.org/html/rfc7231#section-4.3.1) specs, GET requests should not accept a body. This removes the body from the `available_dates` FlowAPI endpoint.