### PR TITLE
Deployment Ansible script tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - A new Ansible playbook was added in `deployment/provision-dev.yml`. In addition to the standard provisioning
-  this installs pyenv and Python 3.7, and clones the FlowKit repository, which is useful for development purposes.
+  this installs pyenv, Python 3.7, pipenv and clones the FlowKit repository, which is useful for development purposes.
 
 ### Changed
 - FlowAPI's `available_dates` endpoint now always returns available dates for all event types and does not accept JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- A new Ansible playbook was added in `deployment/provision-dev.yml`. In addition to the standard provisioning
+  this installs pyenv and Python 3.7, and clones the FlowKit repository, which is useful for development purposes.
 
 ### Changed
-- FlowAPI's `available_dates` endpoint now always returns available dates for all event types and does not accept JSON 
+- FlowAPI's `available_dates` endpoint now always returns available dates for all event types and does not accept JSON
+- The Ansible playbooks in `deployment/` now allow configuring the username and password for the FlowKit user account.
 
 ### Fixed
 - FlowDB synthetic data container no longer silently fails to generate data if data generator is not set [#654](https://github.com/Flowminder/FlowKit/issues/654)

--- a/deployment/.gitignore
+++ b/deployment/.gitignore
@@ -1,0 +1,2 @@
+*.retry
+roles/avanov.pyenv

--- a/deployment/Pipfile
+++ b/deployment/Pipfile
@@ -5,9 +5,9 @@ name = "pypi"
 
 [packages]
 ansible = "*"
+passlib = "*"
 
 [dev-packages]
-passlib = "*"
 
 [requires]
 python_version = "3.7"

--- a/deployment/Pipfile.lock
+++ b/deployment/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "744034091943ccc5c3d8a654310e9016c89f6e974d5864612fab2bd8175a73e8"
+            "sha256": "2d98f2b1e77ca2e6ced9f164b77aa3a0590a8e24c426e825ea9ab21293d28df1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -56,36 +56,36 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:00b97afa72c233495560a0793cdc86c2571721b4271c0667addc83c417f3d90f",
-                "sha256:0ba1b0c90f2124459f6966a10c03794082a2f3985cd699d7d63c4a8dae113e11",
-                "sha256:0bffb69da295a4fc3349f2ec7cbe16b8ba057b0a593a92cbe8396e535244ee9d",
-                "sha256:21469a2b1082088d11ccd79dd84157ba42d940064abbfa59cf5f024c19cf4891",
-                "sha256:2e4812f7fa984bf1ab253a40f1f4391b604f7fc424a3e21f7de542a7f8f7aedf",
-                "sha256:2eac2cdd07b9049dd4e68449b90d3ef1adc7c759463af5beb53a84f1db62e36c",
-                "sha256:2f9089979d7456c74d21303c7851f158833d48fb265876923edcb2d0194104ed",
-                "sha256:3dd13feff00bddb0bd2d650cdb7338f815c1789a91a6f68fdc00e5c5ed40329b",
-                "sha256:4065c32b52f4b142f417af6f33a5024edc1336aa845b9d5a8d86071f6fcaac5a",
-                "sha256:51a4ba1256e9003a3acf508e3b4f4661bebd015b8180cc31849da222426ef585",
-                "sha256:59888faac06403767c0cf8cfb3f4a777b2939b1fbd9f729299b5384f097f05ea",
-                "sha256:59c87886640574d8b14910840327f5cd15954e26ed0bbd4e7cef95fa5aef218f",
-                "sha256:610fc7d6db6c56a244c2701575f6851461753c60f73f2de89c79bbf1cc807f33",
-                "sha256:70aeadeecb281ea901bf4230c6222af0248c41044d6f57401a614ea59d96d145",
-                "sha256:71e1296d5e66c59cd2c0f2d72dc476d42afe02aeddc833d8e05630a0551dad7a",
-                "sha256:8fc7a49b440ea752cfdf1d51a586fd08d395ff7a5d555dc69e84b1939f7ddee3",
-                "sha256:9b5c2afd2d6e3771d516045a6cfa11a8da9a60e3d128746a7fe9ab36dfe7221f",
-                "sha256:9c759051ebcb244d9d55ee791259ddd158188d15adee3c152502d3b69005e6bd",
-                "sha256:b4d1011fec5ec12aa7cc10c05a2f2f12dfa0adfe958e56ae38dc140614035804",
-                "sha256:b4f1d6332339ecc61275bebd1f7b674098a66fea11a00c84d1c58851e618dc0d",
-                "sha256:c030cda3dc8e62b814831faa4eb93dd9a46498af8cd1d5c178c2de856972fd92",
-                "sha256:c2e1f2012e56d61390c0e668c20c4fb0ae667c44d6f6a2eeea5d7148dcd3df9f",
-                "sha256:c37c77d6562074452120fc6c02ad86ec928f5710fbc435a181d69334b4de1d84",
-                "sha256:c8149780c60f8fd02752d0429246088c6c04e234b895c4a42e1ea9b4de8d27fb",
-                "sha256:cbeeef1dc3c4299bd746b774f019de9e4672f7cc666c777cd5b409f0b746dac7",
-                "sha256:e113878a446c6228669144ae8a56e268c91b7f1fafae927adc4879d9849e0ea7",
-                "sha256:e21162bf941b85c0cda08224dade5def9360f53b09f9f259adb85fc7dd0e7b35",
-                "sha256:fb6934ef4744becbda3143d30c6604718871495a5e36c408431bf33d9c146889"
+                "sha256:041c81822e9f84b1d9c401182e174996f0bae9991f33725d059b771744290774",
+                "sha256:046ef9a22f5d3eed06334d01b1e836977eeef500d9b78e9ef693f9380ad0b83d",
+                "sha256:066bc4c7895c91812eff46f4b1c285220947d4aa46fa0a2651ff85f2afae9c90",
+                "sha256:066c7ff148ae33040c01058662d6752fd73fbc8e64787229ea8498c7d7f4041b",
+                "sha256:2444d0c61f03dcd26dbf7600cf64354376ee579acad77aef459e34efcb438c63",
+                "sha256:300832850b8f7967e278870c5d51e3819b9aad8f0a2c8dbe39ab11f119237f45",
+                "sha256:34c77afe85b6b9e967bd8154e3855e847b70ca42043db6ad17f26899a3df1b25",
+                "sha256:46de5fa00f7ac09f020729148ff632819649b3e05a007d286242c4882f7b1dc3",
+                "sha256:4aa8ee7ba27c472d429b980c51e714a24f47ca296d53f4d7868075b175866f4b",
+                "sha256:4d0004eb4351e35ed950c14c11e734182591465a33e960a4ab5e8d4f04d72647",
+                "sha256:4e3d3f31a1e202b0f5a35ba3bc4eb41e2fc2b11c1eff38b362de710bcffb5016",
+                "sha256:50bec6d35e6b1aaeb17f7c4e2b9374ebf95a8975d57863546fa83e8d31bdb8c4",
+                "sha256:55cad9a6df1e2a1d62063f79d0881a414a906a6962bc160ac968cc03ed3efcfb",
+                "sha256:5662ad4e4e84f1eaa8efce5da695c5d2e229c563f9d5ce5b0113f71321bcf753",
+                "sha256:59b4dc008f98fc6ee2bb4fd7fc786a8d70000d058c2bbe2698275bc53a8d3fa7",
+                "sha256:73e1ffefe05e4ccd7bcea61af76f36077b914f92b76f95ccf00b0c1b9186f3f9",
+                "sha256:a1f0fd46eba2d71ce1589f7e50a9e2ffaeb739fb2c11e8192aa2b45d5f6cc41f",
+                "sha256:a2e85dc204556657661051ff4bab75a84e968669765c8a2cd425918699c3d0e8",
+                "sha256:a5457d47dfff24882a21492e5815f891c0ca35fefae8aa742c6c263dac16ef1f",
+                "sha256:a8dccd61d52a8dae4a825cdbb7735da530179fea472903eb871a5513b5abbfdc",
+                "sha256:ae61af521ed676cf16ae94f30fe202781a38d7178b6b4ab622e4eec8cefaff42",
+                "sha256:b012a5edb48288f77a63dba0840c92d0504aa215612da4541b7b42d849bc83a3",
+                "sha256:d2c5cfa536227f57f97c92ac30c8109688ace8fa4ac086d19d0af47d134e2909",
+                "sha256:d42b5796e20aacc9d15e66befb7a345454eef794fdb0737d1af593447c6c8f45",
+                "sha256:dee54f5d30d775f525894d67b1495625dd9322945e7fee00731952e0368ff42d",
+                "sha256:e070535507bd6aa07124258171be2ee8dfc19119c28ca94c9dfb7efd23564512",
+                "sha256:e1ff2748c84d97b065cc95429814cdba39bcbd77c9c85c89344b317dc0d9cbff",
+                "sha256:ed851c75d1e0e043cbf5ca9a8e1b13c4c90f3fbd863dacb01c0808e2b5204201"
             ],
