### PR TITLE
Split test of quickstart examples into two separate jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,6 +588,25 @@ jobs:
           path: /home/circleci/project/
       - run: ./quick_start.sh
       - run: ./quick_start.sh stop
+      - run:
+          name: Check all containers are down
+          command: |
+            RUNNING=`docker ps -q`
+            if [[ "$RUNNING" != "" ]]
+            then
+              echo "Error: all containers should be down, but some are still running."
+              exit 1
+            fi
+
+  test_quickstart_examples_with_smaller_data:
+    machine:
+      image: circleci/classic:201808-01
+    working_directory: /home/circleci/project
+    environment:
+      BRANCH: $CIRCLE_BRANCH
+    steps:
+      - checkout:
+          path: /home/circleci/project/
       - run: ./quick_start.sh examples smaller_data
       - run: ./quick_start.sh stop
       #- run: ./quick_start.sh larger_data # Synth data spinup with this data volume is very slow so not testing it right now on CI
@@ -816,6 +835,15 @@ workflows:
             - build_flowetl
             - build_examples
           <<: *run_always_org_context
+      - test_quickstart_examples_with_smaller_data:
+          requires:
+            - build_flowdb
+            - build_flowapi
+            - build_flowmachine
+            - build_flowauth
+            - build_flowetl
+            - build_examples
+          <<: *run_always_org_context
       - integration_tests:
           requires:
             - install_flowmachine_deps
@@ -826,6 +854,7 @@ workflows:
           requires:
             &retag_requirements
             - test_quickstart
+            - test_quickstart_examples_with_smaller_data
             - integration_tests
             - build_docs
             - run_flowkit_api_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -808,15 +808,8 @@ workflows:
           requires:
             - install_flowmachine_deps
           <<: *run_always_org_context
-          run_quickstart_tests:
-            parameters:
-              start_arguments:
-                type: enum
-                enum: ["", "examples smaller_data"]
-
       - run_quickstart_tests:
           name: test_quickstart
-          start_arguments: ""
           requires:
             &quickstart_requirements
             - build_flowdb
@@ -850,6 +843,7 @@ workflows:
             &retag_requirements
             - test_quickstart
             - test_quickstart_examples_with_smaller_data
+#            - test_quickstart_with_larger_data
             - integration_tests
             - build_docs
             - run_flowkit_api_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,7 +577,12 @@ jobs:
           path: test_results
       - run: bash <(curl -s https://codecov.io/bash)
 
-  test_quickstart:
+  run_quickstart_tests:
+    parameters:
+      start_arguments:
+        type: enum
+        enum: ["", "examples smaller_data"]
+        default: ""
     machine:
       image: circleci/classic:201808-01
     working_directory: /home/circleci/project
@@ -586,31 +591,8 @@ jobs:
     steps:
       - checkout:
           path: /home/circleci/project/
-      - run: ./quick_start.sh
+      - run: ./quick_start.sh <<parameters.start_arguments>>
       - run: ./quick_start.sh stop
-      - run:
-          name: Check all containers are down
-          command: |
-            RUNNING=`docker ps -q`
-            if [[ "$RUNNING" != "" ]]
-            then
-              echo "Error: all containers should be down, but some are still running."
-              exit 1
-            fi
-
-  test_quickstart_examples_with_smaller_data:
-    machine:
-      image: circleci/classic:201808-01
-    working_directory: /home/circleci/project
-    environment:
-      BRANCH: $CIRCLE_BRANCH
-    steps:
-      - checkout:
-          path: /home/circleci/project/
-      - run: ./quick_start.sh examples smaller_data
-      - run: ./quick_start.sh stop
-      #- run: ./quick_start.sh larger_data # Synth data spinup with this data volume is very slow so not testing it right now on CI
-      #- run: ./quick_start.sh stop
       - run:
           name: Check all containers are down
           command: |
@@ -826,8 +808,17 @@ workflows:
           requires:
             - install_flowmachine_deps
           <<: *run_always_org_context
-      - test_quickstart:
+          run_quickstart_tests:
+            parameters:
+              start_arguments:
+                type: enum
+                enum: ["", "examples smaller_data"]
+
+      - run_quickstart_tests:
+          name: test_quickstart
+          start_arguments: ""
           requires:
+            &quickstart_requirements
             - build_flowdb
             - build_flowapi
             - build_flowmachine
@@ -835,15 +826,19 @@ workflows:
             - build_flowetl
             - build_examples
           <<: *run_always_org_context
-      - test_quickstart_examples_with_smaller_data:
+      - run_quickstart_tests:
+          name: test_quickstart_examples_with_smaller_data
+          start_arguments: "examples smaller_data"
           requires:
-            - build_flowdb
-            - build_flowapi
-            - build_flowmachine
-            - build_flowauth
-            - build_flowetl
-            - build_examples
+            *quickstart_requirements
           <<: *run_always_org_context
+#      # Synth data spinup with the 'large' data volume is very slow so not testing it right now on CI
+#      - run_quickstart_tests:
+#          name: test_quickstart_with_larger_data
+#          start_arguments: "larger_data"
+#          requires:
+#            *quickstart_requirements
+#          <<: *run_always_org_context
       - integration_tests:
           requires:
             - install_flowmachine_deps


### PR DESCRIPTION
### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This PR splits the test of the quickstart examples into two separate jobs, to reduce the build time by ~5 minutes (the time it takes to run the quickstart examples after the regular quickstart script has been run).

There may be a reason why we don't want this (maybe because it creates an additional job?) but I thought I'd throw it out there.