### PR TITLE
Fix quickstart script to work with branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -624,7 +624,7 @@ jobs:
       image: circleci/classic:201808-01
     working_directory: /home/circleci/project
     environment:
-      GIT_REVISION_OR_BRANCH: $CIRCLE_BRANCH
+      GIT_REVISION: $CIRCLE_SHA1
     steps:
       - checkout:
           path: /home/circleci/project/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -624,7 +624,7 @@ jobs:
       image: circleci/classic:201808-01
     working_directory: /home/circleci/project
     environment:
-      BRANCH: $CIRCLE_BRANCH
+      GIT_REV_OR_BRANCH: $CIRCLE_BRANCH
     steps:
       - checkout:
           path: /home/circleci/project/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -624,7 +624,7 @@ jobs:
       image: circleci/classic:201808-01
     working_directory: /home/circleci/project
     environment:
-      GIT_REV_OR_BRANCH: $CIRCLE_BRANCH
+      GIT_REVISION_OR_BRANCH: $CIRCLE_BRANCH
     steps:
       - checkout:
           path: /home/circleci/project/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - The quick-start script now only pulls the docker images for the services that are actually started up. [#898](https://github.com/Flowminder/FlowKit/issues/898)
+- The docker-compose files and quick-start script now consistently use the single environment variable `GIT_REVISION_OR_BRANCH` to configure the branch to be deployed.
+  (Previously the variables `CONTAINER_TAG` and/or `BRANCH` needed to be set).
 
 ### Fixed
 
 - When creating a new token in FlowAuth, the expiry now always shows the year, seconds till expiry, and timezone. [#260](https://github.com/Flowminder/FlowKit/issues/260)
+- The quick-start script now works correctly with branches. [#902](https://github.com/Flowminder/FlowKit/issues/902)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - The quick-start script now only pulls the docker images for the services that are actually started up. [#898](https://github.com/Flowminder/FlowKit/issues/898)
-- The docker-compose files and quick-start script now consistently use the single environment variable `GIT_REVISION_OR_BRANCH` to configure the branch to be deployed.
+- The docker-compose files and quick-start script now consistently use the single environment variable `GIT_REVISION` to configure the version of the docker containers to be deployed.
   (Previously the variables `CONTAINER_TAG` and/or `BRANCH` needed to be set).
 
 ### Fixed

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -10,50 +10,50 @@ version: '3.5'
 services:
 
   flowdb:
-    image: flowminder/flowdb:${CONTAINER_TAG:-latest}
+    image: flowminder/flowdb:${GIT_REV_OR_BRANCH:-latest}
     build:
       context: ./flowdb/
       dockerfile: Dockerfile
 
   flowdb_testdata:
-    image: flowminder/flowdb-testdata:${CONTAINER_TAG:-latest}
+    image: flowminder/flowdb-testdata:${GIT_REV_OR_BRANCH:-latest}
     build:
       context: ./flowdb/testdata/
       dockerfile: Dockerfile
 
   flowdb_synthetic_data:
-    image: flowminder/flowdb-synthetic-data:${CONTAINER_TAG:-latest}
+    image: flowminder/flowdb-synthetic-data:${GIT_REV_OR_BRANCH:-latest}
     build:
       context: ./flowdb/testdata/
       dockerfile: Dockerfile.synthetic_data
 
   flowmachine:
-    image: flowminder/flowmachine:${CONTAINER_TAG:-latest}
+    image: flowminder/flowmachine:${GIT_REV_OR_BRANCH:-latest}
     build:
       context: ./flowmachine
       dockerfile: Dockerfile
 
   worked_examples:
     container_name: worked_examples
-    image: flowminder/flowkit-examples:${CONTAINER_TAG:-latest}
+    image: flowminder/flowkit-examples:${GIT_REV_OR_BRANCH:-latest}
     build:
       context: .
       dockerfile: Dockerfile
 
   flowapi:
-    image: flowminder/flowapi:${CONTAINER_TAG:-latest}
+    image: flowminder/flowapi:${GIT_REV_OR_BRANCH:-latest}
     build:
       context: ./flowapi
       dockerfile: Dockerfile
 
   flowauth:
-    image: flowminder/flowauth:${CONTAINER_TAG:-latest}
+    image: flowminder/flowauth:${GIT_REV_OR_BRANCH:-latest}
     build:
       context: ./flowauth
       dockerfile: Dockerfile
 
   flowetl:
-    image: flowminder/flowetl:${CONTAINER_TAG:-latest}
+    image: flowminder/flowetl:${GIT_REV_OR_BRANCH:-latest}
     build:
       context: ./flowetl
       dockerfile: Dockerfile

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -10,50 +10,50 @@ version: '3.5'
 services:
 
   flowdb:
-    image: flowminder/flowdb:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowdb:${GIT_REVISION_OR_BRANCH:-latest}
     build:
       context: ./flowdb/
       dockerfile: Dockerfile
 
   flowdb_testdata:
-    image: flowminder/flowdb-testdata:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowdb-testdata:${GIT_REVISION_OR_BRANCH:-latest}
     build:
       context: ./flowdb/testdata/
       dockerfile: Dockerfile
 
   flowdb_synthetic_data:
-    image: flowminder/flowdb-synthetic-data:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowdb-synthetic-data:${GIT_REVISION_OR_BRANCH:-latest}
     build:
       context: ./flowdb/testdata/
       dockerfile: Dockerfile.synthetic_data
 
   flowmachine:
-    image: flowminder/flowmachine:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowmachine:${GIT_REVISION_OR_BRANCH:-latest}
     build:
       context: ./flowmachine
       dockerfile: Dockerfile
 
   worked_examples:
     container_name: worked_examples
-    image: flowminder/flowkit-examples:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowkit-examples:${GIT_REVISION_OR_BRANCH:-latest}
     build:
       context: .
       dockerfile: Dockerfile
 
   flowapi:
-    image: flowminder/flowapi:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowapi:${GIT_REVISION_OR_BRANCH:-latest}
     build:
       context: ./flowapi
       dockerfile: Dockerfile
 
   flowauth:
-    image: flowminder/flowauth:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowauth:${GIT_REVISION_OR_BRANCH:-latest}
     build:
       context: ./flowauth
       dockerfile: Dockerfile
 
   flowetl:
-    image: flowminder/flowetl:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowetl:${GIT_REVISION_OR_BRANCH:-latest}
     build:
       context: ./flowetl
       dockerfile: Dockerfile

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -10,50 +10,50 @@ version: '3.5'
 services:
 
   flowdb:
-    image: flowminder/flowdb:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowdb:${GIT_REVISION:-latest}
     build:
       context: ./flowdb/
       dockerfile: Dockerfile
 
   flowdb_testdata:
-    image: flowminder/flowdb-testdata:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowdb-testdata:${GIT_REVISION:-latest}
     build:
       context: ./flowdb/testdata/
       dockerfile: Dockerfile
 
   flowdb_synthetic_data:
-    image: flowminder/flowdb-synthetic-data:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowdb-synthetic-data:${GIT_REVISION:-latest}
     build:
       context: ./flowdb/testdata/
       dockerfile: Dockerfile.synthetic_data
 
   flowmachine:
-    image: flowminder/flowmachine:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowmachine:${GIT_REVISION:-latest}
     build:
       context: ./flowmachine
       dockerfile: Dockerfile
 
   worked_examples:
     container_name: worked_examples
-    image: flowminder/flowkit-examples:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowkit-examples:${GIT_REVISION:-latest}
     build:
       context: .
       dockerfile: Dockerfile
 
   flowapi:
-    image: flowminder/flowapi:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowapi:${GIT_REVISION:-latest}
     build:
       context: ./flowapi
       dockerfile: Dockerfile
 
   flowauth:
-    image: flowminder/flowauth:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowauth:${GIT_REVISION:-latest}
     build:
       context: ./flowauth
       dockerfile: Dockerfile
 
   flowetl:
-    image: flowminder/flowetl:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowetl:${GIT_REVISION:-latest}
     build:
       context: ./flowetl
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   flowdb:
     container_name: flowdb
-    image: flowminder/flowdb:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowdb:${GIT_REVISION:-latest}
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
 
@@ -44,7 +44,7 @@ services:
 
   flowdb_testdata:
     container_name: flowdb_testdata
-    image: flowminder/flowdb-testdata:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowdb-testdata:${GIT_REVISION:-latest}
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
     environment:
@@ -60,7 +60,7 @@ services:
 
   flowdb_synthetic_data:
     container_name: flowdb_synthetic_data
-    image: flowminder/flowdb-synthetic-data:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowdb-synthetic-data:${GIT_REVISION:-latest}
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
     environment:
@@ -90,7 +90,7 @@ services:
 
   flowmachine:
     container_name: flowmachine
-    image: flowminder/flowmachine:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowmachine:${GIT_REVISION:-latest}
     ports:
       - ${FLOWMACHINE_PORT:?Must set FLOWMACHINE_PORT env var}:5555
     depends_on:
@@ -116,7 +116,7 @@ services:
 
   worked_examples:
     container_name: worked_examples
-    image: flowminder/flowkit-examples:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowkit-examples:${GIT_REVISION:-latest}
     ports:
       - ${WORKED_EXAMPLES_PORT:?Must set WORKED_EXAMPLES_PORT env var}:8888
     tty: true
@@ -140,7 +140,7 @@ services:
 
   flowapi:
     container_name: flowapi
-    image: flowminder/flowapi:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowapi:${GIT_REVISION:-latest}
     ports:
       - ${FLOWAPI_PORT:?Must set FLOWAPI_PORT env var}:9090
     environment:
@@ -162,7 +162,7 @@ services:
 
   flowauth:
     container_name: flowauth
-    image: flowminder/flowauth:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowauth:${GIT_REVISION:-latest}
     ports:
       - ${FLOWAUTH_PORT:?Must set FLOWAUTH_PORT env var}:80
     environment:
@@ -187,7 +187,7 @@ services:
 
   flowetl:
     container_name: flowetl
-    image: flowminder/flowetl:${GIT_REVISION_OR_BRANCH:-latest}
+    image: flowminder/flowetl:${GIT_REVISION:-latest}
     restart: always
     tty: true
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   flowdb:
     container_name: flowdb
-    image: flowminder/flowdb:${CONTAINER_TAG:-latest}
+    image: flowminder/flowdb:${GIT_REV_OR_BRANCH:-latest}
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
 
@@ -44,7 +44,7 @@ services:
 
   flowdb_testdata:
     container_name: flowdb_testdata
-    image: flowminder/flowdb-testdata:${CONTAINER_TAG:-latest}
+    image: flowminder/flowdb-testdata:${GIT_REV_OR_BRANCH:-latest}
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
     environment:
@@ -60,7 +60,7 @@ services:
 
   flowdb_synthetic_data:
     container_name: flowdb_synthetic_data
-    image: flowminder/flowdb-synthetic-data:${CONTAINER_TAG:-latest}
+    image: flowminder/flowdb-synthetic-data:${GIT_REV_OR_BRANCH:-latest}
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
     environment:
@@ -90,7 +90,7 @@ services:
 
   flowmachine:
     container_name: flowmachine
-    image: flowminder/flowmachine:${CONTAINER_TAG:-latest}
+    image: flowminder/flowmachine:${GIT_REV_OR_BRANCH:-latest}
     ports:
       - ${FLOWMACHINE_PORT:?Must set FLOWMACHINE_PORT env var}:5555
     depends_on:
@@ -116,7 +116,7 @@ services:
 
   worked_examples:
     container_name: worked_examples
-    image: flowminder/flowkit-examples:${CONTAINER_TAG:-latest}
+    image: flowminder/flowkit-examples:${GIT_REV_OR_BRANCH:-latest}
     ports:
       - ${WORKED_EXAMPLES_PORT:?Must set WORKED_EXAMPLES_PORT env var}:8888
     tty: true
@@ -140,7 +140,7 @@ services:
 
   flowapi:
     container_name: flowapi
-    image: flowminder/flowapi:${CONTAINER_TAG:-latest}
+    image: flowminder/flowapi:${GIT_REV_OR_BRANCH:-latest}
     ports:
       - ${FLOWAPI_PORT:?Must set FLOWAPI_PORT env var}:9090
     environment:
@@ -162,7 +162,7 @@ services:
 
   flowauth:
     container_name: flowauth
-    image: flowminder/flowauth:${CONTAINER_TAG:-latest}
+    image: flowminder/flowauth:${GIT_REV_OR_BRANCH:-latest}
     ports:
       - ${FLOWAUTH_PORT:?Must set FLOWAUTH_PORT env var}:80
     environment:
@@ -187,7 +187,7 @@ services:
 
   flowetl:
     container_name: flowetl
-    image: flowminder/flowetl:${CONTAINER_TAG:-latest}
+    image: flowminder/flowetl:${GIT_REV_OR_BRANCH:-latest}
     restart: always
     tty: true
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   flowdb:
     container_name: flowdb
-    image: flowminder/flowdb:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowdb:${GIT_REVISION_OR_BRANCH:-latest}
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
 
@@ -44,7 +44,7 @@ services:
 
   flowdb_testdata:
     container_name: flowdb_testdata
-    image: flowminder/flowdb-testdata:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowdb-testdata:${GIT_REVISION_OR_BRANCH:-latest}
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
     environment:
@@ -60,7 +60,7 @@ services:
 
   flowdb_synthetic_data:
     container_name: flowdb_synthetic_data
-    image: flowminder/flowdb-synthetic-data:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowdb-synthetic-data:${GIT_REVISION_OR_BRANCH:-latest}
     ports:
       - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
     environment:
@@ -90,7 +90,7 @@ services:
 
   flowmachine:
     container_name: flowmachine
-    image: flowminder/flowmachine:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowmachine:${GIT_REVISION_OR_BRANCH:-latest}
     ports:
       - ${FLOWMACHINE_PORT:?Must set FLOWMACHINE_PORT env var}:5555
     depends_on:
@@ -116,7 +116,7 @@ services:
 
   worked_examples:
     container_name: worked_examples
-    image: flowminder/flowkit-examples:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowkit-examples:${GIT_REVISION_OR_BRANCH:-latest}
     ports:
       - ${WORKED_EXAMPLES_PORT:?Must set WORKED_EXAMPLES_PORT env var}:8888
     tty: true
@@ -140,7 +140,7 @@ services:
 
   flowapi:
     container_name: flowapi
-    image: flowminder/flowapi:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowapi:${GIT_REVISION_OR_BRANCH:-latest}
     ports:
       - ${FLOWAPI_PORT:?Must set FLOWAPI_PORT env var}:9090
     environment:
@@ -162,7 +162,7 @@ services:
 
   flowauth:
     container_name: flowauth
-    image: flowminder/flowauth:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowauth:${GIT_REVISION_OR_BRANCH:-latest}
     ports:
       - ${FLOWAUTH_PORT:?Must set FLOWAUTH_PORT env var}:80
     environment:
@@ -187,7 +187,7 @@ services:
 
   flowetl:
     container_name: flowetl
-    image: flowminder/flowetl:${GIT_REV_OR_BRANCH:-latest}
+    image: flowminder/flowetl:${GIT_REVISION_OR_BRANCH:-latest}
     restart: always
     tty: true
     stdin_open: true

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -47,5 +47,5 @@ curl http://localhost:9090/api/0/spec/openapi-redoc.json -o source/_static/opena
 echo "Started FlowAPI."
 echo "Starting build."
 
-# Note: the BRANCH variable is used by `mkdocs.yml` to pick up the correct git repositories for building API docs
-BRANCH=${CIRCLE_BRANCH:="master"} FLOWMACHINE_LOG_LEVEL=error pipenv run mkdocs "${@:-build}"
+# Note: the DOCS_BRANCH variable is used by `mkdocs.yml` to pick up the correct git repositories for building API docs
+DOCS_BRANCH=${CIRCLE_BRANCH:="master"} FLOWMACHINE_LOG_LEVEL=error pipenv run mkdocs "${@:-build}"

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -47,4 +47,5 @@ curl http://localhost:9090/api/0/spec/openapi-redoc.json -o source/_static/opena
 echo "Started FlowAPI."
 echo "Starting build."
 
+# Note: the BRANCH variable is used by `mkdocs.yml` to pick up the correct git repositories for building API docs
 BRANCH=${CIRCLE_BRANCH:="master"} FLOWMACHINE_LOG_LEVEL=error pipenv run mkdocs "${@:-build}"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -9,10 +9,10 @@ plugins:
       modules:
         flowmachine:
           section: flowmachine
-          source_repo: "https://github.com/Flowminder/FlowKit/tree/$BRANCH/flowmachine"
+          source_repo: "https://github.com/Flowminder/FlowKit/tree/$DOCS_BRANCH/flowmachine"
         flowclient:
           section: flowclient
-          source_repo: "https://github.com/Flowminder/FlowKit/tree/$BRANCH/flowclient"
+          source_repo: "https://github.com/Flowminder/FlowKit/tree/$DOCS_BRANCH/flowclient"
   - mknotebooks:
       execute: true
       preamble: "notebook_preamble.py"

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -309,7 +309,7 @@ This will bring up a single node swarm, create random 16 character passwords for
 
 For convenience, you can also do `pipenv run secrets_quickstart` from the `secrets_quickstart` directory.
 
-Note that if you wish to deploy a branch other than `master`, you should set the `GIT_REV_OR_BRANCH` environment variable before running, to ensure that Docker pulls the correct tags.
+Note that if you wish to deploy a branch other than `master`, you should set the `GIT_REVISION_OR_BRANCH` environment variable before running, to ensure that Docker pulls the correct tags.
 
 You can then provide the certificate to `flowclient`, and finally connect via https:
 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -309,7 +309,7 @@ This will bring up a single node swarm, create random 16 character passwords for
 
 For convenience, you can also do `pipenv run secrets_quickstart` from the `secrets_quickstart` directory.
 
-Note that if you wish to deploy a branch other than master, you should set the `CIRCLE_BRANCH` environment variable before running, to ensure that Docker pulls the correct tags.
+Note that if you wish to deploy a branch other than `master`, you should set the `GIT_REV_OR_BRANCH` environment variable before running, to ensure that Docker pulls the correct tags.
 
 You can then provide the certificate to `flowclient`, and finally connect via https:
 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -309,7 +309,7 @@ This will bring up a single node swarm, create random 16 character passwords for
 
 For convenience, you can also do `pipenv run secrets_quickstart` from the `secrets_quickstart` directory.
 
-Note that if you wish to deploy a branch other than `master`, you should set the `GIT_REVISION_OR_BRANCH` environment variable before running, to ensure that Docker pulls the correct tags.
+Note that if you wish to deploy a branch other than `master`, you should set the `GIT_REVISION` environment variable before running, to ensure that Docker pulls the correct tags.
 
 You can then provide the certificate to `flowclient`, and finally connect via https:
 

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -51,9 +51,9 @@ function confirm {
 # Set git revision or branch name to be used
 #
 if [ "$CI" = "true" ]; then
-    export GIT_REV_OR_BRANCH=$CIRCLE_SHA1
+    export GIT_REVISION_OR_BRANCH=$CIRCLE_SHA1
 else
-    export GIT_REV_OR_BRANCH=${GIT_REV_OR_BRANCH:-master}
+    export GIT_REVISION_OR_BRANCH=${GIT_REVISION_OR_BRANCH:-master}
 fi
 
 if [ $# -gt 0 ] && [ "$1" = "larger_data" ] || [ "$2" = "larger_data" ]
@@ -96,18 +96,18 @@ if [ $# -gt 0 ] && [ "$1" = "stop" ]
 then
     export DOCKER_FLOWDB_HOST=flowdb_testdata
     echo "Stopping containers"
-    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REV_OR_BRANCH}/development_environment)"
-    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REV_OR_BRANCH}/docker-compose.yml | docker-compose -f - down -v
+    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION_OR_BRANCH}/development_environment)"
+    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION_OR_BRANCH}/docker-compose.yml | docker-compose -f - down -v
 else
