### PR TITLE
Cypress recording

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -456,7 +456,7 @@ jobs:
             - /home/circleci/project/flowauth/frontend/node_modules
       - run:
           name: Run Cypress end-to-end tests
-          command: pipenv run test-frontend-with-record --reporter junit --reporter-options "mochaFile=../results/flowauth-frontend.xml"
+          command: pipenv run test-frontend-with-record --reporter junit --reporter-options "mochaFile=../results/flowauth-frontend.[hash].xml"
       - store_test_results:
           path: results
       - store_artifacts:


### PR DESCRIPTION
This switches back on recording of Flowauth frontend tests, making them available at https://dashboard.cypress.io/#/projects/67obxt/runs again, because we now have an OSS plan with Cypress 🎉 

(Also fixes not showing all the test results in the circle test summary)