### PR TITLE
Move installation of docker-compose into separate ansible role

### DIFF
--- a/deployment/provision-dev.yml
+++ b/deployment/provision-dev.yml
@@ -12,6 +12,7 @@
   roles:
     - base_packages
     - docker
+    - docker-compose
     - role: user_accounts
       username: "{{ username }}"
       password: "{{ password }}"

--- a/deployment/provision.yml
+++ b/deployment/provision.yml
@@ -10,6 +10,7 @@
   roles:
     - base_packages
     - docker
+    - docker-compose
     - role: user_accounts
       username: "{{ username }}"
       password: "{{ password }}"

--- a/deployment/roles/docker/tasks/main.yml
+++ b/deployment/roles/docker/tasks/main.yml
@@ -51,37 +51,10 @@
   when: pipcheck.stdout == ''
   become: yes
 
-# Note: we used to install docker-compose by downloading the binary directly from
-#       the Github releases page and placing it into /usr/local/hin/docker-compose
-#       (as described here: https://docs.docker.com/compose/install/). However, this
-#       does not make the docker-compose Python module available to Ansible (which
-#       is needed for the docker_service ansible module). Therefore we're installing
-#       docker-compose now system-wide via pip. The docs warn that "many operating systems
-#       have python system packages that conflict with docker-compose dependencies".
-#       However, this seems to work fine for CentOS >=7.4 (which we're assuming).
-#- name: "Install docker-compose (version {{ DOCKER_COMPOSE_VERSION }})"
-#  pip:
-#    name: docker-compose
-#    version: "{{ DOCKER_COMPOSE_VERSION }}"
-#  become: yes
-
-- name: "Install docker-compose (version {{ DOCKER_COMPOSE_VERSION }})"
-  get_url:
-    url: https://github.com/docker/compose/releases/download/{{ DOCKER_COMPOSE_VERSION }}/docker-compose-{{ ansible_system }}-{{ ansible_userspace_architecture }}
-    dest: /usr/local/bin/docker-compose
-    mode: 'a+x'
-  become: yes
-
 - name: "Install bash completion for docker"
   get_url:
     url: https://raw.githubusercontent.com/docker/docker-ce/v{{ DOCKER_VERSION }}-ce/components/cli/contrib/completion/bash/docker
     dest: /etc/bash_completion.d/docker-machine
-  become: yes
-
-- name: "Install bash completion for docker-compose"
-  get_url:
-    url: https://raw.githubusercontent.com/docker/compose/{{ DOCKER_COMPOSE_VERSION }}/contrib/completion/bash/docker-compose
-    dest: /etc/bash_completion.d/docker-compose
   become: yes
 
 - name: "Start Docker daemon"
@@ -90,10 +63,6 @@
 
 - name: "Create docker group"
   group: name=docker state=present
-  become: yes
-
-- name: "Add user vagrant to docker group"
-  user: name=vagrant groups=docker append=yes
   become: yes
 
 

--- a/deployment/roles/docker_compose/defaults/main.yml
+++ b/deployment/roles/docker_compose/defaults/main.yml
@@ -2,4 +2,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-DOCKER_VERSION: 18.06.1
+DOCKER_COMPOSE_VERSION: 1.22.0

--- a/deployment/roles/docker_compose/tasks/main.yml
+++ b/deployment/roles/docker_compose/tasks/main.yml
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+ # Note: we used to install docker-compose by downloading the binary directly from
+ #       the Github releases page and placing it into /usr/local/hin/docker-compose
+ #       (as described here: https://docs.docker.com/compose/install/). However, this
+ #       does not make the docker-compose Python module available to Ansible (which
+ #       is needed for the docker_service ansible module). Therefore we're installing
+ #       docker-compose now system-wide via pip. The docs warn that "many operating systems
+ #       have python system packages that conflict with docker-compose dependencies".
+ #       However, this seems to work fine for CentOS >=7.4 (which we're assuming).
+ #- name: "Install docker-compose (version {{ DOCKER_COMPOSE_VERSION }})"
+ #  pip:
+ #    name: docker-compose
+ #    version: "{{ DOCKER_COMPOSE_VERSION }}"
+ #  become: yes
+
+ - name: "Install docker-compose (version {{ DOCKER_COMPOSE_VERSION }})"
+   get_url:
+     url: https://github.com/docker/compose/releases/download/{{ DOCKER_COMPOSE_VERSION }}/docker-compose-{{ ansible_system }}-{{ ansible_userspace_architecture }}
+     dest: /usr/local/bin/docker-compose
+     mode: 'a+x'
+   become: yes
+
+ - name: "Install bash completion for docker-compose"
+   get_url:
+     url: https://raw.githubusercontent.com/docker/compose/{{ DOCKER_COMPOSE_VERSION }}/contrib/completion/bash/docker-compose
+     dest: /etc/bash_completion.d/docker-compose
+   become: yes


### PR DESCRIPTION
### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Small refactoring which separates the installation of `docker` and `docker-compose` into two separate Ansible roles. This makes it a little easier to _not_ install docker-compose (by uncommenting a single line in `provision.yml`), for example in case we want to use docker stack instead of compose.