-    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REV_OR_BRANCH}/development_environment)"
+    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION_OR_BRANCH}/development_environment)"
      echo "Starting containers (this may take a few minutes)"
-    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REV_OR_BRANCH}/docker-compose.yml | docker-compose -f - ps -q $DOCKER_FLOWDB_HOST flowapi flowmachine flowauth flowmachine_query_locker $WORKED_EXAMPLES`
+    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION_OR_BRANCH}/docker-compose.yml | docker-compose -f - ps -q $DOCKER_FLOWDB_HOST flowapi flowmachine flowauth flowmachine_query_locker $WORKED_EXAMPLES`
     if [[ "$RUNNING" != "" ]]; then
         confirm "Existing containers are running and will be replaced. Are you sure?" || exit 1
     fi
     DOCKER_SERVICES="$DOCKER_FLOWDB_HOST flowapi flowmachine flowauth flowmachine_query_locker $WORKED_EXAMPLES"
-    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REV_OR_BRANCH}/docker-compose.yml | docker-compose -f - pull $DOCKER_SERVICES
-    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REV_OR_BRANCH}/docker-compose.yml | docker-compose -f - up -d $DOCKER_SERVICES
+    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION_OR_BRANCH}/docker-compose.yml | docker-compose -f - pull $DOCKER_SERVICES
+    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION_OR_BRANCH}/docker-compose.yml | docker-compose -f - up -d $DOCKER_SERVICES
     echo "Waiting for containers to be ready.."
     docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until { [ $i -ge 24 ] && exit_status=1; } || { (pg_isready -h 127.0.0.1 -p 5432) && exit_status=0; }; do let i=i+1; echo Waiting 10s; sleep 10; done; exit $exit_status' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including the output of running 'docker logs flowdb'" && exit 1)
     echo "FlowDB ready."

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -49,14 +49,13 @@ function confirm {
 
 #
 # Set git revision or branch name to be used. Note that the
-# environment variable GIT_REVISION_OR_BRANCH is also used
-# inside the docker-compose file which is downloaded and run
-# below.
+# environment variable GIT_REVISION is also used  inside the
+# docker-compose file which is downloaded and run below.
 #
 if [ "$CI" = "true" ]; then
-    export GIT_REVISION_OR_BRANCH=$CIRCLE_SHA1
+    export GIT_REVISION=$CIRCLE_SHA1
 else
-    export GIT_REVISION_OR_BRANCH=${GIT_REVISION_OR_BRANCH:-master}
+    export GIT_REVISION=${GIT_REVISION:-master}
 fi
 
 if [ $# -gt 0 ] && [ "$1" = "larger_data" ] || [ "$2" = "larger_data" ]
@@ -99,18 +98,18 @@ if [ $# -gt 0 ] && [ "$1" = "stop" ]
 then
     export DOCKER_FLOWDB_HOST=flowdb_testdata
     echo "Stopping containers"
-    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION_OR_BRANCH}/development_environment)"
-    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION_OR_BRANCH}/docker-compose.yml | docker-compose -f - down -v
+    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/development_environment)"
+    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/docker-compose.yml | docker-compose -f - down -v
 else
