### PR TITLE
Flowauth fernet key env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,7 +406,7 @@ jobs:
     docker:
       - image: circleci/python:3.6
     environment:
-      FERNET_KEY: "XU-J5xNOtkaUKAoqWT7_VoT3zk2OTuoqKPBN3l0pOFg="
+      FLOWAUTH_FERNET_KEY: "XU-J5xNOtkaUKAoqWT7_VoT3zk2OTuoqKPBN3l0pOFg="
       FLASK_APP: flowauth
     working_directory: /home/circleci/project/flowauth
     steps:
@@ -426,7 +426,7 @@ jobs:
     docker:
       - image: circleci/python:3.6
     environment:
-      FERNET_KEY: "XU-J5xNOtkaUKAoqWT7_VoT3zk2OTuoqKPBN3l0pOFg="
+      FLOWAUTH_FERNET_KEY: "XU-J5xNOtkaUKAoqWT7_VoT3zk2OTuoqKPBN3l0pOFg="
       FLASK_APP: flowauth
     working_directory: /home/circleci/project/flowauth
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - FlowClient docs rendered to website now show the options available for arguments that require a string from some set of possibilities [#695](https://github.com/Flowminder/FlowKit/issues/695).
 - The Flowmachine loggers are now initialised only once when flowmachine is imported, with a call to `connect()` only changing the log level [#691](https://github.com/Flowminder/FlowKit/issues/691)
+- The FERNET_KEY environment variable for FlowAuth is now named FLOWAUTH_FERNET_KEY
 
 ### Removed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,7 @@ services:
       - ${FLOWAUTH_PORT:?Must set FLOWAUTH_PORT env var}:80
     environment:
       DEMO_MODE: ${DEMO_MODE:?Must set DEMO_MODE env var}
+      FLOWAUTH_FERNET_KEY: ${FLOWAUTH_FERNET_KEY:?Must set FLOWAUTH_FERNET_KEY env var}
 
   flowmachine_query_locker:
     container_name: flowmachine_query_locker

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -176,11 +176,11 @@ To initialise the tables, you can either set the `INIT_DB` environment variable 
 
 To create an initial administrator, use the `ADMIN_USER` and `ADMIN_PASSWORD` environment variables or set them as secrets. Alternatively, you may run `flask add-admin <username> <password>` from inside the container. You can combine these environment variables with the `INIT_DB` environment variable.
 
-You _must_ also provide two additional environment variables or secrets: `FERNET_KEY`, and `SECRET_KEY`. `FERNET_KEY` is used to encrypt server secret keys, and tokens while 'at rest' in the database, and decrypt them for use. `SECRET_KEY` is used to secure session, and CSRF protection cookies.
+You _must_ also provide two additional environment variables or secrets: `FLOWAUTH_FERNET_KEY`, and `SECRET_KEY`. `FLOWAUTH_FERNET_KEY` is used to encrypt server secret keys, and tokens while 'at rest' in the database, and decrypt them for use. `SECRET_KEY` is used to secure session, and CSRF protection cookies.
 
 By default, `SECRET_KEY` will be set to `secret`. You should supply this to ensure a secure system.
 
-While `SECRET_KEY` can be any arbitrary string, `FERNET_KEY` should be a valid Fernet key. A convenience command is provided to generate one - `flask get-fernet`.  
+While `SECRET_KEY` can be any arbitrary string, `FLOWAUTH_FERNET_KEY` should be a valid Fernet key. A convenience command is provided to generate one - `flask get-fernet`.  
 
 
 #### Running with Secrets

--- a/flowauth/backend/config.py
+++ b/flowauth/backend/config.py
@@ -37,6 +37,8 @@ SQLALCHEMY_DATABASE_URI = getsecret(
 SECRET_KEY = getsecret("SECRET_KEY", os.getenv("SECRET_KEY", "secret"))
 SESSION_PROTECTION = "strong"
 SQLALCHEMY_TRACK_MODIFICATIONS = False
-FERNET_KEY = getsecret("FERNET_KEY", os.getenv("FERNET_KEY", "")).encode()
-Fernet(FERNET_KEY)  # Error if fernet key is bad
+FLOWAUTH_FERNET_KEY = getsecret(
+    "FLOWAUTH_FERNET_KEY", os.getenv("FLOWAUTH_FERNET_KEY", "")
+).encode()
+Fernet(FLOWAUTH_FERNET_KEY)  # Error if fernet key is bad
 DEMO_MODE = True if os.getenv("DEMO_MODE") is not None else False

--- a/flowauth/backend/flowauth/__init__.py
+++ b/flowauth/backend/flowauth/__init__.py
@@ -107,7 +107,7 @@ def create_app(test_config=None):
             pass  # Definitely not an admin
 
     @app.cli.command("get-fernet")
-    def make_FLOWAUTH_FERNET_KEY():
+    def make_flowauth_fernet_key():
         """
         Generate a new Fernet key for symmetric encryption of data at
         rest.

--- a/flowauth/backend/flowauth/__init__.py
+++ b/flowauth/backend/flowauth/__init__.py
@@ -107,12 +107,12 @@ def create_app(test_config=None):
             pass  # Definitely not an admin
 
     @app.cli.command("get-fernet")
-    def make_fernet_key():
+    def make_FLOWAUTH_FERNET_KEY():
         """
         Generate a new Fernet key for symmetric encryption of data at
         rest.
         """
-        print(f'FERNET_KEY="{Fernet.generate_key().decode()}"')
+        print(f'FLOWAUTH_FERNET_KEY="{Fernet.generate_key().decode()}"')
 
     # Add flask <command> CLI commands
     app.cli.add_command(demodata)

--- a/flowauth/backend/flowauth/models.py
+++ b/flowauth/backend/flowauth/models.py
@@ -64,7 +64,7 @@ def get_fernet() -> Fernet:
     -------
     crypography.fernet.Fernet
     """
-    return Fernet(current_app.config["FERNET_KEY"])
+    return Fernet(current_app.config["FLOWAUTH_FERNET_KEY"])
 
 
 class User(db.Model):

--- a/flowauth/backend/prestart.sh
+++ b/flowauth/backend/prestart.sh
@@ -9,24 +9,24 @@ export FLASK_APP=flowauth
 if [ -n "$DEMO_MODE" ]
 then
     echo "Creating demodata"
-    if [ -z "$FERNET_KEY" ]
+    if [ -z "$FLOWAUTH_FERNET_KEY" ]
     then
-        echo "No FERNET_KEY env var set, checking for a secret."
-        if [ ! -e /run/secrets/FERNET_KEY ]
+        echo "No FLOWAUTH_FERNET_KEY env var set, checking for a secret."
+        if [ ! -e /run/secrets/FLOWAUTH_FERNET_KEY ]
         then
-            echo "NO FERNET_KEY PROVIDED. USING DEMO KEY."
+            echo "NO FLOWAUTH_FERNET_KEY PROVIDED. USING DEMO KEY."
             mkdir -p /run/secrets | true
-            echo "XU-J5xNOtkaUKAoqWT7_VoT3zk2OTuoqKPBN3l0pOFg=" > /run/secrets/FERNET_KEY
+            echo "XU-J5xNOtkaUKAoqWT7_VoT3zk2OTuoqKPBN3l0pOFg=" > /run/secrets/FLOWAUTH_FERNET_KEY
         fi
     fi
     flask demodata
 else
-    if [ -z "$FERNET_KEY" ]
+    if [ -z "$FLOWAUTH_FERNET_KEY" ]
     then
-        echo "No FERNET_KEY env var set, checking for a secret."
-        if [ ! -e /run/secrets/FERNET_KEY ]
+        echo "No FLOWAUTH_FERNET_KEY env var set, checking for a secret."
+        if [ ! -e /run/secrets/FLOWAUTH_FERNET_KEY ]
         then
-            echo "NO FERNET_KEY PROVIDED!"
+            echo "NO FLOWAUTH_FERNET_KEY PROVIDED!"
             exit 1
         fi
     fi


### PR DESCRIPTION
### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

#720 renamed the env var for FlowAuth's fernet key, but didn't carry that through to most uses of it, this fixes that, and adds it to the top level compose (it was previously missing).