### PR TITLE
Rename parameters in connect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The docs now contain information about required versions of installation prerequisites [#703](https://github.com/Flowminder/FlowKit/issues/703)
 
 ### Changed
+- Parameter names in `flowmachine.connect()` have been renamed as follows to be consistent with the associated environment variables [#728](https://github.com/Flowminder/FlowKit/issues/728):
+    - `db_port -> flowdb_port`
+    - `db_user -> flowdb_user`
+    - `db_pass -> flowdb_password`
+    - `db_host -> flowdb_host`
+    - `db_connection_pool_size -> flowdb_connection_pool_size`
+    - `db_connection_pool_overflow -> flowdb_connection_pool_overflow`
 
 ### Fixed
 - FlowClient docs rendered to website now show the options available for arguments that require a string from some set of possibilities [#695](https://github.com/Flowminder/FlowKit/issues/695).

--- a/flowmachine/flowmachine/core/init.py
+++ b/flowmachine/flowmachine/core/init.py
@@ -29,12 +29,12 @@ logger = structlog.get_logger("flowmachine.debug", submodule=__name__)
 
 def connect(
     log_level: Union[str, None] = None,
-    db_port: Union[int, None] = None,
-    db_user: Union[str, None] = None,
-    db_pass: Union[str, None] = None,
-    db_host: Union[str, None] = None,
-    db_connection_pool_size: Union[int, None] = None,
-    db_connection_pool_overflow: Union[int, None] = None,
+    flowdb_port: Union[int, None] = None,
+    flowdb_user: Union[str, None] = None,
+    flowdb_password: Union[str, None] = None,
+    flowdb_host: Union[str, None] = None,
+    flowdb_connection_pool_size: Union[int, None] = None,
+    flowdb_connection_pool_overflow: Union[int, None] = None,
     redis_host: Union[str, None] = None,
     redis_port: Union[int, None] = None,
     redis_password: Union[str, None] = None,
@@ -49,17 +49,17 @@ def connect(
     ----------
     log_level : str, default "error"
         Level to log at
-    db_port : int, default 9000
+    flowdb_port : int, default 9000
         Port number to connect to flowdb
-    db_user : str, default "flowmachine"
+    flowdb_user : str, default "flowmachine"
         Name of user to connect to flowdb as
-    db_pass : str, default "foo"
+    flowdb_password : str, default "foo"
         Password to connect to flowdb
-    db_host : str, default "localhost"
+    flowdb_host : str, default "localhost"
         Hostname of flowdb server
-    db_connection_pool_size : int, default 5
+    flowdb_connection_pool_size : int, default 5
         Default number of database connections to use
-    db_connection_pool_overflow : int, default 1
+    flowdb_connection_pool_overflow : int, default 1
         Number of extra database connections to allow
     redis_host : str, default "localhost"
         Hostname for redis server.
@@ -92,46 +92,46 @@ def connect(
         if log_level is None
         else log_level
     )
-    db_port = int(
+    flowdb_port = int(
         getsecret("FLOWDB_PORT", os.getenv("FLOWDB_PORT", 9000))
-        if db_port is None
-        else db_port
+        if flowdb_port is None
+        else flowdb_port
     )
-    db_user = (
+    flowdb_user = (
         getsecret(
             "FLOWMACHINE_FLOWDB_USER",
             os.getenv("FLOWMACHINE_FLOWDB_USER", "flowmachine"),
         )
-        if db_user is None
-        else db_user
+        if flowdb_user is None
+        else flowdb_user
     )
-    db_pass = (
+    flowdb_password = (
         getsecret(
             "FLOWMACHINE_FLOWDB_PASSWORD", os.getenv("FLOWMACHINE_FLOWDB_PASSWORD")
         )
-        if db_pass is None
-        else db_pass
+        if flowdb_password is None
+        else flowdb_password
     )
-    db_host = (
+    flowdb_host = (
         getsecret("FLOWDB_HOST", os.getenv("FLOWDB_HOST", "localhost"))
-        if db_host is None
-        else db_host
+        if flowdb_host is None
+        else flowdb_host
     )
-    db_connection_pool_size = (
+    flowdb_connection_pool_size = (
         int(
             getsecret(
                 "DB_CONNECTION_POOL_SIZE", os.getenv("DB_CONNECTION_POOL_SIZE", 5)
             )
         )
-        if db_connection_pool_size is None
-        else db_connection_pool_size
+        if flowdb_connection_pool_size is None
+        else flowdb_connection_pool_size
     )
-    db_connection_pool_overflow = int(
+    flowdb_connection_pool_overflow = int(
         getsecret(
             "DB_CONNECTION_POOL_OVERFLOW", os.getenv("DB_CONNECTION_POOL_OVERFLOW", 1)
         )
-        if db_connection_pool_overflow is None
-        else db_connection_pool_overflow
+        if flowdb_connection_pool_overflow is None
+        else flowdb_connection_pool_overflow
     )
 
     redis_host = (
@@ -150,7 +150,7 @@ def connect(
         else redis_password
     )
 
-    if db_pass is None:
+    if flowdb_password is None:
         raise ValueError(
             "You must provide a secret named FLOWMACHINE_FLOWDB_PASSWORD, set an environment variable named FLOWMACHINE_FLOWDB_PASSWORD, or provide a db_pass argument."
         )
@@ -167,25 +167,25 @@ def connect(
         set_log_level("flowmachine.debug", log_level)
         if conn is None:
             conn = Connection(
-                host=db_host,
-                port=db_port,
-                user=db_user,
-                password=db_pass,
+                host=flowdb_host,
+                port=flowdb_port,
+                user=flowdb_user,
+                password=flowdb_password,
                 database="flowdb",
-                pool_size=db_connection_pool_size,
-                overflow=db_connection_pool_overflow,
+                pool_size=flowdb_connection_pool_size,
+                overflow=flowdb_connection_pool_overflow,
             )
         Query.connection = conn
 
         Query.redis = redis.StrictRedis(
             host=redis_host, port=redis_port, password=redis_pw
         )
-        _start_threadpool(thread_pool_size=db_connection_pool_size)
+        _start_threadpool(thread_pool_size=flowdb_connection_pool_size)
 
         print(f"FlowMachine version: {flowmachine.__version__}")
 
         print(
-            f"Flowdb running on: {db_host}:{db_port}/flowdb (connecting user: {db_user})"
+            f"Flowdb running on: {flowdb_host}:{flowdb_port}/flowdb (connecting user: {flowdb_user})"
         )
     return Query.connection
 

--- a/flowmachine/flowmachine/core/init.py
+++ b/flowmachine/flowmachine/core/init.py
@@ -28,6 +28,7 @@ logger = structlog.get_logger("flowmachine.debug", submodule=__name__)
 
 
 def connect(
+    *,
     log_level: Union[str, None] = None,
     flowdb_port: Union[int, None] = None,
     flowdb_user: Union[str, None] = None,

--- a/flowmachine/flowmachine/core/init.py
+++ b/flowmachine/flowmachine/core/init.py
@@ -153,7 +153,7 @@ def connect(
 
     if flowdb_password is None:
         raise ValueError(
-            "You must provide a secret named FLOWMACHINE_FLOWDB_PASSWORD, set an environment variable named FLOWMACHINE_FLOWDB_PASSWORD, or provide a db_pass argument."
+            "You must provide a secret named FLOWMACHINE_FLOWDB_PASSWORD, set an environment variable named FLOWMACHINE_FLOWDB_PASSWORD, or provide a flowdb_pass argument."
         )
 
     if redis_password is None:

--- a/flowmachine/flowmachine/core/init.py
+++ b/flowmachine/flowmachine/core/init.py
@@ -145,7 +145,7 @@ def connect(
         if redis_port is None
         else redis_port
     )
-    redis_pw = (
+    redis_password = (
         getsecret("REDIS_PASSWORD", os.getenv("REDIS_PASSWORD"))
         if redis_password is None
         else redis_password
@@ -156,7 +156,7 @@ def connect(
             "You must provide a secret named FLOWMACHINE_FLOWDB_PASSWORD, set an environment variable named FLOWMACHINE_FLOWDB_PASSWORD, or provide a db_pass argument."
         )
 
-    if redis_pw is None:
+    if redis_password is None:
         raise ValueError(
             "You must provide a secret named REDIS_PASSWORD, set an environment variable named REDIS_PASSWORD, or provide a redis_password argument."
         )
@@ -179,7 +179,7 @@ def connect(
         Query.connection = conn
 
         Query.redis = redis.StrictRedis(
-            host=redis_host, port=redis_port, password=redis_pw
+            host=redis_host, port=redis_port, password=redis_password
         )
         _start_threadpool(thread_pool_size=flowdb_connection_pool_size)
 

--- a/flowmachine/tests/test_init.py
+++ b/flowmachine/tests/test_init.py
@@ -61,12 +61,12 @@ def test_param_priority(mocked_connections, monkeypatch):
     )
     connect(
         log_level="dummy_log_level",
-        db_port=1234,
-        db_user="dummy_db_user",
-        db_pass="dummy_db_pass",
-        db_host="dummy_db_host",
-        db_connection_pool_size=6789,
-        db_connection_pool_overflow=1011,
+        flowdb_port=1234,
+        flowdb_user="dummy_db_user",
+        flowdb_password="dummy_db_pass",
+        flowdb_host="dummy_db_host",
+        flowdb_connection_pool_size=6789,
+        flowdb_connection_pool_overflow=1011,
         redis_host="dummy_redis_host",
         redis_port=1213,
         redis_password="dummy_redis_password",
@@ -132,7 +132,7 @@ def test_connect_defaults(mocked_connections, monkeypatch):
     core_set_log_level_mock, core_init_Connection_mock, core_init_StrictRedis_mock, core_init_start_threadpool_mock = (
         mocked_connections
     )
-    connect(db_pass="foo", redis_password="fm_redis")
+    connect(flowdb_password="foo", redis_password="fm_redis")
     core_set_log_level_mock.assert_called_with("flowmachine.debug", "error")
     core_init_Connection_mock.assert_called_with(
         port=9000,
@@ -153,7 +153,7 @@ def test_connect_defaults(mocked_connections, monkeypatch):
 
 @pytest.mark.usefixtures("clean_env")
 @pytest.mark.parametrize(
-    "args", [{}, {"db_pass": "foo"}, {"redis_password": "fm_redis"}]
+    "args", [{}, {"flowdb_password": "foo"}, {"redis_password": "fm_redis"}]
 )
 def test_connect_passwords_required(args):
     """Test connect raises a valueerror if no password is set for db or redis"""


### PR DESCRIPTION
Closes #728 

### I have:

- [X] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [X] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Renames the parameters in `connect()` as suggested in #728, and also makes them keyword-only arguments.