### PR TITLE
Fix sporadic flowauth fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - FlowAuth's docker container can now be used with a Postgres backing database. [#825](https://github.com/Flowminder/FlowKit/issues/825) 
 - FlowAPI now starts up successfully when following the "Secrets Quickstart" instructions in the docs. [#836](https://github.com/Flowminder/FlowKit/issues/836)
 - The command to generate an SSL certificate in the "Secrets Quickstart" section in the docs has been fixed and made more robust [#837](https://github.com/Flowminder/FlowKit/issues/837)
+- FlowAuth will no longer try to initialise the database or create demo data multiple times when running under uwsgi with multiple workers [#844](https://github.com/Flowminder/FlowKit/issues/844)
 
 ### Removed
 - The `FLOWDB_SERVICES` environment variable has been removed from the toplevel Makefile, so that now `DOCKER_SERVICES` is the only environment variable that controls which services are spun up when running `make up`. [#827](https://github.com/Flowminder/FlowKit/issues/827)

--- a/flowauth/backend/flowauth/__init__.py
+++ b/flowauth/backend/flowauth/__init__.py
@@ -1,6 +1,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
 from functools import partial
 
 import flask
@@ -51,15 +53,14 @@ def create_app(test_config=None):
         aggregation_unit_blueprint, url_prefix="/spatial_aggregation"
     )
 
-    # Initialise the database
-    app.before_first_request(partial(init_db, force=app.config["RESET_DB"]))
-
     # Set the log level
     app.before_first_request(partial(app.logger.setLevel, app.config["LOG_LEVEL"]))
 
     if app.config["DEMO_MODE"]:  # Create demo data
         app.before_first_request(make_demodata)
     else:
+        # Initialise the database
+        app.before_first_request(partial(init_db, force=app.config["RESET_DB"]))
         # Create an admin user
         app.before_first_request(
             partial(
@@ -68,6 +69,10 @@ def create_app(test_config=None):
                 password=app.config["ADMIN_PASSWORD"],
             )
         )
+
+    app.before_first_request(
+        app.config["DB_IS_SET_UP"].wait
+    )  # Cause workers to wait for db to set up
 
     @app.after_request
     def set_xsrf_cookie(response):

--- a/flowauth/backend/flowauth/config.py
+++ b/flowauth/backend/flowauth/config.py
@@ -1,6 +1,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from multiprocessing import Event
+
 from typing import Optional
 
 import logging
@@ -70,4 +72,6 @@ def get_config():
         FLOWAUTH_FERNET_KEY=flowauth_fernet_key,
         DEMO_MODE=True if os.getenv("DEMO_MODE") is not None else False,
         RESET_DB=True if os.getenv("RESET_FLOWAUTH_DB") is not None else False,
+        DB_IS_SETTING_UP=Event(),
+        DB_IS_SET_UP=Event(),
     )

--- a/flowauth/backend/flowauth/models.py
+++ b/flowauth/backend/flowauth/models.py
@@ -491,11 +491,14 @@ def init_db(force: bool = False) -> None:
         )
         return
     current_app.config["DB_IS_SETTING_UP"].set()
+    current_app.logger.debug("Initialising db.")
     if force:
+        current_app.logger.debug("Dropping existing db.")
         db.drop_all()
     db.create_all()
     current_app.config["DB_IS_SET_UP"].set()
     current_app.config["DB_IS_SETTING_UP"].clear()
+    current_app.logger.debug("Initialised db.")
 
 
 @click.command("add-admin")
@@ -545,12 +548,15 @@ def make_demodata():
     Generate some demo data.
     """
     if current_app.config["DB_IS_SET_UP"].is_set():
-        current_app.logger.debug("Database already set up, skipping.")
+        current_app.logger.debug("Database already set up by another worker, skipping.")
         return
     if current_app.config["DB_IS_SETTING_UP"].is_set():
-        current_app.logger.debug("Database setup in progress, skipping.")
+        current_app.logger.debug(
+            "Database setup in progress by another worker, skipping."
+        )
         return
     current_app.config["DB_IS_SETTING_UP"].set()
+    current_app.logger.debug("Creating demo data.")
     db.drop_all()
     db.create_all()
     agg_units = [SpatialAggregationUnit(name=f"admin{x}") for x in range(4)]
@@ -637,6 +643,7 @@ def make_demodata():
     db.session.commit()
     current_app.config["DB_IS_SET_UP"].set()
     current_app.config["DB_IS_SETTING_UP"].clear()
+    current_app.logger.debug("Made demo data.")
 
 
 @click.command("demodata")

--- a/flowauth/backend/tests/test_commands.py
+++ b/flowauth/backend/tests/test_commands.py
@@ -64,6 +64,7 @@ def test_init_db_force(app):
             add_admin_command, ["DUMMY_ADMINISTRATOR", "DUMMY_ADMINISTATOR_PASSWORD"]
         )
         assert len(User.query.all()) > 0
+        app.config["DB_IS_SET_UP"].clear()
         result = runner.invoke(init_db_command, ["--force"])
         assert len(User.query.all()) == 0
 
@@ -74,6 +75,7 @@ def test_demo_data(app):
     """
     with app.app_context():
         runner = app.test_cli_runner()
+        app.config["DB_IS_SET_UP"].clear()
         result = runner.invoke(demodata)
         assert len(User.query.all()) == 2
         assert len(Group.query.all()) == 3

--- a/flowauth/backend/tests/test_commands.py
+++ b/flowauth/backend/tests/test_commands.py
@@ -69,6 +69,61 @@ def test_init_db_force(app):
         assert len(User.query.all()) == 0
 
 
+def test_demo_data_only_sets_up_once(app, caplog):
+    """
+    Demo data should only be created once.
+    """
+    with app.app_context():
+        runner = app.test_cli_runner()
+        app.config["DB_IS_SET_UP"].clear()
+        result = runner.invoke(demodata)
+        result = runner.invoke(demodata)
+        assert len(User.query.all()) == 2
+        assert len(Group.query.all()) == 3
+    assert "Database already set up by another worker, skipping." in caplog.text
+
+
+def test_demo_data_skips_when_in_progress(app, caplog):
+    """
+    Shouldn't attempt to create demo data if something else is.
+    """
+    with app.app_context():
+        runner = app.test_cli_runner()
+        app.config["DB_IS_SET_UP"].clear()
+        app.config["DB_IS_SETTING_UP"].set()
+        result = runner.invoke(demodata)
+        assert len(User.query.all()) == 1
+        assert len(Group.query.all()) == 1
+    assert "Database setup in progress by another worker, skipping." in caplog.text
+
+
+def test_db_init_skips_when_in_progress(app, caplog):
+    """
+    Shouldn't attempt to init the db if something else is.
+    """
+    with app.app_context():
+        runner = app.test_cli_runner()
+        app.config["DB_IS_SET_UP"].clear()
+        app.config["DB_IS_SETTING_UP"].set()
+        result = runner.invoke(init_db_command)
+
+        assert len(User.query.all()) == 1
+        assert len(Group.query.all()) == 1
+    assert "Database setup in progress by another worker, skipping." in caplog.text
+
+
+def test_db_init_only_runs_once(app, caplog):
+    """
+    Shouldn't attempt to init the db if something else has.
+    """
+    with app.app_context():
+        runner = app.test_cli_runner()
+        app.config["DB_IS_SET_UP"].set()
+        result = runner.invoke(init_db_command)
+
+    assert "Database already set up by another worker, skipping." in caplog.text
+
+
 def test_demo_data(app):
     """
     DB should contain demo data..


### PR DESCRIPTION
Closes #844

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 


### Description

Added two multiprocessing `Event`s, which prevent more than one forked flowauth process from trying to initialise the database, or create demo data, and will cause others to wait until this is done.