-            "version": "==1.12.2"
+            "version": "==1.12.3"
         },
         "cryptography": {
             "hashes": [
@@ -158,6 +158,14 @@
             ],
             "version": "==2.4.2"
         },
+        "passlib": {
+            "hashes": [
+                "sha256:3d948f64138c25633613f303bcc471126eae67c04d5e3f6b7b8ce6242f8653e0",
+                "sha256:43526aea08fa32c6b6dbbbe9963c4c767285b78147b7437597f992812f69d280"
+            ],
+            "index": "pypi",
+            "version": "==1.7.1"
+        },
         "pyasn1": {
             "hashes": [
                 "sha256:da2420fe13a9452d8ae97a0e478adde1dee153b11ba832a95b223a2ba01c10f7",
@@ -219,14 +227,5 @@
             "version": "==1.12.0"
         }
     },
-    "develop": {
-        "passlib": {
-            "hashes": [
-                "sha256:3d948f64138c25633613f303bcc471126eae67c04d5e3f6b7b8ce6242f8653e0",
-                "sha256:43526aea08fa32c6b6dbbbe9963c4c767285b78147b7437597f992812f69d280"
-            ],
-            "index": "pypi",
-            "version": "==1.7.1"
-        }
-    }
+    "develop": {}
 }

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,8 +1,9 @@
 To provision the machine:
 
