### PR TITLE
One line demo startup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,7 +682,6 @@ workflows:
           component: flowmachine
           requires:
             - run_flowmachine_tests
-            - integration_tests
           <<: *run_always_org_context
       - build_docs:
           name: build_docs
@@ -702,7 +701,6 @@ workflows:
           component: flowapi
           requires:
             - run_flowkit_api_tests
-            - integration_tests
           <<: *run_always_org_context
       - build_python_wheel:
           name: build_flowclient_wheel
@@ -733,19 +731,13 @@ workflows:
       - retag_images:
           name: retag_master_branch
           requires:
-            - build_flowmachine
-            - build_flowdb
-            - build_flowapi
-            - build_flowauth
+            - test_quickstart
             - build_docs
           <<: *master_only_org_context
       - retag_images:
           name: retag_tagged_build
           requires:
-            - build_flowmachine
-            - build_flowdb
-            - build_flowapi
-            - build_flowauth
+            - test_quickstart
             - build_docs
           tag: CIRCLE_TAG
           <<: *tag_only_org_context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,6 +506,17 @@ jobs:
           path: test_results
       - run: bash <(curl -s https://codecov.io/bash)
 
+  test_quickstart:
+    machine:
+      image: circleci/classic:201808-01
+    working_directory: /home/circleci/project
+    environment:
+      BRANCH: $CIRCLE_BRANCH
+    steps:
+      - checkout:
+          path: /home/circleci/project/
+      - run: ./quick_start.sh
+
   build_docs:
     parameters:
       deploy:
@@ -706,6 +717,13 @@ workflows:
           requires:
             - run_flowmachine_tests
             - integration_tests
+          <<: *run_always_org_context
+      - test_quickstart:
+          requires:
+            - build_flowdb
+            - build_flowapi
+            - build_flowmachine
+            - build_flowauth
           <<: *run_always_org_context
       - integration_tests:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,6 +516,7 @@ jobs:
       - checkout:
           path: /home/circleci/project/
       - run: ./quick_start.sh
+      - run: ./quick_start.sh stop
 
   build_docs:
     parameters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- A new Ansible playbook was added in `deployment/provision-dev.yml`. In addition to the standard provisioning
+  this installs pyenv, Python 3.7, pipenv and clones the FlowKit repository, which is useful for development purposes.
+- Added a 'quick start' setup script for trying out a complete FlowKit system [#688](https://github.com/Flowminder/FlowKit/issues/688).
 
 ### Changed
-- FlowAPI's `available_dates` endpoint now always returns available dates for all event types and does not accept JSON 
+- FlowAPI's `available_dates` endpoint now always returns available dates for all event types and does not accept JSON
 - Hints are now displayed in the add user form of FlowAuth if the form is not completed [#679](https://github.com/Flowminder/FlowKit/issues/679)
+- The Ansible playbooks in `deployment/` now allow configuring the username and password for the FlowKit user account.
+- Default compose file no longer includes build blocks, these have been moved to 
 
 ### Fixed
 - FlowDB synthetic data container no longer silently fails to generate data if data generator is not set [#654](https://github.com/Flowminder/FlowKit/issues/654)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - FlowAPI's `available_dates` endpoint now always returns available dates for all event types and does not accept JSON
 - Hints are now displayed in the add user form of FlowAuth if the form is not completed [#679](https://github.com/Flowminder/FlowKit/issues/679)
 - The Ansible playbooks in `deployment/` now allow configuring the username and password for the FlowKit user account.
-- Default compose file no longer includes build blocks, these have been moved to 
+- Default compose file no longer includes build blocks, these have been moved to `docker-compose-build.yml`.
 
 ### Fixed
 - FlowDB synthetic data container no longer silently fails to generate data if data generator is not set [#654](https://github.com/Flowminder/FlowKit/issues/654)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@
 #
 # flowmachine and flowapi will connected to the first flowdb service in the list.
 
-DOCKER_COMPOSE_FILE_DEV ?= docker-compose.yml
+DOCKER_COMPOSE_FILE ?= docker-compose.yml
+DOCKER_COMPOSE_FILE_BUILD ?= docker-compose-build.yml
 FLOWDB_SERVICES ?= flowdb_testdata
 DOCKER_SERVICES ?= $(FLOWDB_SERVICES) flowapi flowmachine flowauth query_locker
 export DOCKER_FLOWDB_HOST=$(word 1, $(FLOWDB_SERVICES))
@@ -27,20 +28,20 @@ export DOCKER_FLOWDB_HOST=$(word 1, $(FLOWDB_SERVICES))
 all:
 
 up: flowdb-build
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d --build $(DOCKER_SERVICES)
+	docker-compose -f $(DOCKER_COMPOSE_FILE) -f $(DOCKER_COMPOSE_FILE_BUILD)  up -d --build $(DOCKER_SERVICES)
 
 up-no_build:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d $(DOCKER_SERVICES)
+	docker-compose -f $(DOCKER_COMPOSE_FILE) up -d $(DOCKER_SERVICES)
 
 down:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) down
+	docker-compose -f $(DOCKER_COMPOSE_FILE) down
 
 
 # Note: the targets below are repetitive and could be simplified by using
 # a pattern rule as follows:
 #
 #   %-up: %-build
-#       docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d --build $*
+#       docker-compose -f $(DOCKER_COMPOSE_FILE) up -d --build $*
 #
 # The reason we are keeping the explicitly spelled-out versions is in order
 # to increase discoverability of the available Makefile targets and to enable
@@ -48,67 +49,67 @@ down:
 
 
 flowdb-up: flowdb-build
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d --build flowdb
+	docker-compose -f $(DOCKER_COMPOSE_FILE) -f $(DOCKER_COMPOSE_FILE_BUILD) up -d --build flowdb
 
 flowdb-down:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) rm -f -s -v flowdb
+	docker-compose -f $(DOCKER_COMPOSE_FILE) rm -f -s -v flowdb
 
 flowdb-build:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) build flowdb
+	docker-compose -f $(DOCKER_COMPOSE_FILE) -f $(DOCKER_COMPOSE_FILE_BUILD) build flowdb
 
 
 flowdb_testdata-up: flowdb_testdata-build
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d --build flowdb_testdata
+	docker-compose -f $(DOCKER_COMPOSE_FILE) -f $(DOCKER_COMPOSE_FILE_BUILD) up -d --build flowdb_testdata
 
 flowdb_testdata-down:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) rm -f -s -v flowdb_testdata
+	docker-compose -f $(DOCKER_COMPOSE_FILE) rm -f -s -v flowdb_testdata
 
 flowdb_testdata-build: flowdb-build
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) build flowdb_testdata
+	docker-compose -f $(DOCKER_COMPOSE_FILE) -f $(DOCKER_COMPOSE_FILE_BUILD) build flowdb_testdata
 
 
 flowdb_synthetic_data-up: flowdb_synthetic_data-build
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d --build flowdb_synthetic_data
+	docker-compose -f $(DOCKER_COMPOSE_FILE) -f $(DOCKER_COMPOSE_FILE_BUILD) up -d --build flowdb_synthetic_data
 
 flowdb_synthetic_data-down:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) rm -f -s -v flowdb_synthetic_data