-    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION_OR_BRANCH}/development_environment)"
+    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/development_environment)"
      echo "Starting containers (this may take a few minutes)"
-    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION_OR_BRANCH}/docker-compose.yml | docker-compose -f - ps -q $DOCKER_FLOWDB_HOST flowapi flowmachine flowauth flowmachine_query_locker $WORKED_EXAMPLES`
+    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/docker-compose.yml | docker-compose -f - ps -q $DOCKER_FLOWDB_HOST flowapi flowmachine flowauth flowmachine_query_locker $WORKED_EXAMPLES`
     if [[ "$RUNNING" != "" ]]; then
         confirm "Existing containers are running and will be replaced. Are you sure?" || exit 1
     fi
     DOCKER_SERVICES="$DOCKER_FLOWDB_HOST flowapi flowmachine flowauth flowmachine_query_locker $WORKED_EXAMPLES"
-    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION_OR_BRANCH}/docker-compose.yml | docker-compose -f - pull $DOCKER_SERVICES
-    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION_OR_BRANCH}/docker-compose.yml | docker-compose -f - up -d $DOCKER_SERVICES
+    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/docker-compose.yml | docker-compose -f - pull $DOCKER_SERVICES
+    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/docker-compose.yml | docker-compose -f - up -d $DOCKER_SERVICES
     echo "Waiting for containers to be ready.."
     docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until { [ $i -ge 24 ] && exit_status=1; } || { (pg_isready -h 127.0.0.1 -p 5432) && exit_status=0; }; do let i=i+1; echo Waiting 10s; sleep 10; done; exit $exit_status' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including the output of running 'docker logs flowdb'" && exit 1)
     echo "FlowDB ready."

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -48,7 +48,10 @@ function confirm {
 }
 
 #