-- Set up the pipenv environment:
+- Set up the pipenv environment and install auxiliary Ansible roles.
   ```bash
   pipenv install
+  pipenv run ansible-galaxy install -p ./roles -r requirements.yml
   ```
 
 - Create a file called `./ssh_keys/authorized_keys.txt` which contains the public
@@ -31,13 +32,12 @@ To provision the machine:
 
   Here is an example setting the relevant environment variables:
   ```bash
-  # Required
+  # Required settings
   export HOST=<some_host_name>
   export SSH_PROVISIONING_USER=root
 
   # Optional (only needed if you want to change the username or password).
-  # See here for details how to determine the password hash:
-  #    https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module
+  # See above how to determine the hashed password.
   export FLOWKIT_USER_NAME=flowkit
   export FLOWKIT_USER_PASSWORD='$6$YaOatFoRa91eOA06$cLJCvJCdd0sLKBEM01eQ2wJ7ZKkTZJz.YWGFK5r0bs4yqiwAz1Lw9pmExiS.PPBBJv13cuBpiHYU88ThX4TeG/'
   ```
@@ -45,8 +45,6 @@ To provision the machine:
 - Finally, run the following command (make sure you don't forget the comma
   after `${HOST}` if you type it manually):
   ```bash
-  pipenv run ansible-galaxy install -p ./roles -r requirements.yml
-
   # Option 1 (using the default username and password)
   pipenv run ansible-playbook -i ${HOST}, --user=${SSH_PROVISIONING_USER} provision.yml
 
@@ -54,7 +52,7 @@ To provision the machine:
   pipenv run ansible-playbook -i ${HOST}, --user=${SSH_PROVISIONING_USER} --extra-vars="username=${FLOWKIT_USER_NAME} password=${FLOWKIT_USER_PASSWORD_SHA512}" provision.yml
   ```
 
-You can also replace `provision.yml` with `provision-dev.yml` in the last line.
+You can also replace `provision.yml` with `provision-dev.yml` in the previous commands.
 In addition to the standard provisioning tasks (the same as in `provision.yml`)
 this will also install Python 3 via `pyenv` and clone the FlowKit repository
 at `/home/flowkit/code/FlowKit`.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,5 +1,10 @@
 To provision the machine:
 
+- Set up the pipenv environment:
+  ```bash
+  pipenv install
+  ```
+
 - Create a file called `ssh_keys/authorized_keys.txt` which contains the public
   SSH keys of the users who should be able to log into the `flowkit` account
   once the machine is provisioned.
@@ -14,11 +19,17 @@ To provision the machine:
   and `FLOWKIT_USER_PASSWORD_SHA512`. These specify the username and (hashed)
   password of the user account that will install FlowKit. The default username
   is `flowkit` (with the password being the same). Note that the password env
