### PR TITLE
Fix uncopyable examples in generate-jwt cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The FERNET_KEY environment variable for FlowAuth is now named FLOWAUTH_FERNET_KEY
 - The quick-start script now correctly aborts if one of the FlowKit services doesn't fully start up [#745](https://github.com/Flowminder/flowkit/issues/745)
 - The maps in the worked examples docs pages now appear in any browser
+- Example invocations of `generate-jwt` are no longer uncopyable due to line wrapping [#778](https://github.com/Flowminder/flowkit/issues/745)
 
 ### Removed
 

--- a/flowkit_jwt_generator/flowkit_jwt_generator/jwt.py
+++ b/flowkit_jwt_generator/flowkit_jwt_generator/jwt.py
@@ -273,10 +273,12 @@ def print_token(username, secret_key, lifetime, audience):
 
     For example:
 
+    \b
     generate-jwt TEST_USER SECRET 1 TEST_SERVER --all-access http://localhost:9090
 
     Or,
 
+    \b
     generate-jwt TEST_USER SECRET 1 TEST_SERVER --query -a admin0 -a admin1 -p run -p get_result daily_location --query -a admin0 -p get_result flows
     """
     pass


### PR DESCRIPTION
Closes #778

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Turns off click's line wrapping for the example invocations of the `generate-jwt` cli, so that they can be copied.