### PR TITLE
Expose TotalLocationEvents 'interval' parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `flowmachine.utils.calculate_dependency_graph` now includes the `Query` objects in the `query_object` field of the graph's nodes dictionary [#767](https://github.com/Flowminder/FlowKit/issues/767)
 - Architectural Decision Records (ADR) have been added and are included in the auto-generated docs [#780](https://github.com/Flowminder/FlowKit/issues/780)
 
+### Fixed
+- API parameter `interval` for `location_event_counts` queries is now correctly passed to the underlying FlowMachine query object [#807](https://github.com/Flowminder/FlowKit/issues/807).
+
 
 ### Changed
 - Parameter names in `flowmachine.connect()` have been renamed as follows to be consistent with the associated environment variables [#728](https://github.com/Flowminder/FlowKit/issues/728):

--- a/flowmachine/flowmachine/core/server/query_schemas/location_event_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/location_event_counts.py
@@ -65,6 +65,7 @@ class LocationEventCountsExposed(BaseExposedQuery):
         return TotalLocationEvents(
             start=self.start_date,
             stop=self.end_date,
+            interval=self.interval,
             direction=self.direction,
             table=self.event_types,
             level=self.aggregation_unit,

--- a/flowmachine/tests/test_query_object_construction.test_construct_query.approved.txt
+++ b/flowmachine/tests/test_query_object_construction.test_construct_query.approved.txt
@@ -9,7 +9,7 @@
       "subscriber_subset": null
     }
   },
-  "fe104962050bf4d6c70c545bb97aa9f7": {
+  "a81e3c6d78666534dd7726f76ff1aaac": {
     "query_kind": "location_event_counts",
     "start_date": "2016-01-01",
     "end_date": "2016-01-02",


### PR DESCRIPTION
Closes #807 

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Exposes the 'interval' parameter of `TotalLocationEvents` objects through the API (this parameter was already included in the API spec, but was not actually passed to the `TotalLocationEvents` object).