### PR TITLE
Fix quickstart script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -624,7 +624,7 @@ jobs:
       image: circleci/classic:201808-01
     working_directory: /home/circleci/project
     environment:
-      BRANCH: $CIRCLE_BRANCH
+      GIT_REVISION: $CIRCLE_SHA1
     steps:
       - checkout:
           path: /home/circleci/project/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - The quick-start script now only pulls the docker images for the services that are actually started up. [#898](https://github.com/Flowminder/FlowKit/issues/898)
+- The quick-start script now uses the environment variable `GIT_REVISION` to control the version to be deployed.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - When creating a new token in FlowAuth, the expiry now always shows the year, seconds till expiry, and timezone. [#260](https://github.com/Flowminder/FlowKit/issues/260)
 - Distances in `Displacement` are now calculated with longitude and latitude the corrcet way around. [#913](https://github.com/Flowminder/FlowKit/issues/913)
+- The quick-start script now works correctly with branches. [#902](https://github.com/Flowminder/FlowKit/issues/902)
 
 ### Removed
 

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -47,4 +47,5 @@ curl http://localhost:9090/api/0/spec/openapi-redoc.json -o source/_static/opena
 echo "Started FlowAPI."
 echo "Starting build."
 
-BRANCH=${CIRCLE_BRANCH:="master"} FLOWMACHINE_LOG_LEVEL=error pipenv run mkdocs "${@:-build}"
+# Note: the DOCS_BRANCH variable is used by `mkdocs.yml` to pick up the correct git repositories for building API docs
+DOCS_BRANCH=${CIRCLE_BRANCH:="master"} FLOWMACHINE_LOG_LEVEL=error pipenv run mkdocs "${@:-build}"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -9,10 +9,10 @@ plugins:
       modules:
         flowmachine:
           section: flowmachine
-          source_repo: "https://github.com/Flowminder/FlowKit/tree/$BRANCH/flowmachine"
+          source_repo: "https://github.com/Flowminder/FlowKit/tree/$DOCS_BRANCH/flowmachine"
         flowclient:
           section: flowclient
-          source_repo: "https://github.com/Flowminder/FlowKit/tree/$BRANCH/flowclient"
+          source_repo: "https://github.com/Flowminder/FlowKit/tree/$DOCS_BRANCH/flowclient"
   - mknotebooks:
       execute: true
       preamble: "notebook_preamble.py"

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -309,7 +309,7 @@ This will bring up a single node swarm, create random 16 character passwords for
 
 For convenience, you can also do `pipenv run secrets_quickstart` from the `secrets_quickstart` directory.
 
-Note that if you wish to deploy a branch other than master, you should set the `CONTAINER_TAG` environment variable before running, to ensure that Docker pulls the correct tags.
+Note that if you wish to deploy a branch other than `master`, you should set the `CONTAINER_TAG` environment variable before running, to ensure that Docker pulls the correct tags.
 
 You can then provide the certificate to `flowclient`, and finally connect via https:
 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -309,7 +309,7 @@ This will bring up a single node swarm, create random 16 character passwords for
 
 For convenience, you can also do `pipenv run secrets_quickstart` from the `secrets_quickstart` directory.
 
-Note that if you wish to deploy a branch other than master, you should set the `CIRCLE_BRANCH` environment variable before running, to ensure that Docker pulls the correct tags.
+Note that if you wish to deploy a branch other than master, you should set the `CONTAINER_TAG` environment variable before running, to ensure that Docker pulls the correct tags.
 
 You can then provide the certificate to `flowclient`, and finally connect via https:
 

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -5,7 +5,9 @@
 set -e
 set -a
 
-
+#
+# Helper functions to ask user for confirmation
+#
 
 # Read a single char from /dev/tty, prompting with "$*"
 # Note: pressing enter will return a null string. Perhaps a version terminated with X and then remove it in caller?
@@ -45,10 +47,24 @@ function confirm {
   get_yes_keypress "$prompt" 1
 }
 
-export CONTAINER_TAG=$CONTAINER_TAG
+#
+# Set git revision / container tag to be used. Note that the
+# environment variable CONTAINER_TAG is also passed on to
+# the docker-compose file which is downloaded and run below.
+# Typically the values of CONTAINER_TAG and GIT_REVISION are
+# identical (referring to the SHA-1 checksum of the git revision
+# to be deployed), but if we want to deploy the latest master
+# we need to use GIT_REVISION=master and CONTAINER_TAG=latest.
+#
 if [ "$CI" = "true" ]; then
-    export CONTAINER_TAG=$CIRCLE_SHA1
-    export BRANCH=$CIRCLE_SHA1
+    export GIT_REVISION=$CIRCLE_SHA1
+else
+    export GIT_REVISION=${GIT_REVISION:-master}
+fi
+if [ "$GIT_REVISION" = "master" ]; then
+    export CONTAINER_TAG="latest"
+else
+    export CONTAINER_TAG=$GIT_REVISION
 fi
 
 if [ $# -gt 0 ] && [ "$1" = "larger_data" ] || [ "$2" = "larger_data" ]
@@ -91,18 +107,18 @@ if [ $# -gt 0 ] && [ "$1" = "stop" ]
 then
     export DOCKER_FLOWDB_HOST=flowdb_testdata
     echo "Stopping containers"
-    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/development_environment)"
-    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - down -v
+    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/development_environment)"
+    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/docker-compose.yml | docker-compose -f - down -v
 else
-    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/development_environment)"
+    source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/development_environment)"
      echo "Starting containers (this may take a few minutes)"
-    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - ps -q $DOCKER_FLOWDB_HOST flowapi flowmachine flowauth flowmachine_query_locker $WORKED_EXAMPLES`
+    RUNNING=`curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/docker-compose.yml | docker-compose -f - ps -q $DOCKER_FLOWDB_HOST flowapi flowmachine flowauth flowmachine_query_locker $WORKED_EXAMPLES`
     if [[ "$RUNNING" != "" ]]; then
         confirm "Existing containers are running and will be replaced. Are you sure?" || exit 1
     fi
     DOCKER_SERVICES="$DOCKER_FLOWDB_HOST flowapi flowmachine flowauth flowmachine_query_locker $WORKED_EXAMPLES"
-    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - pull $DOCKER_SERVICES
-    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${BRANCH:-master}/docker-compose.yml | docker-compose -f - up -d $DOCKER_SERVICES
+    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/docker-compose.yml | docker-compose -f - pull $DOCKER_SERVICES
+    curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/docker-compose.yml | docker-compose -f - up -d $DOCKER_SERVICES
     echo "Waiting for containers to be ready.."
     docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until { [ $i -ge 24 ] && exit_status=1; } || { (pg_isready -h 127.0.0.1 -p 5432) && exit_status=0; }; do let i=i+1; echo Waiting 10s; sleep 10; done; exit $exit_status' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including the output of running 'docker logs flowdb'" && exit 1)
     echo "FlowDB ready."

--- a/secrets_quickstart/docker-stack.yml
+++ b/secrets_quickstart/docker-stack.yml
@@ -29,7 +29,7 @@ networks:
   api:
 services:
     flowdb:
-        image: "flowminder/flowdb-testdata:${CIRCLE_BRANCH:-latest}"
+        image: "flowminder/flowdb-testdata:${CONTAINER_TAG:-latest}"
         environment:
           - POSTGRES_PASSWORD_FILE=/run/secrets/POSTGRES_PASSWORD
         ports:
@@ -52,7 +52,7 @@ services:
             aliases:
               - flowdb
     flowmachine:
-        image: "flowminder/flowmachine:${CIRCLE_BRANCH:-latest}"
+        image: "flowminder/flowmachine:${CONTAINER_TAG:-latest}"
         environment:
             - FLOWDB_PORT=5432
             - FLOWDB_HOST=flowdb
@@ -68,7 +68,7 @@ services:
           - redis
           - zero
     flowapi:
-        image: "flowminder/flowapi:${CIRCLE_BRANCH:-latest}"
+        image: "flowminder/flowapi:${CONTAINER_TAG:-latest}"
         ports:
           - "9090:9090"
         environment:


### PR DESCRIPTION
Closes #902 

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [X] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

As opposed to the first attempt in #903, I have left the `CONTAINER_TAG` variables in the docker-compose files untouched.

The `quick_start.sh` script is now controlled by the environment variable `GIT_REVISION` (and sets `CONTAINER_TAG` internally, which is picked up by the docker-compose files). I'd be grateful if someone could double-check the logic in L59-67 of `quick_start.sh` just to make sure my logic is correct.

I also renamed `BRANCH` to `DOCS_BRANCH` in `docs/build.sh` and `docs/mkdocs.yml`, to make it a bit clearer that this variable is independent of any of the branch/git revision related variables in other scripts.