-  var must contain the password in _hashed_ form. See the Ansible
+  var must contain the password in _hashed_ form. You can determine this using
+  the following command (which presents an interactive prompt where you can
+  enter the password):
+  ```bash
+  pipenv run python -c "from passlib.hash import sha512_crypt; import getpass; print(sha512_crypt.using(rounds=5000).hash(getpass.getpass()))"
+  ```
+  (See the Ansible
   [FAQ](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module)
-  for details how to determine a SHA512 hash of the password.
+  for alternative methods to determine a SHA512 hash of the password.)
 
-  Here is an example:
+  Here is an example setting the relevant environment variables:
   ```bash
   # Required
   export HOST=<some_host_name>
@@ -34,7 +45,6 @@ To provision the machine:
 - Finally, run the following command (make sure you don't forget the comma
   after `${HOST}` if you type it manually):
   ```bash
-  pipenv install
   pipenv run ansible-galaxy install -p ./roles -r requirements.yml
 
   # Option 1 (using the default username and password)

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -12,7 +12,12 @@ To provision the machine:
   after `${HOST}` if you type it manually):
   ```
   pipenv install
+  pipenv run ansible-galaxy install -p ./roles -r requirements.yml
   pipenv run ansible-playbook -i ${HOST}, --user=${SSH_USER} provision.yml
   ```
+
+You can also replace `provision.yml` with `provision-dev.yml` in the last line.
+This runs the standard provisioning (the same as in `provision.yml`) and will also
+install Python 3 via `pyenv` and clone the FlowKit repository at `/home/flowkit/code/FlowKit`.
 
 This has been tested with CentOS Linux release 7.5.1804.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,23 +1,52 @@
 To provision the machine:
 
-- Set the environment variables `HOST` and `SSH_USER` to the host and username
-  of the machine to be provisioned (note that the provisioning user needs admin
-  rights because it needs to be able to install packages on the system).
-
 - Create a file called `ssh_keys/authorized_keys.txt` which contains the public
   SSH keys of the users who should be able to log into the `flowkit` account
   once the machine is provisioned.
 
+- Set the environment variables `HOST` and `SSH_PROVISIONING_USER` to the host
+  of the machine to be provisioned and the username of the provisioning user.
+  Note that this user needs admin permissions because it needs to be able to
+  install packages on the system. For a cloud VM the provisioning user will
+  typically be the root user
+
+  Optionally, you can also set the environment variables `FLOWKIT_USER_NAME`
+  and `FLOWKIT_USER_PASSWORD_SHA512`. These specify the username and (hashed)
+  password of the user account that will install FlowKit. The default username
+  is `flowkit` (with the password being the same). Note that the password env
+  var must contain the password in _hashed_ form. See the Ansible
+  [FAQ](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module)
+  for details how to determine a SHA512 hash of the password.
+
+  Here is an example:
+  ```bash
+  # Required
+  export HOST=<some_host_name>
+  export SSH_PROVISIONING_USER=root
+
+  # Optional (only needed if you want to change the username or password).
+  # See here for details how to determine the password hash:
+  #    https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module
+  export FLOWKIT_USER_NAME=flowkit
+  export FLOWKIT_USER_PASSWORD='$6$YaOatFoRa91eOA06$cLJCvJCdd0sLKBEM01eQ2wJ7ZKkTZJz.YWGFK5r0bs4yqiwAz1Lw9pmExiS.PPBBJv13cuBpiHYU88ThX4TeG/'
+  ```
+
 - Finally, run the following command (make sure you don't forget the comma
   after `${HOST}` if you type it manually):
-  ```
+  ```bash
   pipenv install
   pipenv run ansible-galaxy install -p ./roles -r requirements.yml