+	docker-compose -f $(DOCKER_COMPOSE_FILE) rm -f -s -v flowdb_synthetic_data
 
 flowdb_synthetic_data-build: flowdb-build
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) build flowdb_synthetic_data
+	docker-compose -f $(DOCKER_COMPOSE_FILE) -f $(DOCKER_COMPOSE_FILE_BUILD) build flowdb_synthetic_data
 
 
 flowmachine-up:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d --build flowmachine
+	docker-compose -f $(DOCKER_COMPOSE_FILE) -f $(DOCKER_COMPOSE_FILE_BUILD) up -d --build flowmachine
 
 flowmachine-down:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) rm -f -s -v flowmachine
+	docker-compose -f $(DOCKER_COMPOSE_FILE) rm -f -s -v flowmachine
 
 flowmachine-build:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) build flowmachine
+	docker-compose -f $(DOCKER_COMPOSE_FILE) -f $(DOCKER_COMPOSE_FILE_BUILD) build flowmachine
 
 
 flowapi-up:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d --build flowapi
+	docker-compose -f $(DOCKER_COMPOSE_FILE) -f $(DOCKER_COMPOSE_FILE_BUILD) up -d --build flowapi
 
 flowapi-down:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) rm -f -s -v flowapi
+	docker-compose -f $(DOCKER_COMPOSE_FILE) rm -f -s -v flowapi
 
 flowapi-build:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) build flowapi
+	docker-compose -f $(DOCKER_COMPOSE_FILE) -f $(DOCKER_COMPOSE_FILE_BUILD) build flowapi
 
 
 flowauth-up:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d --build flowauth
+	docker-compose -f $(DOCKER_COMPOSE_FILE) -f $(DOCKER_COMPOSE_FILE_BUILD) up -d --build flowauth
 
 flowauth-down:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) rm -f -s -v flowauth
+	docker-compose -f $(DOCKER_COMPOSE_FILE) rm -f -s -v flowauth
 
 flowauth-build:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) build flowauth
+	docker-compose -f $(DOCKER_COMPOSE_FILE) -f $(DOCKER_COMPOSE_FILE_BUILD) build flowauth
 
 
 query_locker-up:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) up -d query_locker
+	docker-compose -f $(DOCKER_COMPOSE_FILE) up -d query_locker
 
 query_locker-down:
-	docker-compose -f $(DOCKER_COMPOSE_FILE_DEV) rm -f -s -v query_locker
+	docker-compose -f $(DOCKER_COMPOSE_FILE) rm -f -s -v query_locker

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 DOCKER_COMPOSE_FILE ?= docker-compose.yml
 DOCKER_COMPOSE_FILE_BUILD ?= docker-compose-build.yml
 FLOWDB_SERVICES ?= flowdb_testdata
-DOCKER_SERVICES ?= $(FLOWDB_SERVICES) flowapi flowmachine flowauth query_locker
+DOCKER_SERVICES ?= $(FLOWDB_SERVICES) flowapi flowmachine flowauth flowmachine_query_locker
 export DOCKER_FLOWDB_HOST=$(word 1, $(FLOWDB_SERVICES))
 
 
@@ -108,8 +108,8 @@ flowauth-build:
 	docker-compose -f $(DOCKER_COMPOSE_FILE) -f $(DOCKER_COMPOSE_FILE_BUILD) build flowauth
 
 
-query_locker-up:
-	docker-compose -f $(DOCKER_COMPOSE_FILE) up -d query_locker
+flowmachine_query_locker-up:
+	docker-compose -f $(DOCKER_COMPOSE_FILE) up -d flowmachine_query_locker
 
-query_locker-down:
-	docker-compose -f $(DOCKER_COMPOSE_FILE) rm -f -s -v query_locker
+flowmachine_query_locker-down:
+	docker-compose -f $(DOCKER_COMPOSE_FILE) rm -f -s -v flowmachine_query_locker

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -1,0 +1,43 @@
+#
+# DOCKER COMPOSE BUILDER FOR FLOWKIT
+#
+
+version: '3.7'
+
+services:
+
+  flowdb:
+    image: flowminder/flowdb:latest
+    build:
+      context: ./flowdb/
+      dockerfile: Dockerfile
+
+  flowdb_testdata:
+    image: flowminder/flowdb-testdata:latest
+    build:
+      context: ./flowdb/testdata/
+      dockerfile: Dockerfile
+
+  flowdb_synthetic_data:
+    image: flowminder/flowdb-synthetic-data:latest
+    build:
+      context: ./flowdb/testdata/
+      dockerfile: Dockerfile.synthetic_data
+
+  flowmachine:
+    image: flowminder/flowmachine:latest
+    build:
+      context: ./flowmachine
+      dockerfile: Dockerfile
+
+  flowapi:
+    image: flowminder/flowapi:latest
+    build:
+      context: ./flowapi
+      dockerfile: Dockerfile
+
+  flowauth:
+    image: flowminder/flowauth:latest
+    build:
+      context: ./flowauth
+      dockerfile: Dockerfile

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -1,3 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # DOCKER COMPOSE BUILDER FOR FLOWKIT
 #

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -10,37 +10,37 @@ version: '3.7'
 services:
 
   flowdb:
-    image: flowminder/flowdb:latest
+    image: flowminder/flowdb:${CONTAINER_TAG:-latest}
     build:
       context: ./flowdb/
       dockerfile: Dockerfile
 
   flowdb_testdata:
-    image: flowminder/flowdb-testdata:latest
+    image: flowminder/flowdb-testdata:${CONTAINER_TAG:-latest}
     build:
       context: ./flowdb/testdata/
       dockerfile: Dockerfile
 
   flowdb_synthetic_data:
-    image: flowminder/flowdb-synthetic-data:latest
+    image: flowminder/flowdb-synthetic-data:${CONTAINER_TAG:-latest}
     build:
       context: ./flowdb/testdata/
       dockerfile: Dockerfile.synthetic_data
 
   flowmachine:
-    image: flowminder/flowmachine:latest
+    image: flowminder/flowmachine:${CONTAINER_TAG:-latest}
     build:
       context: ./flowmachine
       dockerfile: Dockerfile
 
   flowapi:
