### PR TITLE
Display year, seconds, tz when creating tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- When creating a new token in FlowAuth, the expiry now always shows the year, seconds till expiry, and timezone. [#260](https://github.com/Flowminder/FlowKit/issues/260)
+
 ### Removed
 
 ## [0.6.4]
 
 ### Added
 
-- Buttons to copy token to clipboard and download token as file added to token list page.[#704](https://github.com/Flowminder/FlowKit/issues/704)
+- Buttons to copy token to clipboard and download token as file added to token list page. [#704](https://github.com/Flowminder/FlowKit/issues/704)
 - Two new worked examples: "Cell Towers Per Region" and "Unique Subscriber Counts". [#633](https://github.com/Flowminder/FlowKit/issues/633), [#634](https://github.com/Flowminder/FlowKit/issues/634)
 
 ### Changed

--- a/flowauth/frontend/src/TokenDetails.js
+++ b/flowauth/frontend/src/TokenDetails.js
@@ -25,12 +25,16 @@ const styles = theme => ({
 });
 
 class TokenDetails extends React.Component {
+  constructor(props) {
+    super(props);
+    this.nameRef = React.createRef();
+  }
   state = {
     nickName: {},
     rights: {},
     expiry: new Date(),
     latest_expiry: new Date(),
-    username_helper_text: ""
+    name_helper_text: ""
   };
 
   handleSubmit = () => {
@@ -42,6 +46,11 @@ class TokenDetails extends React.Component {
           cancel();
         }
       );
+    } else if (!name) {
+      this.setState({
+        name_helper_text: "Token name cannot be blank."
+      });
+      this.scrollToRef(this.nameRef);
     }
   };
 
@@ -55,6 +64,7 @@ class TokenDetails extends React.Component {
     rights[claim].permissions[right] = event.target.checked;
     this.setState(Object.assign(this.state, { rights: rights }));
   };
+  scrollToRef = ref => ref.current.scrollIntoView();
 
   handleAggUnitChange = (claim_id, claim, unit) => event => {
     var rights = this.state.rights;
@@ -177,6 +187,7 @@ class TokenDetails extends React.Component {
 
     return (
       <React.Fragment>
+        <div ref={this.nameRef} />
         <Grid item xs={12}>
           <Typography variant="h5" component="h1">
             Token Name
@@ -191,7 +202,7 @@ class TokenDetails extends React.Component {
             value={name}
             onChange={this.handleNameChange}
             margin="normal"
-            error={this.state.name_helper_text}
+            error={this.state.name_helper_text !== ""}
             helperText={this.state.name_helper_text}
           />
         </Grid>
@@ -201,16 +212,22 @@ class TokenDetails extends React.Component {
           </Typography>
         </Grid>
         <Divider />
-        <Grid item xs={12}>
+        <Grid item xs>
           <MuiPickersUtilsProvider utils={DateFnsUtils}>
             <DateTimePicker
               value={expiry}
               onChange={this.handleDateChange}
               disablePast={true}
               maxDate={latest_expiry}
+              format="yyyy/MM/dd HH:mm:ss"
+              ampm={false}
+              margin="normal"
+              helperText={new Date().toTimeString().slice(9)}
             />
           </MuiPickersUtilsProvider>
         </Grid>
+
+        <Divider />
         <Grid item xs={12}>
           <Typography variant="h5" component="h1">
             API Permissions

--- a/flowauth/frontend/src/TokenDetails.js
+++ b/flowauth/frontend/src/TokenDetails.js
@@ -222,7 +222,7 @@ class TokenDetails extends React.Component {
               format="yyyy/MM/dd HH:mm:ss"
               ampm={false}
               margin="normal"
-              helperText={new Date().toTimeString().slice(9)}
+              helperText={new Date().toTimeString().slice(9)} // Display the timezone
             />
           </MuiPickersUtilsProvider>
         </Grid>


### PR DESCRIPTION
Closes #260

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Switches the display of token expiry date time in the create token screen from:

<img width="257" alt="Screenshot 2019-06-04 at 16 12 26" src="https://user-images.githubusercontent.com/472828/58890977-92cb3580-86e3-11e9-8c9f-179eda3f82fa.png">

to:

<img width="343" alt="Screenshot 2019-06-04 at 16 12 11" src="https://user-images.githubusercontent.com/472828/58890991-9bbc0700-86e3-11e9-9ee1-059563b63793.png">