-  pipenv run ansible-playbook -i ${HOST}, --user=${SSH_USER} provision.yml
+
+  # Option 1 (using the default username and password)
+  pipenv run ansible-playbook -i ${HOST}, --user=${SSH_PROVISIONING_USER} provision.yml
+
+  # Option 2 (run this line if you changed the username or password above)
+  pipenv run ansible-playbook -i ${HOST}, --user=${SSH_PROVISIONING_USER} --extra-vars="username=${FLOWKIT_USER_NAME} password=${FLOWKIT_USER_PASSWORD_SHA512}" provision.yml
   ```
 
 You can also replace `provision.yml` with `provision-dev.yml` in the last line.
-This runs the standard provisioning (the same as in `provision.yml`) and will also
-install Python 3 via `pyenv` and clone the FlowKit repository at `/home/flowkit/code/FlowKit`.
+In addition to the standard provisioning tasks (the same as in `provision.yml`)
+this will also install Python 3 via `pyenv` and clone the FlowKit repository
+at `/home/flowkit/code/FlowKit`.
 
 This has been tested with CentOS Linux release 7.5.1804.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -14,7 +14,12 @@ To provision the machine:
   of the machine to be provisioned and the username of the provisioning user.
   Note that this user needs admin permissions because it needs to be able to
   install packages on the system. For a cloud VM the provisioning user will
-  typically be the root user
+  typically be the root user.
+
+  You should also set `PROVISIONING_PLAYBOOK` to either `provision.yml` or
+  `provision-dev.yml`. In addition to the standard provisioning tasks (the
+  same as in `provision.yml`), the latter will also install Python 3 via
+  `pyenv` and clone the FlowKit repository at `/home/flowkit/code/FlowKit`.
 
   Optionally, you can also set the environment variables `FLOWKIT_USER_NAME`
   and `FLOWKIT_USER_PASSWORD_SHA512`. These specify the username and (hashed)
@@ -35,6 +40,7 @@ To provision the machine:
   # Required settings
   export HOST=<some_host_name>
   export SSH_PROVISIONING_USER=root
+  export PROVISIONING_PLAYBOOK=provision.yml  # alternatively, use "provision-dev.yml"
 
   # Optional (only needed if you want to change the username or password).
   # See above how to determine the hashed password.
@@ -46,15 +52,10 @@ To provision the machine:
   after `${HOST}` if you type it manually):
   ```bash
   # Option 1 (using the default username and password)
-  pipenv run ansible-playbook -i ${HOST}, --user=${SSH_PROVISIONING_USER} provision.yml
+  pipenv run ansible-playbook -i ${HOST}, --user=${SSH_PROVISIONING_USER} ${PROVISIONING_PLAYBOOK}
 
   # Option 2 (run this line if you changed the username or password above)
-  pipenv run ansible-playbook -i ${HOST}, --user=${SSH_PROVISIONING_USER} --extra-vars="username=${FLOWKIT_USER_NAME} password=${FLOWKIT_USER_PASSWORD_SHA512}" provision.yml
+  pipenv run ansible-playbook -i ${HOST}, --user=${SSH_PROVISIONING_USER} --extra-vars="username=${FLOWKIT_USER_NAME} password=${FLOWKIT_USER_PASSWORD_SHA512}" ${PROVISIONING_PLAYBOOK}
   ```
-
-You can also replace `provision.yml` with `provision-dev.yml` in the previous commands.
-In addition to the standard provisioning tasks (the same as in `provision.yml`)
-this will also install Python 3 via `pyenv` and clone the FlowKit repository
-at `/home/flowkit/code/FlowKit`.
 
 This has been tested with CentOS Linux release 7.5.1804.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -21,13 +21,13 @@ To provision the machine:
   same as in `provision.yml`), the latter will also install Python 3 via
   `pyenv` and clone the FlowKit repository at `/home/flowkit/code/FlowKit`.
 
-  Optionally, you can also set the environment variables `FLOWKIT_USER_NAME`
+  You also need to set the environment variables `FLOWKIT_USER_NAME`
   and `FLOWKIT_USER_PASSWORD_SHA512`. These specify the username and (hashed)
-  password of the user account that will install FlowKit. The default username
-  is `flowkit` (with the password being the same). Note that the password env
-  var must contain the password in _hashed_ form. You can determine this using
-  the following command (which presents an interactive prompt where you can
-  enter the password):
+  password of the user account that will install FlowKit. The default values
+  are given below (simply use these if you want to keep the default username
+  and password `flowkit:flowkit`). Note that the password env var must contain
+  the password in _hashed_ form. You can determine this using the following
+  command (which presents you with an interactive prompt to enter the password):
   ```bash
   pipenv run python -c "from passlib.hash import sha512_crypt; import getpass; print(sha512_crypt.using(rounds=5000).hash(getpass.getpass()))"
   ```
@@ -35,15 +35,14 @@ To provision the machine:
   [FAQ](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module)
   for alternative methods to determine a SHA512 hash of the password.)
 
-  Here is an example setting the relevant environment variables:
+  Here is an example how to set the relevant environment variables:
   ```bash
-  # Required settings
   export HOST=<some_host_name>
   export SSH_PROVISIONING_USER=root
   export PROVISIONING_PLAYBOOK=provision.yml  # alternatively, use "provision-dev.yml"
 