-    image: flowminder/flowapi:latest
+    image: flowminder/flowapi:${CONTAINER_TAG:-latest}
     build:
       context: ./flowapi
       dockerfile: Dockerfile
 
   flowauth:
-    image: flowminder/flowauth:latest
+    image: flowminder/flowauth:${CONTAINER_TAG:-latest}
     build:
       context: ./flowauth
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # DOCKER COMPOSE FOR FLOWKIT
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,6 @@ services:
   flowdb:
     container_name: flowdb
     image: flowminder/flowdb:latest
-    build:
-      context: ./flowdb/
-      dockerfile: Dockerfile
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
 
@@ -44,9 +41,6 @@ services:
   flowdb_testdata:
     container_name: flowdb_testdata
     image: flowminder/flowdb-testdata:latest
-    build:
-      context: ./flowdb/testdata/
-      dockerfile: Dockerfile
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
     environment:
@@ -63,9 +57,6 @@ services:
   flowdb_synthetic_data:
     container_name: flowdb_synthetic_data
     image: flowminder/flowdb-synthetic-data:latest
-    build:
-      context: ./flowdb/testdata/
-      dockerfile: Dockerfile.synthetic_data
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
     environment:
@@ -96,9 +87,6 @@ services:
   flowmachine:
     container_name: flowmachine
     image: flowminder/flowmachine:latest
-    build:
-      context: ./flowmachine
-      dockerfile: Dockerfile
     ports:
       - ${FLOWMACHINE_PORT:?Must set FLOWMACHINE_PORT env var}:5555
     depends_on:
@@ -125,9 +113,6 @@ services:
   flowapi:
     container_name: flowapi
     image: flowminder/flowapi:latest
-    build:
-      context: ./flowapi
-      dockerfile: Dockerfile
     ports:
       - ${FLOWAPI_PORT:?Must set FLOWAPI_PORT env var}:9090
     environment:
@@ -149,9 +134,6 @@ services:
   flowauth:
     container_name: flowauth
     image: flowminder/flowauth:latest
-    build:
-      context: ./flowauth
-      dockerfile: Dockerfile
     ports:
       - ${FLOWAUTH_PORT:?Must set FLOWAUTH_PORT env var}:80
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
     ports:
       - ${FLOWMACHINE_PORT:?Must set FLOWMACHINE_PORT env var}:5555
     depends_on:
-      - query_locker
+      - flowmachine_query_locker
     tty: true
     stdin_open: true
     environment:
@@ -104,7 +104,7 @@ services:
       - FLOWDB_HOST=${DOCKER_FLOWDB_HOST:?Must set DOCKER_FLOWDB_HOST env var}
       - FLOWMACHINE_FLOWDB_USER=${FLOWMACHINE_FLOWDB_USER:?Must set FLOWMACHINE_FLOWDB_USER env var}
       - FLOWMACHINE_FLOWDB_PASSWORD=${FLOWMACHINE_FLOWDB_PASSWORD:?Must set FLOWMACHINE_FLOWDB_PASSWORD env var}
-      - REDIS_HOST=query_locker
+      - REDIS_HOST=flowmachine_query_locker
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:?Must set REDIS_PASSWORD env var}
     restart: always
@@ -142,8 +142,8 @@ services:
     environment:
       DEMO_MODE: ${DEMO_MODE:?Must set DEMO_MODE env var}
 
-  query_locker:
-    container_name: query_locker
+  flowmachine_query_locker:
+    container_name: flowmachine_query_locker
     image: bitnami/redis
     ports:
       - ${REDIS_PORT:?Must set REDIS_PORT env var}:6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   flowdb:
     container_name: flowdb
-    image: flowminder/flowdb:latest
+    image: flowminder/flowdb:${CONTAINER_TAG:-latest}
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
 
@@ -43,7 +43,7 @@ services:
 
   flowdb_testdata:
     container_name: flowdb_testdata
-    image: flowminder/flowdb-testdata:latest
+    image: flowminder/flowdb-testdata:${CONTAINER_TAG:-latest}
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
     environment:
@@ -59,7 +59,7 @@ services:
 
   flowdb_synthetic_data:
     container_name: flowdb_synthetic_data
-    image: flowminder/flowdb-synthetic-data:latest
+    image: flowminder/flowdb-synthetic-data:${CONTAINER_TAG:-latest}
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
     environment:
@@ -89,7 +89,7 @@ services:
 
   flowmachine:
     container_name: flowmachine
-    image: flowminder/flowmachine:latest
+    image: flowminder/flowmachine:${CONTAINER_TAG:-latest}
     ports:
       - ${FLOWMACHINE_PORT:?Must set FLOWMACHINE_PORT env var}:5555
     depends_on:
@@ -115,7 +115,7 @@ services:
 
   flowapi:
     container_name: flowapi
-    image: flowminder/flowapi:latest
+    image: flowminder/flowapi:${CONTAINER_TAG:-latest}
     ports:
       - ${FLOWAPI_PORT:?Must set FLOWAPI_PORT env var}:9090
     environment:
@@ -136,7 +136,7 @@ services:
 
   flowauth:
     container_name: flowauth
-    image: flowminder/flowauth:latest
+    image: flowminder/flowauth:${CONTAINER_TAG:-latest}
     ports:
       - ${FLOWAUTH_PORT:?Must set FLOWAUTH_PORT env var}:80
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
       DEMO_MODE: ${DEMO_MODE:?Must set DEMO_MODE env var}
 
   query_locker:
-    container_name: redis_flowkit
+    container_name: query_locker
     image: bitnami/redis
     ports:
       - ${REDIS_PORT:?Must set REDIS_PORT env var}:6379

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -7,7 +7,7 @@
 set -e
 
 export FLOWDB_SERVICES="flowdb_synthetic_data"
