### PR TITLE
Marshmallow update

### DIFF
--- a/docs/Pipfile
+++ b/docs/Pipfile
@@ -19,7 +19,7 @@ numpydoc = "*"
 black = "==19.3b0"
 click = "*"
 flowmachine = {editable = true,path = "./../flowmachine"}
-marshmallow = {editable = true,ref = "3.0.0rc5",git = "https://github.com/marshmallow-code/marshmallow.git"} # Temporarily required while there's a marshmallow versions conflict
+marshmallow = {editable = true,ref = "3.0.0rc6",git = "https://github.com/marshmallow-code/marshmallow.git"} # Temporarily required while there's a marshmallow versions conflict
 marshmallow-oneofschema = {editable = true,ref = "8195dc3e595fa33a5f007f10ba7cfc08f2177515",git = "https://github.com/marshmallow-code/marshmallow-oneofschema.git"} # Temporarily required while there's a marshmallow versions conflict
 descartes = "*"
 flowclient = {editable = true,path = "./../flowclient"}

--- a/docs/Pipfile.lock
+++ b/docs/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1e392b8cebb965b165447d0f3f0c3a7b4f33aa83b9da193bd9e4053bcd51e0ae"
+            "sha256": "205d8f8e7b5015ab3aa761734bdefbf8e80fa6bd3ebe9f8c676ac53776f25de6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -321,10 +321,10 @@
         },
         "flask": {
             "hashes": [
-                "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48",
-                "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
+                "sha256:ad7c6d841e64296b962296c2c2dabc6543752985727af86a975072dea984b6f3",
+                "sha256:e7d32475d1de5facaa55e3958bc4ec66d3762076b074296aa50ef8fdc5b9df61"
             ],
-            "version": "==1.0.2"
+            "version": "==1.0.3"
         },
         "flask-jwt-extended": {
             "hashes": [
@@ -415,11 +415,11 @@
         },
         "ipykernel": {
             "hashes": [
-                "sha256:0aeb7ec277ac42cc2b59ae3d08b10909b2ec161dc6908096210527162b53675d",
-                "sha256:0fc0bf97920d454102168ec2008620066878848fcfca06c22b669696212e292f"
+                "sha256:346189536b88859937b5f4848a6fd85d1ad0729f01724a411de5cae9b618819c",
+                "sha256:f0e962052718068ad3b1d8bcc703794660858f58803c3798628817f492a8769c"
             ],
             "index": "pypi",
-            "version": "==5.1.0"
+            "version": "==5.1.1"
         },
         "ipython": {
             "hashes": [
@@ -569,7 +569,7 @@
         "marshmallow": {
             "editable": true,
             "git": "https://github.com/marshmallow-code/marshmallow.git",
-            "ref": "01837167ef1758df1f2decb819e7294200ec9f67"
+            "ref": "a04d481865a44e24ede38eaa921c3fc76111a48c"
         },
         "marshmallow-oneofschema": {
             "editable": true,
@@ -578,17 +578,17 @@
         },
         "matplotlib": {
             "hashes": [
-                "sha256:00b3b4febc91b43f82dd732bfff2edc397386dfd093ea7be1eb0f8f964295914",
-                "sha256:18840067e75af824009538af4b46a835c38befb4680c31f927661d3009a8f38f",
-                "sha256:3fabcbbba7330d9bbd57167c79e1df862d97e3795c3ea98b69686f7dfd301bed",
-                "sha256:4d88eaf52d077507caf08299f1d97eb8b967687a48d612a513ba862f6e6f713d",
-                "sha256:62f1c4acda47690478b949a8d2d45eb707246331cf19d64c5f461796f52bb36d",
-                "sha256:881d857e7c358ad81ca27ca16f6d7c72da8b0d4bd129d6e7267354761a479176",
-                "sha256:89574094a1deecbd7e9454196b28745feae703bb480aa3359cc9f2a4db0a03c8",
-                "sha256:92f10282f38b2b7d2d685da317ac9b1c2bf224e68815fc83a0d2145babc0c6fc",
-                "sha256:a48f3a2fb8f43d933085e48971204a6701ab72afa3574981072874727628d2c9"
+                "sha256:08d9bc2e2acef42965256acd5015dc2c899cbd53e01bf4214c5510c7ea0efd2d",
+                "sha256:1e0213f87cc0076f7b0c4c251d7e23601e2419cd98691df79edb95517ba06f0c",
+                "sha256:1f31053f660df5f0310118d7f5bd1e8025170e9773f0bebe8fec486d0926adf6",
+                "sha256:399bf6352633aeeb45ca55c6c943fa2738022fb17ae498c32a142ced0b41528d",
+                "sha256:409a5894efb810d630d2512449c7a4394de9a4d15fc6394e26a409b17d9cc18c",
+                "sha256:5c5ef5cf1bc8f483123102e2615644937af7d4c01d100acc72bf74a044a78717",
+                "sha256:d0052be5cdfa27018bb08194b8812c47cb985d60eb682e1809c76e9600839516",
+                "sha256:e7d6620d145ca9f6c3e88248e5734b6fda430e75e70755b887e48f8e9bc1de2a",
+                "sha256:f3d8b6bccc577e4e5ecbd58fdd63cacb8e58f0ed1e97616a7f7a7baaf4b8d036"
             ],
-            "version": "==3.1.0rc2"
+            "version": "==3.1.0"
         },
         "mistune": {
             "hashes": [
@@ -607,11 +607,11 @@
         },
         "mkdocs-material": {
             "hashes": [
-                "sha256:4ffe7d8c0c3c53c5313a910c14a88820be74beebb53ed14c9056e521ea9793d5",
-                "sha256:d64b9555ae4ee86fe07a18612c9bd488f3b74a0afd3d9ead7e29efc59d98ca80"
+                "sha256:1c39b6af13a900d9f47ab2b8ac67b3258799f4570b552573e9d6868ad6a438e9",
+                "sha256:22073941cff7176e810b719aced6a90381e64a96d346b8a6803a06b7192b7ad5"
             ],
             "index": "pypi",
-            "version": "==4.2.0"
+            "version": "==4.3.0"
         },
         "mknotebooks": {
             "hashes": [
@@ -1063,10 +1063,10 @@
         },
         "requests": {
             "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
-            "version": "==2.21.0"
+            "version": "==2.22.0"
         },
         "shapely": {
             "hashes": [
@@ -1225,10 +1225,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
-                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
+                "sha256:a53063d8b9210a7bdec15e7b272776b9d42b2fd6816401a0d43006ad2f9902db",
+                "sha256:d363e3607d8de0c220d31950a8f38b18d5ba7c0830facd71a1c6b1036b7ce06c"
             ],
-            "version": "==1.24.3"
+            "version": "==1.25.2"
         },
         "wcwidth": {
             "hashes": [
@@ -1246,10 +1246,10 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:0a73e8bb2ff2feecfc5d56e6f458f5b99290ef34f565ffb2665801ff7de6af7a",
-                "sha256:7fad9770a8778f9576693f0cc29c7dcc36964df916b83734f4431c0e612a7fbc"
+                "sha256:865856ebb55c4dcd0630cdd8f3331a1847a819dda7e8c750d3db6f2aa6c0209c",
+                "sha256:a0b915f0815982fb2a09161cb8f31708052d0951c3ba433ccc5e1aa276507ca6"
             ],
-            "version": "==0.15.2"
+            "version": "==0.15.4"
         },
         "wsproto": {
             "hashes": [
@@ -1312,11 +1312,11 @@
         },
         "ipykernel": {
             "hashes": [
-                "sha256:0aeb7ec277ac42cc2b59ae3d08b10909b2ec161dc6908096210527162b53675d",
-                "sha256:0fc0bf97920d454102168ec2008620066878848fcfca06c22b669696212e292f"
+                "sha256:346189536b88859937b5f4848a6fd85d1ad0729f01724a411de5cae9b618819c",
+                "sha256:f0e962052718068ad3b1d8bcc703794660858f58803c3798628817f492a8769c"
             ],
             "index": "pypi",
-            "version": "==5.1.0"
+            "version": "==5.1.1"
         },
         "ipython": {
             "hashes": [

--- a/flowapi/Pipfile.lock
+++ b/flowapi/Pipfile.lock
@@ -71,10 +71,10 @@
         },
         "flask": {
             "hashes": [
-                "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48",
-                "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
+                "sha256:ad7c6d841e64296b962296c2c2dabc6543752985727af86a975072dea984b6f3",
+                "sha256:e7d32475d1de5facaa55e3958bc4ec66d3762076b074296aa50ef8fdc5b9df61"
             ],
-            "version": "==1.0.2"
+            "version": "==1.0.3"
         },
         "flask-jwt-extended": {
             "hashes": [
@@ -572,10 +572,10 @@
         },
         "requests": {
             "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
-            "version": "==2.21.0"
+            "version": "==2.22.0"
         },
         "six": {
             "hashes": [
@@ -593,10 +593,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
-                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
+                "sha256:a53063d8b9210a7bdec15e7b272776b9d42b2fd6816401a0d43006ad2f9902db",
+                "sha256:d363e3607d8de0c220d31950a8f38b18d5ba7c0830facd71a1c6b1036b7ce06c"
             ],
-            "version": "==1.24.3"
+            "version": "==1.25.2"
         },
         "wcwidth": {
             "hashes": [

--- a/flowmachine/Pipfile
+++ b/flowmachine/Pipfile
@@ -19,7 +19,7 @@ structlog = "*"
 shapely = "*"
 finist = "*"
 python-rapidjson = "*"
-marshmallow = {editable = true,ref = "3.0.0rc5",git = "https://github.com/marshmallow-code/marshmallow.git"} # Temporarily required while there's a marshmallow versions conflict
+marshmallow = {editable = true,ref = "3.0.0rc6",git = "https://github.com/marshmallow-code/marshmallow.git"} # Temporarily required while there's a marshmallow versions conflict
 marshmallow-oneofschema = {editable = true,ref = "8195dc3e595fa33a5f007f10ba7cfc08f2177515",git = "https://github.com/marshmallow-code/marshmallow-oneofschema.git"} # Temporarily required while there's a marshmallow versions conflict
 apispec-oneofschema = "*"
 

--- a/flowmachine/Pipfile.lock
+++ b/flowmachine/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "365790cee03b5af858bc16ff80f80162d58f4e00a06d4b83e82cedfeeed3eeea"
+            "sha256": "3265c98e4a2e887455cb4e03577541fc4252e95e555a5990ec481d4ad5065054"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -55,7 +55,7 @@
         "marshmallow": {
             "editable": true,
             "git": "https://github.com/marshmallow-code/marshmallow.git",
-            "ref": "01837167ef1758df1f2decb819e7294200ec9f67"
+            "ref": "a04d481865a44e24ede38eaa921c3fc76111a48c"
         },
         "marshmallow-oneofschema": {
             "editable": true,
@@ -308,6 +308,14 @@
             ],
             "version": "==1.4.3"
         },
+        "appnope": {
+            "hashes": [
+                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
+                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.0"
+        },
         "approvaltests": {
             "hashes": [
                 "sha256:15c18543f68dcdb124295b9fc0135096f86a9d973381ff5936e40a4457c02038"
@@ -508,10 +516,10 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:2f2e54cbf6b06b16351e4c40a6adb0860cab6cfb95a0c0fcb58bb789c4b450f5",
-                "sha256:37bbea81dec44d1ff72d58a1b5c1599a9f3436537f33e9e26f276610064c4830"
+                "sha256:0e375a4c177090292988d1c2f997c7c2467d908c1adbed3e08fb511486c85457",
+                "sha256:440815529340fb7fdd6a83ebf4258cc2860fb3770d37b52875e37c6f509a4cd6"
             ],
-            "version": "==0.12"
+            "version": "==0.13"
         },
         "ipdb": {
             "hashes": [
@@ -599,21 +607,17 @@
         },
         "matplotlib": {
             "hashes": [
-                "sha256:1ae6549976b6ceb6ee426272a28c0fc9715b3e3669694d560c8f661c5b39e2c5",
-                "sha256:4d4250bf508dd07cca3b43888097f873cadb66eec6ac63dbbfb798798ec07af2",
-                "sha256:53af2e01d7f1700ed2b64a9091bc865360c9c4032f625451c4589a826854c787",
-                "sha256:63e498067d32d627111cd1162cae1621f1221f9d4c6a9745dd7233f29de581b6",
-                "sha256:7169a34971e398dd58e87e173f97366fd88a3fa80852704530433eb224a8ca57",
-                "sha256:91c54d6bb9eeaaff965656c5ea6cbdcbf780bad8462ac99b30b451548194746f",
-                "sha256:aeef177647bb3fccfe09065481989d7dfc5ac59e9367d6a00a3481062cf651e4",
-                "sha256:cf8ae10559a78aee0409ede1e9d4fda03895433eeafe609dd9ed67e45f552db0",
-                "sha256:d51d0889d1c4d51c51a9822265c0494ea3e70a52bdd88358e0863daca46fa23a",
-                "sha256:de5ccd3500247f85fe4f9fad90f80a8bd397e4f110a4c33fabf95f07403e8372",
-                "sha256:e1d33589e32f482d0a7d1957bf473d43341115d40d33f578dad44432e47df7b7",
-                "sha256:e8d1939262aa6b36d0c51f50a50a43a04b9618d20db31e6c0192b1463067aeef",
-                "sha256:e918d51b1fda82a65fdf52d2f3914b2246481cc2a9cd10e223e6be6078916ff3"
+                "sha256:08d9bc2e2acef42965256acd5015dc2c899cbd53e01bf4214c5510c7ea0efd2d",
+                "sha256:1e0213f87cc0076f7b0c4c251d7e23601e2419cd98691df79edb95517ba06f0c",
+                "sha256:1f31053f660df5f0310118d7f5bd1e8025170e9773f0bebe8fec486d0926adf6",
+                "sha256:399bf6352633aeeb45ca55c6c943fa2738022fb17ae498c32a142ced0b41528d",
+                "sha256:409a5894efb810d630d2512449c7a4394de9a4d15fc6394e26a409b17d9cc18c",
+                "sha256:5c5ef5cf1bc8f483123102e2615644937af7d4c01d100acc72bf74a044a78717",
+                "sha256:d0052be5cdfa27018bb08194b8812c47cb985d60eb682e1809c76e9600839516",
+                "sha256:e7d6620d145ca9f6c3e88248e5734b6fda430e75e70755b887e48f8e9bc1de2a",
+                "sha256:f3d8b6bccc577e4e5ecbd58fdd63cacb8e58f0ed1e97616a7f7a7baaf4b8d036"
             ],
-            "version": "==3.0.3"
+            "version": "==3.1.0"
         },
         "more-itertools": {
             "hashes": [
@@ -969,10 +973,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:46dfd547d9ccbf8bdc26ecea52818046bb28509f12bb6a0de1cd66ab06e9a9be",
-                "sha256:d7ac25f895fb65bff937b381353c14eb1fa23d35f40abd72a5342cd57eb57fd1"
+                "sha256:8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d",
+                "sha256:ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
             ],
-            "version": "==0.5.0"
+            "version": "==0.5.1"
         }
     }
 }

--- a/flowmachine/setup.py
+++ b/flowmachine/setup.py
@@ -72,7 +72,7 @@ setup(
         "SQLAlchemy",
         "cachetools",
         "apispec-oneofschema",
-        "marshmallow>=3.0.0rc5",  # TODO: unpin
+        "marshmallow>=3.0.0rc6",  # TODO: unpin
         "marshmallow-oneofschema==2.0.0b2",  # TODO: unpin
         "numpy",
         "networkx",

--- a/integration_tests/Pipfile
+++ b/integration_tests/Pipfile
@@ -17,7 +17,7 @@ requests = "*"
 sqlalchemy = "*"
 pytest-asyncio = "*"
 flowmachine = {editable = true,path = "./../flowmachine"}
-marshmallow = {editable = true,ref = "3.0.0rc5",git = "https://github.com/marshmallow-code/marshmallow.git"} # Temporarily required while there's a marshmallow versions conflict
+marshmallow = {editable = true,ref = "3.0.0rc6",git = "https://github.com/marshmallow-code/marshmallow.git"} # Temporarily required while there's a marshmallow versions conflict
 marshmallow-oneofschema = {editable = true,ref = "8195dc3e595fa33a5f007f10ba7cfc08f2177515",git = "https://github.com/marshmallow-code/marshmallow-oneofschema.git"} # Temporarily required while there's a marshmallow versions conflict
 flowclient = {editable = true,path = "./../flowclient"}
 flowapi = {editable = true,path = "./../flowapi"}

--- a/integration_tests/Pipfile.lock
+++ b/integration_tests/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9b6ac3ee8807b0ea2dd1d826a759f947a6e6351fc1d0a86c3c8a94f965bc2953"
+            "sha256": "15407338e18c12cd2348d06ca60a097ebef82c03e51e07706c66c46e99c92034"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -252,10 +252,10 @@
         },
         "flask": {
             "hashes": [
-                "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48",
-                "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
+                "sha256:ad7c6d841e64296b962296c2c2dabc6543752985727af86a975072dea984b6f3",
+                "sha256:e7d32475d1de5facaa55e3958bc4ec66d3762076b074296aa50ef8fdc5b9df61"
             ],
-            "version": "==1.0.2"
+            "version": "==1.0.3"
         },
         "flask-jwt-extended": {
             "hashes": [
@@ -386,7 +386,7 @@
         "marshmallow": {
             "editable": true,
             "git": "https://github.com/marshmallow-code/marshmallow.git",
-            "ref": "01837167ef1758df1f2decb819e7294200ec9f67"
+            "ref": "a04d481865a44e24ede38eaa921c3fc76111a48c"
         },
         "marshmallow-oneofschema": {
             "editable": true,


### PR DESCRIPTION
Bumps marshmallow to rc6 from rc5.

3.0.0rc6 (2019-05-05)
+++++++++++++++++++++

Support:

- *Backwards-incompatible*: Remove support for Python 2 (:issue:`1120`).
  Only Python>=3.5 is supported.
  Thank you :user:`rooterkyberian` for the suggestion and the PR.
- *Backwards-incompatible*: Remove special-casing in ``fields.List`` and
  ``fields.Tuple`` for accessing nested attributes (:pr:`1188`).
  Use ``fields.List(fields.Pluck(...))`` instead.
- Add ``python_requires`` to ``setup.py`` (:pr:`1194`).
  Thanks :user:`hugovk`.
- Upgrade syntax with ``pyupgrade`` in pre-commit (:pr:`1195`). Thanks
  again :user:`hugovk`.