### PR TITLE
Remove volumes when running 'bash quick_start.sh stop' or 'make down'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,7 @@ up-no_build:
 	docker-compose -f $(DOCKER_COMPOSE_FILE) up -d $(DOCKER_SERVICES)
 
 down:
-	docker-compose -f $(DOCKER_COMPOSE_FILE) down
-
-rm:
-	docker-compose -f $(DOCKER_COMPOSE_FILE) rm -f -s -v
+	docker-compose -f $(DOCKER_COMPOSE_FILE) down -v
 
 
 # Note: the targets below are repetitive and could be simplified by using

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ up-no_build:
 down:
 	docker-compose -f $(DOCKER_COMPOSE_FILE) down
 
+rm:
+	docker-compose -f $(DOCKER_COMPOSE_FILE) rm -f -s -v
+
 
 # Note: the targets below are repetitive and could be simplified by using
 # a pattern rule as follows:

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -92,7 +92,7 @@ then
     export DOCKER_FLOWDB_HOST=flowdb_testdata
     echo "Stopping containers"
     source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/development_environment)"
-    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - down
+    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - down -v
 else
     source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/development_environment)"
      echo "Starting containers (this may take a few minutes)"


### PR DESCRIPTION
Closes #775

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [ ] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This modifies the `make down` and `quick_start.sh stop` targets to run `docker-compose down -v` instead of simply `docker-compose down`, to ensure that volumes are cleaned up properly.