-  # Optional (only needed if you want to change the username or password).
-  # See above how to determine the hashed password.
+  # Use the values below to keep the default username/password (`flowkit:flowkit`), or
+  # change them to use different values. See above how to determine the hashed password.
   export FLOWKIT_USER_NAME=flowkit
   export FLOWKIT_USER_PASSWORD='$6$YaOatFoRa91eOA06$cLJCvJCdd0sLKBEM01eQ2wJ7ZKkTZJz.YWGFK5r0bs4yqiwAz1Lw9pmExiS.PPBBJv13cuBpiHYU88ThX4TeG/'
   ```
@@ -51,10 +50,6 @@ To provision the machine:
 - Finally, run the following command (make sure you don't forget the comma
   after `${HOST}` if you type it manually):
   ```bash
-  # Option 1 (using the default username and password)
-  pipenv run ansible-playbook -i ${HOST}, --user=${SSH_PROVISIONING_USER} ${PROVISIONING_PLAYBOOK}
-
-  # Option 2 (run this line if you changed the username or password above)
   pipenv run ansible-playbook -i ${HOST}, --user=${SSH_PROVISIONING_USER} --extra-vars="username=${FLOWKIT_USER_NAME} password=${FLOWKIT_USER_PASSWORD_SHA512}" ${PROVISIONING_PLAYBOOK}
   ```
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -5,7 +5,7 @@ To provision the machine:
   pipenv install
   ```
 
-- Create a file called `ssh_keys/authorized_keys.txt` which contains the public
+- Create a file called `./ssh_keys/authorized_keys.txt` which contains the public
   SSH keys of the users who should be able to log into the `flowkit` account
   once the machine is provisioned.
 

--- a/deployment/provision-dev.yml
+++ b/deployment/provision-dev.yml
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+---
+- hosts: all
+  roles:
+    - base_packages
+    - docker
+    - user_accounts
+    - role: avanov.pyenv
+      pyenv_env: "system"
+      pyenv_path: "/usr/local/pyenv"
+      pyenv_owner: "{{ ansible_user }}"
+      pyenv_global: "3.7.3"
+      pyenv_python_versions:
+       - "3.7.3"
+      pyenv_virtualenvs:
+       - venv_name: "v3.7.3"
+         py_version: "3.7.3"
+
+  tasks:
+    - name: "Clone FlowKit repo"
+      become: yes
+      become_user: flowkit
+      git:
+        repo: 'https://github.com/Flowminder/FlowKit.git'
+        dest: ~flowkit/code/FlowKit
+        version: master
+        update: no

--- a/deployment/provision-dev.yml
+++ b/deployment/provision-dev.yml
@@ -4,27 +4,33 @@
 
 ---
 - hosts: all
+  vars:
+    username: flowkit
+    password: "$6$YaOatFoRa91eOA06$cLJCvJCdd0sLKBEM01eQ2wJ7ZKkTZJz.YWGFK5r0bs4yqiwAz1Lw9pmExiS.PPBBJv13cuBpiHYU88ThX4TeG/"
+    pyenv_global_python_version: "3.7.3"
   roles:
     - base_packages
     - docker
-    - user_accounts
+    - role: user_accounts
+      USERNAME: "{{ username }}"
+      PASSWORD: "{{ password }}"
     - role: avanov.pyenv
       pyenv_env: "system"
       pyenv_path: "/usr/local/pyenv"
       pyenv_owner: "{{ ansible_user }}"
-      pyenv_global: "3.7.3"
+      pyenv_global: "{{ pyenv_global_python_version }}"
       pyenv_python_versions:
-       - "3.7.3"
+       - "{{ pyenv_global_python_version }}"
       pyenv_virtualenvs:
-       - venv_name: "v3.7.3"
-         py_version: "3.7.3"
+       - venv_name: "v{{ pyenv_global_python_version }}"
+         py_version: "{{ pyenv_global_python_version }}"
 
   tasks:
     - name: "Clone FlowKit repo"
       become: yes
-      become_user: flowkit
+      become_user: "{{ username }}"
       git:
-        repo: 'https://github.com/Flowminder/FlowKit.git'
-        dest: ~flowkit/code/FlowKit
+        repo: "https://github.com/Flowminder/FlowKit.git"
+        dest: "~{{ username }}/code/FlowKit"
         version: master
         update: no

--- a/deployment/provision-dev.yml
+++ b/deployment/provision-dev.yml
@@ -7,6 +7,7 @@
   vars:
     username: flowkit
     password: "$6$YaOatFoRa91eOA06$cLJCvJCdd0sLKBEM01eQ2wJ7ZKkTZJz.YWGFK5r0bs4yqiwAz1Lw9pmExiS.PPBBJv13cuBpiHYU88ThX4TeG/"
