### PR TITLE
Fix docs links

### DIFF
--- a/docs/source/administrator.md
+++ b/docs/source/administrator.md
@@ -2,7 +2,7 @@ Title: Administrator
 
 # Administration Tools
 
-This section contains information on managing the [cache](#caching) and [log files](#logging) relevant to system administrators.
+This section contains information on managing the [cache](#caching) and [log files](#logging-and-audit-trails) relevant to system administrators.
 
 <a name="caching">
 ## Caching in FlowKit

--- a/docs/source/analyst.md
+++ b/docs/source/analyst.md
@@ -38,4 +38,4 @@ To connect FlowClient to FlowAPI, an access token must be generated using FlowAu
 
 ## FlowAPI
 
-Advanced users may wish to write their own clients that interface directly to FlowAPI. This is discussed in more detail in the [Developer](developer.md) section of these documents.
+Advanced users may wish to write their own clients that interface directly to FlowAPI. This is discussed in more detail in the [Developer](developer/developer.md) section of these documents.

--- a/docs/source/developer/adr/0001-pipenv-for-package-and-dependency-management.md
+++ b/docs/source/developer/adr/0001-pipenv-for-package-and-dependency-management.md
@@ -30,7 +30,7 @@ brief summary given our context.
 - Cons: same as `pip`
 
 
-(c) [conda](https://conda.io/miniconda.html)
+&#40;c) [conda](https://conda.io/miniconda.html)
 
 - Pros: supports packaging of non-Python dependencies (e.g. third-party libraries), which is advantageous if the user doesn't have full control over the system (e.g. installation in a non-admin environment)
 - Cons: introduces a third-party dependency; not always clear which conda channels provide which packages

--- a/docs/source/developer/developer.md
+++ b/docs/source/developer/developer.md
@@ -1,6 +1,6 @@
 # Information for Developers
 
-Because FlowKit deployment is primarily done using Docker, the installation for developers is slightly different, see the instructions [here](install.md). 
+Because FlowKit deployment is primarily done using Docker, the installation for developers is slightly different, see the instructions [here](../install.md). 
 
 An outline roadmap is provided below together with details about [contributing to the project](#contrib).
 
@@ -139,7 +139,7 @@ At present, the following query types are accessible through FlowAPI:
 
 ### FlowAPI Access tokens
 
-As explained in the [quick install guide](install.md), user authentication and access control are handled through the use of [JSON Web Tokens (JWT)](http://jwt.io). There are two categories of permissions which can be granted to a user:
+As explained in the [quick install guide](../install.md#quickinstall), user authentication and access control are handled through the use of [JSON Web Tokens (JWT)](http://jwt.io). There are two categories of permissions which can be granted to a user:
 
 - API route permissions
 
@@ -149,7 +149,7 @@ As explained in the [quick install guide](install.md), user authentication and a
 
     Level of spatial aggregation at which the user is allowed to access the results of queries. Currently supports administrative levels `admin0`, `admin1`, `admin2`, `admin3`.
 
-JWTs allow these access permissions to be granted independently for each query kind (e.g. `daily_location`, `modal_location`). The [FlowAuth](install.md#installing-flowauth) authentication management system is designed to generate JWTs for accessing FlowAPI.
+JWTs allow these access permissions to be granted independently for each query kind (e.g. `daily_location`, `modal_location`). The FlowAuth authentication management system is designed to generate JWTs for accessing FlowAPI.
 
 #### Test Tokens
 
@@ -172,7 +172,7 @@ FlowMachine is a Python toolkit for the analysis of CDR data. It is essentially 
 
 ### Documentation
 
-Documentation for FlowMachine can be found [here](../flowmachine/flowmachine/). A worked example of using FlowMachine for analysis is provided [here](../worked_examples/mobile-data-usage/).
+Documentation for FlowMachine can be found [here](../../flowmachine/flowmachine/). A worked example of using FlowMachine for analysis is provided [here](../../worked_examples/mobile-data-usage/).
 
 
 <a name="flowdb">

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -50,7 +50,7 @@ This architecture is shown in the figure below.
 
     A further container is created to host a redis message platform used internally by FlowMachine.  
 
-FlowKit is in active development, visit the project's  [roadmap](developer.md#roadmap) to get a sense about upcoming developments.
+FlowKit is in active development, visit the project's [roadmap](developer/developer.md#roadmap) to get a sense about upcoming developments.
 
 Continue to the FlowKit [installation documents](install.md) to find out what type of install meets your requirements.
 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -33,7 +33,7 @@ The bulk of the installation process consists of using [Docker Compose](https://
 
 These instructions assume use of [Pyenv](https://github.com/pyenv/pyenv) and [Pipenv](https://github.com/pypa/pipenv). If you are using [Anaconda](https://www.anaconda.com/what-is-anaconda/)-based installation commands may be different.
 
-Docker containers for FlowAPI, FlowMachine, FlowDB, FlowAuth and the worked examples are provided in the DockerCloud repositories [flowminder/flowapi](http://https://hub.docker.com/r/flowminder/flowapi), [flowminder/flowmachine](http://https://hub.docker.com/r/flowminder/flowmachine), [flowminder/flowdb](http://https://hub.docker.com/r/flowminder/flowdb), [flowminder/flowauth](http://https://hub.docker.com/r/flowminder/flowauth), and [flowminder/flowkit-examples](http://https://hub.docker.com/r/flowminder/flowkit-examples) respectively. To install them, you will need [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/).
+Docker containers for FlowAPI, FlowMachine, FlowDB, FlowAuth and the worked examples are provided in the DockerCloud repositories [flowminder/flowapi](https://hub.docker.com/r/flowminder/flowapi), [flowminder/flowmachine](https://hub.docker.com/r/flowminder/flowmachine), [flowminder/flowdb](https://hub.docker.com/r/flowminder/flowdb), [flowminder/flowauth](https://hub.docker.com/r/flowminder/flowauth), and [flowminder/flowkit-examples](https://hub.docker.com/r/flowminder/flowkit-examples) respectively. To install them, you will need [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/).
 
 Start the FlowKit test system by running 
 
@@ -157,7 +157,7 @@ pipenv install --dev
 pipenv run pytest
 ```
 
-Also see [Setting up a development environment](dev_environment_setup.md) for further details on setting up FlowKit for code development.
+Also see [Setting up a development environment](developer/dev_environment_setup.md) for further details on setting up FlowKit for code development.
 
 
  <a name="prodinstall">
@@ -171,7 +171,7 @@ Contact Flowminder on [flowkit@flowminder.org](mailto:flowkit@flowminder.org) fo
 
 FlowAuth is designed to be deployed as a single Docker container working in cooperation with a database and, typically, an ssl reverse proxy (e.g. [nginx-proxy](https://github.com/jwilder/nginx-proxy) combined with [letsencrypt-nginx-proxy-companion](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion)).
 
-FlowAuth supports any database supported by [SQLAlchemy](https://sqlache.me), and to connect you will only need to supply a correct URI for the database either using the `DB_URI` environment variable, or by setting the `DB_URI` secret. If `DB_URI` is not set, a temporary sqlite database will be created.
+FlowAuth supports any database supported by [SQLAlchemy](https://sqlalche.me), and to connect you will only need to supply a correct URI for the database either using the `DB_URI` environment variable, or by setting the `DB_URI` secret. If `DB_URI` is not set, a temporary sqlite database will be created.
 
 On first use, you will need to create the necessary tables and an administrator account. 
 
@@ -190,7 +190,7 @@ While `SECRET_KEY` can be any arbitrary string, `FLOWAUTH_FERNET_KEY` should be 
 
 The standard Docker compose file supplies a number of 'secret' values as environment variables. Typically, this is a bad idea.
 
-Instead, you should make use of [docker secrets](https://docs.docker.com/engine/swarm/secrets/), which are stored securely in docker and only made available _inside_ containers.  The `secrets_quickstart` directory contains a [docker _stack_](https://docs.docker.com/docker-cloud/apps/stack-yaml-reference/) file (`docker-stack.yml`). The stack file is very similar to a compose file, but removes container names, and adds a new section - secrets.
+Instead, you should make use of [docker secrets](https://docs.docker.com/engine/swarm/secrets/), which are stored securely in docker and only made available _inside_ containers.  The `secrets_quickstart` directory contains a docker _stack_ file (`docker-stack.yml`). The stack file is very similar to a compose file, but removes container names, and adds a new section - [secrets](https://docs.docker.com/compose/compose-file/#secrets-configuration-reference).
 
 The stack expects you to provide eight secrets:
 

--- a/docs/source/license.md
+++ b/docs/source/license.md
@@ -125,7 +125,7 @@ Contributor:
     Contributions with other software (except as part of its Contributor
     Version); or
 
-(c) under Patent Claims infringed by Covered Software in the absence of
+&#40;c) under Patent Claims infringed by Covered Software in the absence of
     its Contributions.
 
 This License does not grant any rights in the trademarks, service marks,


### PR DESCRIPTION
Closes #823

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Fixes a few broken links in the docs, and also a couple of `(c)`s which were appearing as &copy;