-# Set git revision or branch name to be used
+# Set git revision or branch name to be used. Note that the
+# environment variable GIT_REVISION_OR_BRANCH is also used
+# inside the docker-compose file which is downloaded and run
+# below.
 #
 if [ "$CI" = "true" ]; then
     export GIT_REVISION_OR_BRANCH=$CIRCLE_SHA1

--- a/secrets_quickstart/docker-stack.yml
+++ b/secrets_quickstart/docker-stack.yml
@@ -29,7 +29,7 @@ networks:
   api:
 services:
     flowdb:
-        image: "flowminder/flowdb-testdata:${GIT_REVISION_OR_BRANCH:-latest}"
+        image: "flowminder/flowdb-testdata:${GIT_REVISION:-latest}"
         environment:
           - POSTGRES_PASSWORD_FILE=/run/secrets/POSTGRES_PASSWORD
         ports:
@@ -52,7 +52,7 @@ services:
             aliases:
               - flowdb
     flowmachine:
-        image: "flowminder/flowmachine:${GIT_REVISION_OR_BRANCH:-latest}"
+        image: "flowminder/flowmachine:${GIT_REVISION:-latest}"
         environment:
             - FLOWDB_PORT=5432
             - FLOWDB_HOST=flowdb
@@ -68,7 +68,7 @@ services:
           - redis
           - zero
     flowapi:
-        image: "flowminder/flowapi:${GIT_REVISION_OR_BRANCH:-latest}"
+        image: "flowminder/flowapi:${GIT_REVISION:-latest}"
         ports:
           - "9090:9090"
         environment:

--- a/secrets_quickstart/docker-stack.yml
+++ b/secrets_quickstart/docker-stack.yml
@@ -29,7 +29,7 @@ networks:
   api:
 services:
     flowdb:
-        image: "flowminder/flowdb-testdata:${GIT_REV_OR_BRANCH:-latest}"
+        image: "flowminder/flowdb-testdata:${GIT_REVISION_OR_BRANCH:-latest}"
         environment:
           - POSTGRES_PASSWORD_FILE=/run/secrets/POSTGRES_PASSWORD
         ports:
@@ -52,7 +52,7 @@ services:
             aliases:
               - flowdb
     flowmachine:
-        image: "flowminder/flowmachine:${GIT_REV_OR_BRANCH:-latest}"
+        image: "flowminder/flowmachine:${GIT_REVISION_OR_BRANCH:-latest}"
         environment:
             - FLOWDB_PORT=5432
             - FLOWDB_HOST=flowdb
@@ -68,7 +68,7 @@ services:
           - redis
           - zero
     flowapi:
-        image: "flowminder/flowapi:${GIT_REV_OR_BRANCH:-latest}"
+        image: "flowminder/flowapi:${GIT_REVISION_OR_BRANCH:-latest}"
         ports:
           - "9090:9090"
         environment:

--- a/secrets_quickstart/docker-stack.yml
+++ b/secrets_quickstart/docker-stack.yml
@@ -29,7 +29,7 @@ networks:
   api:
 services:
     flowdb:
-        image: "flowminder/flowdb-testdata:${CIRCLE_BRANCH:-latest}"
+        image: "flowminder/flowdb-testdata:${GIT_REV_OR_BRANCH:-latest}"
         environment:
           - POSTGRES_PASSWORD_FILE=/run/secrets/POSTGRES_PASSWORD
         ports:
@@ -52,7 +52,7 @@ services:
             aliases:
               - flowdb
     flowmachine:
-        image: "flowminder/flowmachine:${CIRCLE_BRANCH:-latest}"
+        image: "flowminder/flowmachine:${GIT_REV_OR_BRANCH:-latest}"
         environment:
             - FLOWDB_PORT=5432
             - FLOWDB_HOST=flowdb
@@ -68,7 +68,7 @@ services:
           - redis
           - zero
     flowapi:
-        image: "flowminder/flowapi:${CIRCLE_BRANCH:-latest}"
+        image: "flowminder/flowapi:${GIT_REV_OR_BRANCH:-latest}"
         ports:
           - "9090:9090"
         environment:


### PR DESCRIPTION
Closes #902 

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [ ] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [X] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [X] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

- Renamed `CONTAINER_TAG` to `GIT_REVISION` in the docker-compose and docker-stack files.

  Rationale is that this makes it clear what the allowed values are and is more immediately intuitive for developers (otherwise, how do you find out the correct container tag?).

- Renamed `BRANCH` to `GIT_REVISION` in `quick_start.sh`. Same rationale as above, and it is good to use the same name in this script as in the docker-compose files so that we don't need to set an additional variable in `quick_start.sh` that is otherwise never used inside the script itself.

- Renamed `BRANCH` to `DOCS_BRANCH` in `docs/build.sh` and `docs/mkdocs.yml`, to distinguish it from the other variables above and make it clear that it is independent of them.

- 