-export DOCKER_SERVICES="flowdb_synthetic_data query_locker"
+export DOCKER_SERVICES="flowdb_synthetic_data flowmachine_query_locker"
 
 KillJobs() {
     for job in $(jobs -p); do

--- a/docs/source/analyst.md
+++ b/docs/source/analyst.md
@@ -38,4 +38,4 @@ To connect FlowClient to FlowAPI, an access token must be generated using FlowAu
 
 ## FlowAPI
 
-Advanced users may wish to write their own clients that interface directly to FlowAPI. This is discussed in more detail in the [Developer](4-developer.md) section of these documents.
+Advanced users may wish to write their own clients that interface directly to FlowAPI. This is discussed in more detail in the [Developer](developer.md) section of these documents.

--- a/docs/source/dev_environment_setup.md
+++ b/docs/source/dev_environment_setup.md
@@ -92,7 +92,7 @@ CONTAINER ID        IMAGE                               COMMAND                 
 e57c8eeb7d38        flowminder/flowmachine:latest       "/bin/sh -c 'pipenv …"   5 minutes ago       Up 5 minutes        0.0.0.0:5555->5555/tcp             flowmachine
 3d54ce0c4484        flowminder/flowapi:latest           "/bin/sh -c 'pipenv …"   5 minutes ago       Up 5 minutes        0.0.0.0:9090->9090/tcp             flowapi
 89e9575c8d42        flowminder/flowauth:latest          "/entrypoint.sh /sta…"   5 minutes ago       Up 5 minutes        443/tcp, 0.0.0.0:8080->80/tcp      flowauth
-384355e94ae6        bitnami/redis                       "/entrypoint.sh /run…"   5 minutes ago       Up 5 minutes        0.0.0.0:6379->6379/tcp             query_locker
+384355e94ae6        bitnami/redis                       "/entrypoint.sh /run…"   5 minutes ago       Up 5 minutes        0.0.0.0:6379->6379/tcp             flowmachine_query_locker
 ```
 
 **Note:** _Currently there is a glitch which means that `flowmachine` may not start up correctly if `flowdb_testdata`

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -50,7 +50,7 @@ This architecture is shown in the figure below.
 
     A further container is created to host a redis message platform used internally by FlowMachine.  
 
-FlowKit is in active development, visit the project's  [roadmap](4-developer.md#roadmap) to get a sense about upcoming developments.
+FlowKit is in active development, visit the project's  [roadmap](developer.md#roadmap) to get a sense about upcoming developments.
 
 Continue to the FlowKit [installation documents](install.md) to find out what type of install meets your requirements.
 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -23,67 +23,13 @@ These instructions assume use of [Pyenv](https://github.com/pyenv/pyenv) and [Pi
 
 Docker containers for FlowAPI, FlowMachine and FlowDB are provided in the [DockerCloud](https://cloud.docker.com/) repositories `flowminder/flowapi`, `flowminder/flowmachine` and `flowminder/flowdb`, respectively. You will need [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/).
 
-Create a directory for your FlowKit install and move into it. Download the [`docker-compose.yml`](https://github.com/Flowminder/FlowKit/raw/master/docker-compose.yml) file.
-
-```
-wget https://raw.githubusercontent.com/Flowminder/FlowKit/master/docker-compose.yml
-```
-Note, it is possible to replace `master` in the above url to install other releases.
-
-The compose file expects the `JWT_SECRET_KEY` environment variable to be set. It is used on FlowAuth and FlowAPI to sign and verify access to the API.
-
 Start the FlowKit test system by running 
 ```bash
-JWT_SECRET_KEY=secret docker-compose up -d
+bash <(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/master/quick_start.sh)
 ``` 
-This will pull any necessary docker containers, and start the system in the background with the API exposed on port `9090` by default.  
+This will pull any necessary docker containers, and start the system in the background with the API exposed on port `9090` by default, and the FlowAuth authentication system accessible by visiting http://localhost:8000 using your web browser.  
 
-In order to use the test system, now install FlowClient and FlowAuth. 
-
-### Installing FlowAuth
-
-FlowAuth must be installed to provide centralised token based authentication management for FlowKit systems.
-
-
-#### FlowAuth Quickstart
-
-To run a demonstration version of FlowAuth use:
-
-```bash
-docker run -p 8000:80 -e DEMO_MODE=1 flowminder/flowauth
-```
-
-This will start FlowAuth at <a href="http://localhost:8000/" target="_blank">http://localhost:8000</a>, and pre-populate a disposable sqlite database with some dummy data. Log in with either `TEST_ADMIN:DUMMY_PASSWORD` or `TEST_USER:DUMMY_PASSWORD`.
-
-#### Granting user permissions in FlowAuth
-
-The following steps using the FlowAuth administration tool are required to add a user and allow them to generate access tokens to communicate with a FlowKit server through FlowAPI:
-
-1. Log into FlowAuth as an administrator.
-
-2. Under "API Routes", add any applicable API routes (e.g. `daily_location`).
-
-3. Under "Aggregation Units", add any applicable aggregation units (e.g. `admin3`).
-
-3. Under "Servers", add a new server and give it a name and secret key. Note that the Secret Key must match the `JWT_SECRET_KEY` set in the flowapi docker container on this server ('secret' in the example above).
-
-4. Enable any permissions for this server under "API Permissions", and aggregation units under "Aggregation Units".
-
-5. Under "Users", add a new user, and set the username and password.
-
-6. Either:
-    - Add a server to the user, and enable/disable API permissions and aggregation units,
-    <p>
-7. Or:
-    <p>
-    - Under "Groups", add a new group,
-
-    - Add a server to the group, and enable/disable API permissions and aggregation units,
-
-    - Add the user to the group.
-
-
-The user can then log into FlowAuth and generate a token (see the [analyst section](3-analyst.md#flowauth) for instructions).
+In order to use the test system, now install FlowClient. 
 
 
 ### FlowClient <a name="flowclient"> </a>

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -24,10 +24,18 @@ These instructions assume use of [Pyenv](https://github.com/pyenv/pyenv) and [Pi
 Docker containers for FlowAPI, FlowMachine and FlowDB are provided in the [DockerCloud](https://cloud.docker.com/) repositories `flowminder/flowapi`, `flowminder/flowmachine` and `flowminder/flowdb`, respectively. You will need [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/).
 
 Start the FlowKit test system by running 
+
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/master/quick_start.sh)
 ``` 
-This will pull any necessary docker containers, and start the system in the background with the API exposed on port `9090` by default, and the FlowAuth authentication system accessible by visiting http://localhost:8000 using your web browser.  
+
+This will pull any necessary docker containers, and start the system in the background with the API exposed on port `9090` by default, and the FlowAuth authentication system accessible by visiting http://localhost:8000 using your web browser.
+
+The default system includes a small amount of test data. For a test system with considerably more data you can run
+
+```bash
+bash <(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/master/quick_start.sh) synth
+```  
 
 In order to use the test system, now install FlowClient. 
 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -29,7 +29,7 @@ Start the FlowKit test system by running
 bash <(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/master/quick_start.sh)
 ``` 
 
-This will pull any necessary docker containers, and start the system in the background with the API exposed on port `9090` by default, and the FlowAuth authentication system accessible by visiting http://localhost:8000 using your web browser.
+This will pull any necessary docker containers, and start the system in the background with the API exposed on port `9090` by default, and the FlowAuth authentication system accessible by visiting <a href="http://localhost:8000/" target="_blank">http://localhost:8000</a> using your web browser.
 
 The default system includes a small amount of test data. For a test system with considerably more data you can run
 
@@ -37,7 +37,41 @@ The default system includes a small amount of test data. For a test system with 
 bash <(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/master/quick_start.sh) synth
 ```  
 
-In order to use the test system, now install FlowClient. 
+In order to use the test system, now install FlowClient, and generate a token using FlowAuth.
+
+#### FlowAuth Quickstart
+
+Visit <a href="http://localhost:8000/" target="_blank">http://localhost:8000</a> and log in with either `TEST_ADMIN:DUMMY_PASSWORD` or `TEST_USER:DUMMY_PASSWORD`. `TEST_USER` is already set up to generate tokens for the FlowAPI instance started by the quick start script.
+
+#### Granting user permissions in FlowAuth
+
+The following steps using the FlowAuth administration tool are required to add a user and allow them to generate access tokens to communicate with a FlowKit server through FlowAPI:
+
+1. Log into FlowAuth as an administrator.
+
+2. Under "API Routes", add any applicable API routes (e.g. `daily_location`).
+
+3. Under "Aggregation Units", add any applicable aggregation units (e.g. `admin3`).
+
+3. Under "Servers", add a new server and give it a name and secret key. Note that the Secret Key must match the `JWT_SECRET_KEY` set in the flowapi docker container on this server ('secret' in the example above).
+
+4. Enable any permissions for this server under "API Permissions", and aggregation units under "Aggregation Units".
+
+5. Under "Users", add a new user, and set the username and password.
+
+6. Either:
+    - Add a server to the user, and enable/disable API permissions and aggregation units,
+    <p>
+7. Or:
+    <p>
+    - Under "Groups", add a new group,
+
+    - Add a server to the group, and enable/disable API permissions and aggregation units,
+
+    - Add the user to the group.
+
+
+The user can then log into FlowAuth and generate a token (see the [analyst section](analyst.md#flowauth) for instructions).
 
 
 ### FlowClient <a name="flowclient"> </a>
@@ -48,7 +82,7 @@ The FlowClient Python client is used to perform CDR analysis using the JupyterLa
 pip install flowclient
 ```
 
-Quick install is continued with an example of FlowClient usage [here](3-analyst.md#flowclient).
+Quick install is continued with an example of FlowClient usage [here](analyst.md#flowclient).
 
 <a name="developers">
 

--- a/flowauth/backend/flowauth/models.py
+++ b/flowauth/backend/flowauth/models.py
@@ -531,10 +531,10 @@ def make_demodata():  # pragma: no cover
         caps.append(c)
     # Add some servers
     test_server = Server(
-        name="Aruba",
+        name="TEST_SERVER",
         longest_token_life=2880,
         latest_token_expiry=datetime.datetime.now() + datetime.timedelta(days=365),
-        secret_key="a_very_secret_key",
+        secret_key="secret",
     )
 
     db.session.add(test_server)
@@ -559,6 +559,9 @@ def make_demodata():  # pragma: no cover
         gsp.spatial_aggregation.append(
             agg_units[0]
         )  # Give Bob access to admin0 agg units
+        gsp.spatial_aggregation.append(
+            agg_units[1]
+        )  # Give Bob access to admin1 agg units
         db.session.add(gsp)
     db.session.add(
         GroupServerTokenLimits(

--- a/flowauth/frontend/cypress/integration/login_spec.js
+++ b/flowauth/frontend/cypress/integration/login_spec.js
@@ -12,7 +12,7 @@ describe("Login screen", function () {
 		cy.get("#username").type("TEST_USER");
 		cy.get("#password").type("DUMMY_PASSWORD");
 		cy.get("button").click();
-		cy.contains("Aruba").should("exist");
+		cy.contains("TEST_SERVER").should("exist");
 		cy.getCookie("session").should("exist");
 		cy.getCookie("X-CSRF").should("exist");
 	});

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -23,4 +23,4 @@ The test suite makes use of the environment variables defined in `development_en
 
 ### Running in PyCharm
 
-To run the tests from within PyCharm, you will need to run `FLOWDB_SERVICES="flowdb_testdata" DOCKER_SERVICES="flowdb_testdata query_locker"` in the project root, and ensure you have provided the environment variables in the top level `development_environment` file to PyCharm (for example, by using the EnvFile plugin).
+To run the tests from within PyCharm, you will need to run `FLOWDB_SERVICES="flowdb_testdata" DOCKER_SERVICES="flowdb_testdata flowmachine_query_locker"` in the project root, and ensure you have provided the environment variables in the top level `development_environment` file to PyCharm (for example, by using the EnvFile plugin).

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -7,7 +7,7 @@
 set -e
 
 export FLOWDB_SERVICES="flowdb_testdata"
-export DOCKER_SERVICES="flowdb_testdata query_locker"
+export DOCKER_SERVICES="flowdb_testdata flowmachine_query_locker"
 
 TrapQuit() {
     if [ "$CI" != "true" ] && [ "$KEEP_CONTAINERS_ALIVE" != "true" ]; then

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -65,11 +65,11 @@ then
 else
     source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/development_environment)"
     echo "Starting containers"
-    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - ps -q ${DOCKER_FLOWDB_HOST} flowapi flowmachine flowauth query_locker`
+    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - ps -q $DOCKER_FLOWDB_HOST flowapi flowmachine flowauth query_locker`
     if [[ "$RUNNING" != "" ]]; then
         confirm "Existing containers are running and will be replaced. Are you sure?" || exit 1
     fi
-    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - up -d flowdb_testdata flowapi flowmachine flowauth query_locker
+    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - up -d $DOCKER_FLOWDB_HOST flowapi flowmachine flowauth query_locker
     echo "Waiting for containers to be ready.."
     docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including the output of running 'docker logs flowdb'" && exit 1)
     echo "FlowDB ready."

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -23,4 +23,5 @@ else
     echo "Access FlowDB using 'PGHOST=$FLOWDB_HOST PGPORT=$FLOWDB_PORT PGDATABASE=flowdb PGUSER=$FLOWMACHINE_FLOWDB_USER PGPASSWORD=$FLOWMACHINE_FLOWDB_PASSWORD psql'"
     echo "Access FlowAPI using FlowClient at http://localhost:$FLOWAPI_PORT"
     echo "View the FlowAPI spec at http://localhost:$FLOWAPI_PORT/api/0/spec/redoc"
+    echo "Generate FlowAPI access tokens using FlowAuth with user TEST_USER and password DUMMY_PASSWORD at http://localhost:$FLOWAUTH_PORT"
 fi

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -3,13 +3,51 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 set -e
-
 set -a
-    export CONTAINER_TAG=$CONTAINER_TAG
-    if [ "$CI" = "true" ]; then
-        export CONTAINER_TAG=$CIRCLE_SHA1
-        export BRANCH=$CIRCLE_SHA1
-    fi
+
+# Read a single char from /dev/tty, prompting with "$*"
+# Note: pressing enter will return a null string. Perhaps a version terminated with X and then remove it in caller?
+# See https://unix.stackexchange.com/a/367880/143394 for dealing with multi-byte, etc.
+function get_keypress {
+  local REPLY IFS=
+  >/dev/tty printf '%s' "$*"
+  [[ $ZSH_VERSION ]] && read -rk1  # Use -u0 to read from STDIN
+  # See https://unix.stackexchange.com/q/383197/143394 regarding '\n' -> ''
+  [[ $BASH_VERSION ]] && </dev/tty read -rn1
+  printf '%s' "$REPLY"
+}
+
+# Get a y/n from the user, return yes=0, no=1 enter=$2
+# Prompt using $1.
+# If set, return $2 on pressing enter, useful for cancel or defualting
+function get_yes_keypress {
+  local prompt="${1:-Are you sure [y/n]? }"
+  local enter_return=$2
+  local REPLY
+  # [[ ! $prompt ]] && prompt="[y/n]? "
+  while REPLY=$(get_keypress "$prompt"); do
+    [[ $REPLY ]] && printf '\n' # $REPLY blank if user presses enter
+    case "$REPLY" in
+      Y|y)  return 0;;
+      N|n)  return 1;;
+      '')   [[ $enter_return ]] && return "$enter_return"
+    esac
+  done
+}
+
+# Credit: http://unix.stackexchange.com/a/14444/143394
+# Prompt to confirm, defaulting to NO on <enter>
+# Usage: confirm "Dangerous. Are you sure?" && rm *
+function confirm {
+  local prompt="${*:-Are you sure} [y/N]? "
+  get_yes_keypress "$prompt" 1
+}
+
+export CONTAINER_TAG=$CONTAINER_TAG
+if [ "$CI" = "true" ]; then
+    export CONTAINER_TAG=$CIRCLE_SHA1
+    export BRANCH=$CIRCLE_SHA1
+fi
 
 if [ $# -gt 0 ] && [ "$1" = "stop" ]
 then
@@ -21,15 +59,19 @@ else
     source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/development_environment)"
     export DOCKER_FLOWDB_HOST=flowdb_testdata
     echo "Starting containers"
