### PR TITLE
Fix failing FlowAPI docker container startup

### DIFF
--- a/flowapi/start.sh
+++ b/flowapi/start.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
Towards #683.

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [ ] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This PR fixes the failing startup of flowapi by running the `start.sh` script through `sh` instead of `bash` (which isn't installed on Alpine by default).

We will also want a CircleCI job to verify this fix, but in the interest of having a functioning container quickly (needed by @josh-gree for example) this is a quick fix.