### PR TITLE
Fix init_logging

### DIFF
--- a/flowmachine/flowmachine/core/dummy_query.py
+++ b/flowmachine/flowmachine/core/dummy_query.py
@@ -2,7 +2,7 @@ import structlog
 from .query import Query
 from .query_state import QueryStateMachine
 
-logger = structlog.get_logger(__name__)
+logger = structlog.get_logger("flowmachine.debug", submodule=__name__)
 
 
 class DummyQuery(Query):

--- a/flowmachine/flowmachine/core/logging.py
+++ b/flowmachine/flowmachine/core/logging.py
@@ -9,6 +9,8 @@ import sys
 
 __all__ = ["init_logging", "set_log_level"]
 
+FLOWKIT_LOGGERS_HAVE_BEEN_INITIALISED = False
+
 
 def init_logging():
     """
@@ -16,6 +18,12 @@ def init_logging():
     and configure structlog so that it passes any messages on to the standard
     library loggers.
     """
+    global FLOWKIT_LOGGERS_HAVE_BEEN_INITIALISED
+    if FLOWKIT_LOGGERS_HAVE_BEEN_INITIALISED:
+        # Only initialise loggers once, to avoid adding multiple
+        # handlers and accidentally re-setting the log level.
+        return
+
     root_logger = logging.getLogger("flowmachine")
     root_logger.setLevel(logging.DEBUG)
 
@@ -47,6 +55,8 @@ def init_logging():
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True,
     )
+
+    FLOWKIT_LOGGERS_HAVE_BEEN_INITIALISED = True
 
 
 def set_log_level(logger_name: str, log_level: str) -> None:

--- a/flowmachine/flowmachine/core/query_info_lookup.py
+++ b/flowmachine/flowmachine/core/query_info_lookup.py
@@ -2,7 +2,7 @@ import rapidjson
 import structlog
 from redis import StrictRedis
 
-logger = structlog.get_logger(__name__)
+logger = structlog.get_logger("flowmachine.debug", submodule=__name__)
 
 
 class QueryInfoLookupError(Exception):

--- a/flowmachine/flowmachine/features/utilities/events_tables_union.py
+++ b/flowmachine/flowmachine/features/utilities/events_tables_union.py
@@ -10,7 +10,7 @@ from ...core import Query
 from ...core.errors import MissingDateError
 from .event_table_subset import EventTableSubset
 
-logger = structlog.get_logger(__name__)
+logger = structlog.get_logger("flowmachine.debug", submodule=__name__)
 
 
 class EventsTablesUnion(Query):


### PR DESCRIPTION
Closes #730

### I have:

- [X] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This PR ensures that the code in `init_logging()` is only executed once.

It also fixes a few calls to `structlog.get_logger()` which didn't use `flowmachine.debug` as the logger name (but rather the Python module name).

I tried to add a test for the issue in #730, but sadly couldn't reproduce this in the context of the test suite. :( It seems that the call to `set_log_level()` always works correctly in the tests, even though I can reproduce the issue in an interactive session.

Are we happy for this to be merged as is, without an explicit test for it?