+    pyenv_path: "/usr/local/pyenv"
     pyenv_global_python_version: "3.7.3"
   roles:
     - base_packages
@@ -16,7 +17,6 @@
       password: "{{ password }}"
     - role: avanov.pyenv
       pyenv_env: "system"
-      pyenv_path: "/usr/local/pyenv"
       pyenv_owner: "{{ ansible_user }}"
       pyenv_global: "{{ pyenv_global_python_version }}"
       pyenv_python_versions:
@@ -26,6 +26,10 @@
          py_version: "{{ pyenv_global_python_version }}"
 
   tasks:
+    - name: "Install pipenv"
+      pip:
+        name: pipenv
+        executable: "{{ pyenv_path }}/shims/pip"
     - name: "Clone FlowKit repo"
       become: yes
       become_user: "{{ username }}"

--- a/deployment/provision-dev.yml
+++ b/deployment/provision-dev.yml
@@ -12,8 +12,8 @@
     - base_packages
     - docker
     - role: user_accounts
-      USERNAME: "{{ username }}"
-      PASSWORD: "{{ password }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
     - role: avanov.pyenv
       pyenv_env: "system"
       pyenv_path: "/usr/local/pyenv"

--- a/deployment/provision.yml
+++ b/deployment/provision.yml
@@ -4,7 +4,13 @@
 
 ---
 - hosts: all
+  vars:
+    username: flowkit
+    password: "$6$YaOatFoRa91eOA06$cLJCvJCdd0sLKBEM01eQ2wJ7ZKkTZJz.YWGFK5r0bs4yqiwAz1Lw9pmExiS.PPBBJv13cuBpiHYU88ThX4TeG/"
+    pyenv_global_python_version: "3.7.3"
   roles:
     - base_packages
     - docker
-    - user_accounts
+    - role: user_accounts
+      username: "{{ username }}"
+      password: "{{ password }}"

--- a/deployment/provision.yml
+++ b/deployment/provision.yml
@@ -7,7 +7,6 @@
   vars:
     username: flowkit
     password: "$6$YaOatFoRa91eOA06$cLJCvJCdd0sLKBEM01eQ2wJ7ZKkTZJz.YWGFK5r0bs4yqiwAz1Lw9pmExiS.PPBBJv13cuBpiHYU88ThX4TeG/"
-    pyenv_global_python_version: "3.7.3"
   roles:
     - base_packages
     - docker

--- a/deployment/requirements.yml
+++ b/deployment/requirements.yml
@@ -1,0 +1,2 @@
+# Install pyenv role from the Ansible Galaxy
+- src: avanov.pyenv

--- a/deployment/roles/base_packages/tasks/main.yml
+++ b/deployment/roles/base_packages/tasks/main.yml
@@ -13,7 +13,7 @@
   become: yes
   become_user: root
   yum:
-    name: ['ack', 'bash-completion-extras', 'colordiff', 'emacs', 'git', 'postgresql', 'tmux', 'tree', 'ufw', 'unzip', 'vim', 'wget']
+    name: ['ack', 'bash-completion-extras', 'colordiff', 'emacs', 'git', 'ncdu', 'postgresql', 'tmux', 'tree', 'ufw', 'unzip', 'vim', 'wget']
     update_cache: yes
 
 - name: "Ensure sshd always restarts"

--- a/deployment/roles/user_accounts/defaults/main.yml
+++ b/deployment/roles/user_accounts/defaults/main.yml
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+---
+USERNAME: "flowkit"
+PASSWORD: "$6$YaOatFoRa91eOA06$cLJCvJCdd0sLKBEM01eQ2wJ7ZKkTZJz.YWGFK5r0bs4yqiwAz1Lw9pmExiS.PPBBJv13cuBpiHYU88ThX4TeG/"
+AUTHORIZED_KEYS_FILE: "./ssh_keys/authorized_keys.txt"

--- a/deployment/roles/user_accounts/defaults/main.yml
+++ b/deployment/roles/user_accounts/defaults/main.yml
@@ -3,6 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 ---
-USERNAME: "flowkit"
-PASSWORD: "$6$YaOatFoRa91eOA06$cLJCvJCdd0sLKBEM01eQ2wJ7ZKkTZJz.YWGFK5r0bs4yqiwAz1Lw9pmExiS.PPBBJv13cuBpiHYU88ThX4TeG/"
-AUTHORIZED_KEYS_FILE: "./ssh_keys/authorized_keys.txt"
+username: "flowkit"
+password: "$6$YaOatFoRa91eOA06$cLJCvJCdd0sLKBEM01eQ2wJ7ZKkTZJz.YWGFK5r0bs4yqiwAz1Lw9pmExiS.PPBBJv13cuBpiHYU88ThX4TeG/"
+authorized_keys_file: "./ssh_keys/authorized_keys.txt"

