### PR TITLE
Fix example string.

### DIFF
--- a/flowmachine/flowmachine/features/subscriber/subscriber_location_cluster.py
+++ b/flowmachine/flowmachine/features/subscriber/subscriber_location_cluster.py
@@ -290,7 +290,7 @@ class HartiganCluster(BaseCluster):
 
         >>> har = HartiganCluster(cd, 50, call_threshold=1)
 
-        >>> har.join(es).head(geom=['cluster'])
+        >>> har.join_to_cluster_components(es).head(geom=['cluster'])
                     subscriber                                      cluster  rank
         038OVABN11Ak4W5P              POINT (87.26522455 27.58509554)     4
         038OVABN11Ak4W5P               POINT (86.00007467 27.2713931)     7


### PR DESCRIPTION
This PR simply fixes an error in the example of `Hartigan.join_to_cluster_components`.