+    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - ps -q flowdb_testdata flowapi flowmachine flowauth query_locker`
+    if [[ "$RUNNING" != "" ]]; then
+        confirm "Existing containers are running and will be replaced. Are you sure?" || exit 1
+    fi
     curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - up -d flowdb_testdata flowapi flowmachine flowauth query_locker
     echo "Waiting for containers to be ready.."
     docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including:" && docker logs flowdb && exit 1)
     echo "FlowDB ready."
-    (netstat -an | grep -q $FLOWMACHINE_PORT) || (>&2 echo "FlowMachine failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowMachine,bug including:" && docker logs flowmachine && exit 1)
+    i=0; until [ $i -ge 24 ] || (netstat -an | grep -q $FLOWMACHINE_PORT) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowMachine failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowMachine,bug including:" && docker logs flowmachine && exit 1)
     echo "FlowMachine ready"
-    curl -s http://localhost:$FLOWAPI_PORT/api/0/spec/openapi-redoc.json > /dev/null || (>&2 echo "FlowAPI failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAPI,bug including:" && docker logs flowapi && exit 1)
+    i=0; until [ $i -ge 24 ] || (curl -s http://localhost:$FLOWAPI_PORT/api/0/spec/openapi.json > /dev/null) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowAPI failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAPI,bug including:" && docker logs flowapi && exit 1)
     echo "FlowAPI ready."
-    curl -s http://localhost:$FLOWAUTH_PORT > /dev/null || (>&2 echo "FlowAuth failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAuth,bug including:" && docker logs flowauth && exit 1)
+    i=0; until [ $i -ge 24 ] || (curl -s http://localhost:$FLOWAUTH_PORT > /dev/null) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowAuth failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAuth,bug including:" && docker logs flowauth && exit 1)
     echo "FlowAuth ready."
     echo "All containers ready!"
     echo "Access FlowDB using 'PGHOST=$FLOWDB_HOST PGPORT=$FLOWDB_PORT PGDATABASE=flowdb PGUSER=$FLOWMACHINE_FLOWDB_USER PGPASSWORD=$FLOWMACHINE_FLOWDB_PASSWORD psql'"

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -65,13 +65,13 @@ else
     fi
     curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - up -d flowdb_testdata flowapi flowmachine flowauth query_locker
     echo "Waiting for containers to be ready.."
-    docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including:" && docker logs flowdb && exit 1)
+    docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including the output of running docker logs flowdb" && exit 1)
     echo "FlowDB ready."
-    i=0; until [ $i -ge 24 ] || (netstat -an | grep -q $FLOWMACHINE_PORT) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowMachine failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowMachine,bug including:" && docker logs flowmachine && exit 1)
+    i=0; until [ $i -ge 24 ] || (netstat -an | grep -q $FLOWMACHINE_PORT) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowMachine failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowMachine,bug including the output of running docker logs flowmachine" && exit 1)
     echo "FlowMachine ready"
-    i=0; until [ $i -ge 24 ] || (curl -s http://localhost:$FLOWAPI_PORT/api/0/spec/openapi.json > /dev/null) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowAPI failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAPI,bug including:" && docker logs flowapi && exit 1)
+    i=0; until [ $i -ge 24 ] || (curl -s http://localhost:$FLOWAPI_PORT/api/0/spec/openapi.json > /dev/null) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowAPI failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAPI,bug including the output of running docker logs flowapi" && exit 1)
     echo "FlowAPI ready."
-    i=0; until [ $i -ge 24 ] || (curl -s http://localhost:$FLOWAUTH_PORT > /dev/null) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowAuth failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAuth,bug including:" && docker logs flowauth && exit 1)
+    i=0; until [ $i -ge 24 ] || (curl -s http://localhost:$FLOWAUTH_PORT > /dev/null) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowAuth failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAuth,bug including the output of running docker logs flowauth" && exit 1)
     echo "FlowAuth ready."
     echo "All containers ready!"
     echo "Access FlowDB using 'PGHOST=$FLOWDB_HOST PGPORT=$FLOWDB_PORT PGDATABASE=flowdb PGUSER=$FLOWMACHINE_FLOWDB_USER PGPASSWORD=$FLOWMACHINE_FLOWDB_PASSWORD psql'"

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -12,19 +12,25 @@ then
     curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - down
 else
     set -a
-    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/development_environment)"
-    export DOCKER_FLOWDB_HOST=flowdb_testdata
+    export CONTAINER_TAG=$CONTAINER_TAG
     if [ "$CI" != "true" ]; then
         export CONTAINER_TAG=$CIRCLE_SHA1
+        export BRANCH=$CIRCLE_SHA1
     fi
+    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/development_environment)"
+    export DOCKER_FLOWDB_HOST=flowdb_testdata
     echo "Starting containers"
     curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - up -d flowdb_testdata flowapi flowmachine flowauth query_locker
     echo "Waiting for containers to be ready.."
     docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including:" && docker logs flowdb && exit 1)
-    curl -s http://localhost:$FLOWAPI_PORT/api/0/spec/openapi-redoc.json > /dev/null || (>&2 echo "FlowAPI failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAPI,bug including:" && docker logs flowapi && exit 1)
-    curl -s http://localhost:$FLOWAUTH_PORT > /dev/null || (>&2 echo "FlowAuth failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAuth,bug including:" && docker logs flowauth && exit 1)
+    echo "FlowDB ready."
     nc -z localhost $FLOWMACHINE_PORT 2> /dev/null || (>&2 echo "FlowMachine failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowMachine,bug including:" && docker logs flowmachine && exit 1)
-    echo "Containers ready!"
+    echo "FlowMachine ready"
+    curl -s http://localhost:$FLOWAPI_PORT/api/0/spec/openapi-redoc.json > /dev/null || (>&2 echo "FlowAPI failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAPI,bug including:" && docker logs flowapi && exit 1)
+    echo "FlowAPI ready."
+    curl -s http://localhost:$FLOWAUTH_PORT > /dev/null || (>&2 echo "FlowAuth failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAuth,bug including:" && docker logs flowauth && exit 1)
+    echo "FlowAuth ready."
+    echo "All containers ready!"
     echo "Access FlowDB using 'PGHOST=$FLOWDB_HOST PGPORT=$FLOWDB_PORT PGDATABASE=flowdb PGUSER=$FLOWMACHINE_FLOWDB_USER PGPASSWORD=$FLOWMACHINE_FLOWDB_PASSWORD psql'"
     echo "Access FlowAPI using FlowClient at http://localhost:$FLOWAPI_PORT"
     echo "View the FlowAPI spec at http://localhost:$FLOWAPI_PORT/api/0/spec/redoc"

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -13,7 +13,7 @@ then
 else
     set -a
     export CONTAINER_TAG=$CONTAINER_TAG
-    if [ "$CI" != "true" ]; then
+    if [ "$CI" = "true" ]; then
         export CONTAINER_TAG=$CIRCLE_SHA1
         export BRANCH=$CIRCLE_SHA1
     fi

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -19,6 +19,8 @@ else
     echo "Waiting for containers to be ready.."
     docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done'
     curl -s http://localhost:$FLOWAPI_PORT/api/0/spec/openapi-redoc.json > /dev/null || (>&2 echo "FlowAPI failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAPI,bug including:" && docker logs flowapi && exit 1)
+    curl -s http://localhost:$FLOWAUTH_PORT > /dev/null || (>&2 echo "FlowAuth failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAuth,bug including:" && docker logs flowauth && exit 1)
+    nc -z localhost $FLOWMACHINE_PORT > /dev/null || (>&2 echo "FlowMachine failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowMachine,bug including:" && docker logs flowmachine && exit 1)
     echo "Containers ready!"
     echo "Access FlowDB using 'PGHOST=$FLOWDB_HOST PGPORT=$FLOWDB_PORT PGDATABASE=flowdb PGUSER=$FLOWMACHINE_FLOWDB_USER PGPASSWORD=$FLOWMACHINE_FLOWDB_PASSWORD psql'"
     echo "Access FlowAPI using FlowClient at http://localhost:$FLOWAPI_PORT"

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+set -e
+
+
+if [ $# -gt 0 ] && [ "$1" = "stop" ]
+then
+    export DOCKER_FLOWDB_HOST=flowdb_testdata
+    echo "Stopping containers"
+    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - down
+else
+    set -a
+    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/development_environment)"
+    export DOCKER_FLOWDB_HOST=flowdb_testdata
+    echo "Starting containers"
+    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - up -d flowdb_testdata flowapi flowmachine flowauth query_locker
+    echo "Waiting for containers to be ready.."
+    docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done'
+    curl -s http://localhost:$FLOWAPI_PORT/api/0/spec/openapi-redoc.json > /dev/null || (>&2 echo "FlowAPI failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAPI,bug including:" && docker logs flowapi && exit 1)
+    echo "Containers ready!"
+    echo "Access FlowDB using 'PGHOST=$FLOWDB_HOST PGPORT=$FLOWDB_PORT PGDATABASE=flowdb PGUSER=$FLOWMACHINE_FLOWDB_USER PGPASSWORD=$FLOWMACHINE_FLOWDB_PASSWORD psql'"
+    echo "Access FlowAPI using FlowClient at http://localhost:$FLOWAPI_PORT"
+    echo "View the FlowAPI spec at http://localhost:$FLOWAPI_PORT/api/0/spec/redoc"
+fi

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -49,6 +49,13 @@ if [ "$CI" = "true" ]; then
     export BRANCH=$CIRCLE_SHA1
 fi
 
+if [ $# -gt 0 ] && [ "$1" = "synth" ]
+then
+    export DOCKER_FLOWDB_HOST=flowdb_synthetic_data
+else
+    export DOCKER_FLOWDB_HOST=flowdb_testdata
+fi
+
 if [ $# -gt 0 ] && [ "$1" = "stop" ]
 then
     export DOCKER_FLOWDB_HOST=flowdb_testdata
@@ -57,9 +64,8 @@ then
     curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - down
 else
     source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/development_environment)"
-    export DOCKER_FLOWDB_HOST=flowdb_testdata
     echo "Starting containers"
-    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - ps -q flowdb_testdata flowapi flowmachine flowauth query_locker`
+    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - ps -q {$DOCKER_FLOWDB_HOST} flowapi flowmachine flowauth query_locker`
     if [[ "$RUNNING" != "" ]]; then
         confirm "Existing containers are running and will be replaced. Are you sure?" || exit 1
     fi

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -14,10 +14,13 @@ else
     set -a
     source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/development_environment)"
     export DOCKER_FLOWDB_HOST=flowdb_testdata
+    if [ "$CI" != "true" ]; then
+        export CONTAINER_TAG=$CIRCLE_SHA1
+    fi
     echo "Starting containers"
     curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - up -d flowdb_testdata flowapi flowmachine flowauth query_locker
     echo "Waiting for containers to be ready.."
-    docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done'
+    docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including:" && docker logs flowdb && exit 1)
     curl -s http://localhost:$FLOWAPI_PORT/api/0/spec/openapi-redoc.json > /dev/null || (>&2 echo "FlowAPI failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAPI,bug including:" && docker logs flowapi && exit 1)
     curl -s http://localhost:$FLOWAUTH_PORT > /dev/null || (>&2 echo "FlowAuth failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAuth,bug including:" && docker logs flowauth && exit 1)
     nc -z localhost $FLOWMACHINE_PORT > /dev/null || (>&2 echo "FlowMachine failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowMachine,bug including:" && docker logs flowmachine && exit 1)

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -65,13 +65,13 @@ else
     fi
     curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - up -d flowdb_testdata flowapi flowmachine flowauth query_locker
     echo "Waiting for containers to be ready.."
-    docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including the output of running docker logs flowdb" && exit 1)
+    docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including the output of running 'docker logs flowdb'" && exit 1)
     echo "FlowDB ready."
-    i=0; until [ $i -ge 24 ] || (netstat -an | grep -q $FLOWMACHINE_PORT) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowMachine failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowMachine,bug including the output of running docker logs flowmachine" && exit 1)
+    i=0; until [ $i -ge 24 ] || (netstat -an | grep -q $FLOWMACHINE_PORT) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowMachine failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowMachine,bug including the output of running 'docker logs flowmachine'" && exit 1)
     echo "FlowMachine ready"
-    i=0; until [ $i -ge 24 ] || (curl -s http://localhost:$FLOWAPI_PORT/api/0/spec/openapi.json > /dev/null) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowAPI failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAPI,bug including the output of running docker logs flowapi" && exit 1)
+    i=0; until [ $i -ge 24 ] || (curl -s http://localhost:$FLOWAPI_PORT/api/0/spec/openapi.json > /dev/null) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowAPI failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAPI,bug including the output of running 'docker logs flowapi'" && exit 1)
     echo "FlowAPI ready."
-    i=0; until [ $i -ge 24 ] || (curl -s http://localhost:$FLOWAUTH_PORT > /dev/null) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowAuth failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAuth,bug including the output of running docker logs flowauth" && exit 1)
+    i=0; until [ $i -ge 24 ] || (curl -s http://localhost:$FLOWAUTH_PORT > /dev/null) ; do let i=i+1; echo Waiting 10s; sleep 10; done || (>&2 echo "FlowAuth failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAuth,bug including the output of running 'docker logs flowauth'" && exit 1)
     echo "FlowAuth ready."
     echo "All containers ready!"
     echo "Access FlowDB using 'PGHOST=$FLOWDB_HOST PGPORT=$FLOWDB_PORT PGDATABASE=flowdb PGUSER=$FLOWMACHINE_FLOWDB_USER PGPASSWORD=$FLOWMACHINE_FLOWDB_PASSWORD psql'"

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -65,11 +65,11 @@ then
 else
     source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/development_environment)"
     echo "Starting containers"
-    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - ps -q $DOCKER_FLOWDB_HOST flowapi flowmachine flowauth query_locker`
+    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - ps -q $DOCKER_FLOWDB_HOST flowapi flowmachine flowauth flowmachine_query_locker`
     if [[ "$RUNNING" != "" ]]; then
         confirm "Existing containers are running and will be replaced. Are you sure?" || exit 1
     fi
-    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - up -d $DOCKER_FLOWDB_HOST flowapi flowmachine flowauth query_locker
+    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - up -d $DOCKER_FLOWDB_HOST flowapi flowmachine flowauth flowmachine_query_locker
     echo "Waiting for containers to be ready.."
     docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including the output of running 'docker logs flowdb'" && exit 1)
     echo "FlowDB ready."

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -23,7 +23,7 @@ else
     docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including:" && docker logs flowdb && exit 1)
     curl -s http://localhost:$FLOWAPI_PORT/api/0/spec/openapi-redoc.json > /dev/null || (>&2 echo "FlowAPI failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAPI,bug including:" && docker logs flowapi && exit 1)
     curl -s http://localhost:$FLOWAUTH_PORT > /dev/null || (>&2 echo "FlowAuth failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowAuth,bug including:" && docker logs flowauth && exit 1)
-    nc -z localhost $FLOWMACHINE_PORT > /dev/null || (>&2 echo "FlowMachine failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowMachine,bug including:" && docker logs flowmachine && exit 1)
+    nc -z localhost $FLOWMACHINE_PORT 2> /dev/null || (>&2 echo "FlowMachine failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowMachine,bug including:" && docker logs flowmachine && exit 1)
     echo "Containers ready!"
     echo "Access FlowDB using 'PGHOST=$FLOWDB_HOST PGPORT=$FLOWDB_PORT PGDATABASE=flowdb PGUSER=$FLOWMACHINE_FLOWDB_USER PGPASSWORD=$FLOWMACHINE_FLOWDB_PASSWORD psql'"
     echo "Access FlowAPI using FlowClient at http://localhost:$FLOWAPI_PORT"

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -65,7 +65,7 @@ then
 else
     source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/development_environment)"
     echo "Starting containers"
-    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - ps -q {$DOCKER_FLOWDB_HOST} flowapi flowmachine flowauth query_locker`
+    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - ps -q ${DOCKER_FLOWDB_HOST} flowapi flowmachine flowauth query_locker`
     if [[ "$RUNNING" != "" ]]; then
         confirm "Existing containers are running and will be replaced. Are you sure?" || exit 1
     fi

--- a/secrets_quickstart/docker-stack.yml
+++ b/secrets_quickstart/docker-stack.yml
@@ -56,7 +56,7 @@ services:
             - FLOWDB_HOST=flowdb
             - FLOWMACHINE_LOG_LEVEL=${FLOWMACHINE_LOG_LEVEL:-error}
             - FLOWMACHINE_SERVER_DEBUG_MODE=${FLOWMACHINE_SERVER_DEBUG_MODE:-False}
-            - REDIS_HOST=query_locker
+            - REDIS_HOST=flowmachine_query_locker
         secrets:
           - FLOWMACHINE_FLOWDB_USER
           - FLOWMACHINE_FLOWDB_PASSWORD
@@ -82,7 +82,7 @@ services:
           - zero
           - db
           - api
-    query_locker:
+    flowmachine_query_locker:
         image: bitnami/redis:latest
         environment:
           - REDIS_PASSWORD_FILE=/run/secrets/REDIS_PASSWORD


### PR DESCRIPTION
Closes #688

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [x] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This introduces a bash script that starts a complete (demo mode) FlowKit system, and can be run (ala homebrew) by simply curl-ing the script direct from GitHub.

I've split the docker-compose file to facilitate this, and moved the build blocks to a separate one, so you can run as before by just using both files.