--- a/deployment/roles/user_accounts/tasks/main.yml
+++ b/deployment/roles/user_accounts/tasks/main.yml
@@ -2,18 +2,26 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-- name: "Create user 'flowkit'"
+- name: "Create user '{{ USERNAME }}'"
   become: yes
   user:
-    name: flowkit
+    name: "{{ USERNAME }}"
     state: present
     groups: docker, wheel
-    password: "$6$YaOatFoRa91eOA06$cLJCvJCdd0sLKBEM01eQ2wJ7ZKkTZJz.YWGFK5r0bs4yqiwAz1Lw9pmExiS.PPBBJv13cuBpiHYU88ThX4TeG/"
+    password: "{{ PASSWORD }}"
+
+- name: "Check that file {{ AUTHORIZED_KEYS_FILE }} exists"
+  local_action: stat path="{{ playbook_dir }}/{{ AUTHORIZED_KEYS_FILE }}"
+  register: p
+- debug:
+    msg: "Please add public ssh keys to the file: {{ playbook_dir }}/{{ AUTHORIZED_KEYS_FILE }}"
+  when: not p.stat.exists
+  failed_when: not p.stat.exists
 
 - name: "Enable ssh access for users defined above"
   authorized_key:
     user: "{{ item }}"
     state: present
-    key: "{{ lookup('file', playbook_dir + '/ssh_keys/authorized_keys.txt') }}"
+    key: "{{ lookup('file', playbook_dir + '/' + AUTHORIZED_KEYS_FILE) }}"
   with_items:
-    - flowkit
+    - "{{ USERNAME }}"

--- a/deployment/roles/user_accounts/tasks/main.yml
+++ b/deployment/roles/user_accounts/tasks/main.yml
@@ -2,19 +2,19 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-- name: "Create user '{{ USERNAME }}'"
+- name: "Create user '{{ username }}'"
   become: yes
   user:
-    name: "{{ USERNAME }}"
+    name: "{{ username }}"
     state: present
     groups: docker, wheel
-    password: "{{ PASSWORD }}"
+    password: "{{ password }}"
 
-- name: "Check that file {{ AUTHORIZED_KEYS_FILE }} exists"
-  local_action: stat path="{{ playbook_dir }}/{{ AUTHORIZED_KEYS_FILE }}"
+- name: "Check that file {{ authorized_keys_file }} exists"
+  local_action: stat path="{{ playbook_dir }}/{{ authorized_keys_file }}"
   register: p
 - debug:
-    msg: "Please add public ssh keys to the file: {{ playbook_dir }}/{{ AUTHORIZED_KEYS_FILE }}"
+    msg: "Please add public ssh keys to the file: {{ playbook_dir }}/{{ authorized_keys_file }}"
   when: not p.stat.exists
   failed_when: not p.stat.exists
 
@@ -22,6 +22,6 @@
   authorized_key:
     user: "{{ item }}"
     state: present
-    key: "{{ lookup('file', playbook_dir + '/' + AUTHORIZED_KEYS_FILE) }}"
+    key: "{{ lookup('file', playbook_dir + '/' + authorized_keys_file) }}"
   with_items:
-    - "{{ USERNAME }}"
+    - "{{ username }}"

--- a/deployment/roles/user_accounts/tasks/main.yml
+++ b/deployment/roles/user_accounts/tasks/main.yml
@@ -20,8 +20,6 @@
 
 - name: "Enable ssh access for users defined above"
   authorized_key:
-    user: "{{ item }}"
+    user: "{{ username }}"
     state: present
     key: "{{ lookup('file', playbook_dir + '/' + authorized_keys_file) }}"
-  with_items:
-    - "{{ username }}"


### PR DESCRIPTION
### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [X] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [X] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This PR tweaks the deployment Ansible scripts as follows:
- Allows configuring the username/password of the FlowKit user account on the machine to be provisioned.
- Adds a "dev" version of the provisioning script which also installs pyenv, Python 3.7 (via pyenv) and clones the FlowKit repository.

I have been using these locally a few times so thought we might as well integrate them here to make setting up a VM with the correct Python version more convenient.