### PR TITLE
Minor flowetl tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -582,7 +582,7 @@ jobs:
           name: run flowetl integration tests
           command: |
             cd flowetl
-            FLOWETL_CONTAINERS_TAG=$CIRCLE_SHA1 pipenv run pytest --junit-xml=test_results/pytest/results_integration.xml ./tests
+            FLOWETL_TESTS_CONTAINERS_TAG=$CIRCLE_SHA1 pipenv run pytest --junit-xml=test_results/pytest/results_integration.xml ./tests
       - run:
           name: run etl module unit tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -582,7 +582,7 @@ jobs:
           name: run flowetl integration tests
           command: |
             cd flowetl
-            TAG=$CIRCLE_SHA1 pipenv run pytest --junit-xml=test_results/pytest/results_integration.xml ./tests
+            FLOWETL_CONTAINERS_TAG=$CIRCLE_SHA1 pipenv run pytest --junit-xml=test_results/pytest/results_integration.xml ./tests
       - run:
           name: run etl module unit tests
           command: |

--- a/flowetl/Pipfile
+++ b/flowetl/Pipfile
@@ -12,6 +12,7 @@ docker = "*"
 ipython = "*"
 etl = {editable = true,path = "./etl"}
 pytest-cov = "*"
+structlog = "*"
 
 [packages]
 

--- a/flowetl/Pipfile.lock
+++ b/flowetl/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "77a73b1040d7ed3b315e08413f50ede39822c98b24eda3ea9b9558290bc6c61a"
+            "sha256": "a95c071887e12a5af975415020281382444f29f0a98e3203314b77a8e6df1b79"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -40,14 +40,6 @@
                 "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
             ],
             "version": "==1.4.3"
-        },
-        "appnope": {
-            "hashes": [
-                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
-                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
-            ],
-            "markers": "sys_platform == 'darwin'",
-            "version": "==0.1.0"
         },
         "astroid": {
             "hashes": [
@@ -809,6 +801,14 @@
                 "sha256:5bb2c4fc2bcc3447ad45716c66581eab982c007dcf925482498d8733f86f17c7"
             ],
             "version": "==1.2.19"
+        },
+        "structlog": {
+            "hashes": [
+                "sha256:5feae03167620824d3ae3e8915ea8589fc28d1ad6f3edf3cc90ed7c7cb33fab5",
+                "sha256:db441b81c65b0f104a7ce5d86c5432be099956b98b8a2c8be0b3fb3a7a0b1536"
+            ],
+            "index": "pypi",
+            "version": "==19.1.0"
         },
         "tabulate": {
             "hashes": [

--- a/flowetl/dags/etl.py
+++ b/flowetl/dags/etl.py
@@ -6,8 +6,8 @@
 """
 Skeleton specification for ETL DAG
 """
-import logging
 import os
+import structlog
 
 from pathlib import Path
 
@@ -22,12 +22,13 @@ from etl.dag_task_callable_mappings import (
 from etl.etl_utils import construct_etl_dag, CDRType
 from etl.config_parser import validate_config, get_config_from_file
 
+logger = structlog.get_logger("flowetl")
 default_args = {"owner": "flowminder", "start_date": parse("1900-01-01")}
 
 # Determine if we are in a testing environment - use dummy callables if so
 if os.environ.get("TESTING", "") == "true":
     task_callable_mapping = TEST_ETL_TASK_CALLABLES
-    logging.info("running in testing environment")
+    logger.info("running in testing environment")
     dag = construct_etl_dag(
         task_callable_mapping=task_callable_mapping,
         default_args=default_args,
@@ -35,7 +36,7 @@ if os.environ.get("TESTING", "") == "true":
     )
 else:
     task_callable_mapping = PRODUCTION_ETL_TASK_CALLABLES
-    logging.info("running in production environment")
+    logger.info("running in production environment")
 
     # read and validate the config file before creating the DAGs
     global_config_dict = get_config_from_file(

--- a/flowetl/dags/etl_sensor.py
+++ b/flowetl/dags/etl_sensor.py
@@ -6,7 +6,9 @@
 import logging
 import os
 
-from airflow import DAG
+# need to import and not use so that airflow looks here for a DAG
+from airflow import DAG  # pylint: disable=unused-import
+
 from pendulum import parse
 
 from etl.etl_utils import construct_etl_sensor_dag

--- a/flowetl/dags/etl_sensor.py
+++ b/flowetl/dags/etl_sensor.py
@@ -3,8 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # -*- coding: utf-8 -*-
-import logging
 import os
+import structlog
 
 # need to import and not use so that airflow looks here for a DAG
 from airflow import DAG  # pylint: disable=unused-import
@@ -17,15 +17,17 @@ from etl.dag_task_callable_mappings import (
     PRODUCTION_ETL_SENSOR_TASK_CALLABLE,
 )
 
+logger = structlog.get_logger("flowetl")
+
 default_args = {"owner": "flowminder", "start_date": parse("1900-01-01")}
 
 if os.environ.get("TESTING", "") == "true":
-    logging.info("running in testing environment")
+    logger.info("running in testing environment")
     dag = construct_etl_sensor_dag(
         callable=TEST_ETL_SENSOR_TASK_CALLABLE, default_args=default_args
     )
 else:
-    logging.info("running in production environment")
+    logger.info("running in production environment")
     dag = construct_etl_sensor_dag(
         callable=PRODUCTION_ETL_SENSOR_TASK_CALLABLE, default_args=default_args
     )

--- a/flowetl/etl/etl/__init__.py
+++ b/flowetl/etl/etl/__init__.py
@@ -3,3 +3,23 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # -*- coding: utf-8 -*-
+
+import structlog
+
+
+structlog.configure(
+    processors=[
+        structlog.stdlib.filter_by_level,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        structlog.processors.JSONRenderer(serializer=rapidjson.dumps),
+    ],
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.stdlib.BoundLogger,
+    context_class=dict,
+    cache_logger_on_first_use=True,
+)

--- a/flowetl/etl/etl/__init__.py
+++ b/flowetl/etl/etl/__init__.py
@@ -4,6 +4,7 @@
 
 # -*- coding: utf-8 -*-
 
+import json
 import structlog
 
 
@@ -16,7 +17,7 @@ structlog.configure(
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
-        structlog.processors.JSONRenderer(serializer=rapidjson.dumps),
+        structlog.processors.JSONRenderer(serializer=json.dumps),
     ],
     logger_factory=structlog.stdlib.LoggerFactory(),
     wrapper_class=structlog.stdlib.BoundLogger,

--- a/flowetl/etl/etl/dummy_task_callables.py
+++ b/flowetl/etl/etl/dummy_task_callables.py
@@ -8,12 +8,14 @@ Contains the definition of dummy callables to be used when testing
 """
 
 import os
-import logging
+import structlog
 
 from uuid import uuid1
 from pendulum import utcnow
 from airflow.models import DagRun, TaskInstance
 from airflow.api.common.experimental.trigger_dag import trigger_dag
+
+logger = structlog.get_logger("flowetl")
 
 # pylint: disable=unused-argument
 def dummy__callable(*, dag_run: DagRun, task_instance: TaskInstance, **kwargs):
@@ -22,7 +24,7 @@ def dummy__callable(*, dag_run: DagRun, task_instance: TaskInstance, **kwargs):
     TASK_TO_FAIL is set to the name of the current task, otherwise succeeds
     silently.
     """
-    logging.info(dag_run)
+    logger.info(dag_run)
     if os.environ.get("TASK_TO_FAIL", "") == task_instance.task_id:
         raise Exception
 
@@ -31,7 +33,7 @@ def dummy_failing__callable(*, dag_run: DagRun, **kwargs):
     """
     Dummy python callable raising an exception
     """
-    logging.info(dag_run)
+    logger.info(dag_run)
     raise Exception
 
 
@@ -40,5 +42,5 @@ def dummy_trigger__callable(*, dag_run: DagRun, **kwargs):
     In test env we just want to trigger the etl_testing DAG with
     no config.
     """
-    logging.info(dag_run)
+    logger.info(dag_run)
     trigger_dag("etl_testing", run_id=str(uuid1()), execution_date=utcnow())

--- a/flowetl/etl/setup.py
+++ b/flowetl/etl/setup.py
@@ -13,5 +13,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     # pinning airflow version so that it is the same as in the Dockerfile
-    install_requires=["apache-airflow[postgres]==1.10.3"],
+    install_requires=["apache-airflow[postgres]==1.10.3, structlog"],
 )

--- a/flowetl/etl/setup.py
+++ b/flowetl/etl/setup.py
@@ -13,5 +13,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     # pinning airflow version so that it is the same as in the Dockerfile
-    install_requires=["apache-airflow[postgres]==1.10.3, structlog"],
+    install_requires=["apache-airflow[postgres]==1.10.3", "structlog"],
 )

--- a/flowetl/etl/tests/test_config.py
+++ b/flowetl/etl/tests/test_config.py
@@ -88,7 +88,7 @@ def test_find_files_default_filter(tmpdir):
 
     tmpdir_path_obj = Path(dump_path=tmpdir)
 
-    files = find_files(tmpdir_path_obj)
+    files = find_files(dump_path=tmpdir_path_obj)
 
     assert set([file.name for file in files]) == set(["A.txt", "B.txt"])
 

--- a/flowetl/etl/tests/test_config.py
+++ b/flowetl/etl/tests/test_config.py
@@ -93,7 +93,7 @@ def test_find_files_default_filter(tmpdir):
     assert set([file.name for file in files]) == set(["A.txt", "B.txt"])
 
 
-def test_find_files_default_filter(tmpdir):
+def test_find_files_non_default_filter(tmpdir):
     """
     Test that find files returns correct files
     with non-default filter argument.

--- a/flowetl/etl/tests/test_config.py
+++ b/flowetl/etl/tests/test_config.py
@@ -86,7 +86,7 @@ def test_find_files_default_filter(tmpdir):
     tmpdir.join("B.txt").write("content")
     tmpdir.join("README.md").write("content")
 
-    tmpdir_path_obj = Path(dump_path=tmpdir)
+    tmpdir_path_obj = Path(tmpdir)
 
     files = find_files(dump_path=tmpdir_path_obj)
 

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -307,9 +307,9 @@ def airflow_local_setup():
     }
     env = {**os.environ, **extra_env}
     # make test Airflow home dir
-    test_airflow_home_dir = os.environ["AIRFLOW_HOME"]
-    if not os.path.exists(test_airflow_home_dir):
-        os.makedirs(test_airflow_home_dir)
+    airflow_home_dir_for_tests = os.environ["AIRFLOW_HOME"]
+    if not os.path.exists(airflow_home_dir_for_tests):
+        os.makedirs(airflow_home_dir_for_tests)
 
     initdb = Popen(
         ["airflow", "initdb"], shell=False, stdout=DEVNULL, stderr=DEVNULL, env=env
@@ -327,7 +327,7 @@ def airflow_local_setup():
 
     scheduler.terminate()
 
-    shutil.rmtree(test_airflow_home_dir)
+    shutil.rmtree(airflow_home_dir_for_tests)
     os.unlink("./scheduler.log")
 
 
@@ -339,11 +339,11 @@ def airflow_local_pipeline_run():
     subsequent trigger of the etl dag.
     """
     scheduler_to_clean_up = None
-    test_airflow_home_dir = None
+    airflow_home_dir_for_tests = None
 
     def run_func(extra_env):
         nonlocal scheduler_to_clean_up
-        nonlocal test_airflow_home_dir
+        nonlocal airflow_home_dir_for_tests
         default_env = {
             "AIRFLOW__CORE__DAGS_FOLDER": "./dags",
             "AIRFLOW__CORE__LOAD_EXAMPLES": "false",
@@ -351,9 +351,9 @@ def airflow_local_pipeline_run():
         env = {**os.environ, **default_env, **extra_env}
 
         # make test Airflow home dir
-        test_airflow_home_dir = os.environ["AIRFLOW_HOME"]
-        if not os.path.exists(test_airflow_home_dir):
-            os.makedirs(test_airflow_home_dir)
+        airflow_home_dir_for_tests = os.environ["AIRFLOW_HOME"]
+        if not os.path.exists(airflow_home_dir_for_tests):
+            os.makedirs(airflow_home_dir_for_tests)
 
         initdb = Popen(
             ["airflow", "initdb"], shell=False, stdout=DEVNULL, stderr=DEVNULL, env=env
@@ -398,7 +398,7 @@ def airflow_local_pipeline_run():
 
     scheduler_to_clean_up.terminate()
 
-    shutil.rmtree(test_airflow_home_dir)
+    shutil.rmtree(airflow_home_dir_for_tests)
     os.unlink("./scheduler.log")
 
 

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -54,7 +54,7 @@ def tag():
     """
     Get tag to use for containers
     """
-    return os.environ.get("FLOWETL_CONTAINERS_TAG", "latest")
+    return os.environ.get("FLOWETL_TESTS_CONTAINER_TAG", "latest")
 
 
 @pytest.fixture(scope="session")

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -88,12 +88,17 @@ def container_env():
 @pytest.fixture(scope="session")
 def container_ports():
     """
-    Exposed ports for flowetl_db and flowdb
+    Exposed ports for flowetl_db and flowdb (
     """
+    flowetl_airflow_host_port = 8080
     flowetl_db_host_port = 9000
     flowdb_host_port = 9001
 
-    return {"flowetl_db": flowetl_db_host_port, "flowdb": flowdb_host_port}
+    return {
+        "flowetl_airflow": flowetl_airflow_host_port,
+        "flowetl_db": flowetl_db_host_port,
+        "flowdb": flowdb_host_port,
+    }
 
 
 @pytest.fixture(scope="function")
@@ -217,6 +222,7 @@ def flowetl_container(
     container_env,
     container_network,
     mounts,
+    container_ports,
 ):
     """
     Start (and clean up) flowetl. Setting user to uid/gid of
@@ -230,7 +236,7 @@ def flowetl_container(
         name="flowetl",
         network="testing",
         restart_policy={"Name": "always"},
-        ports={"8080": "8080"},
+        ports={"8080": container_ports["flowetl_airflow"]},
         mounts=mounts["flowetl"],
         user=user,
         detach=True,

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -6,6 +6,7 @@
 """
 Conftest for flowetl integration tests
 """
+import docker
 import os
 import shutil
 import logging
@@ -19,7 +20,6 @@ from pendulum import now, Interval
 from airflow.models import DagRun
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
-from docker import from_env, APIClient
 from docker.types import Mount
 from shutil import rmtree
 
@@ -29,7 +29,7 @@ def docker_client():
     """
     docker client object - used to run containers
     """
-    return from_env()
+    return docker.from_env()
 
 
 @pytest.fixture(scope="session")
@@ -37,7 +37,7 @@ def docker_APIClient():
     """
     docker APIClient object - needed to inspect containers
     """
-    return APIClient()
+    return docker.APIClient()
 
 
 @pytest.fixture(scope="session")

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -311,6 +311,19 @@ def write_files_to_dump(flowetl_mounts_dir):
     [file.unlink() for file in files_to_remove]
 
 
+@pytest.fixture(scope="session", autouse=True)
+def ensure_required_env_vars_are_set():
+    if "AIRFLOW_HOME" not in os.environ:
+        raise RuntimeError(
+            "Must set environment variable AIRFLOW_HOME to run the flowetl tests."
+        )
+
+    if "true" != os.getenv("TESTING", "false").lower():
+        raise RuntimeError(
+            "Must set environment variable TESTING='true' to run the flowetl tests."
+        )
+
+
 @pytest.fixture(scope="module")
 def airflow_local_setup():
     """

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -112,7 +112,7 @@ def container_network(docker_client):
 
 
 @pytest.fixture(scope="function")
-def data_dir():
+def postgres_data_dir_for_tests():
     """
     Creates and cleans up a directory for storing pg data.
     Used by Flowdb because on unix changing flowdb user is
@@ -126,7 +126,7 @@ def data_dir():
 
 
 @pytest.fixture(scope="function")
-def mounts(data_dir):
+def mounts(postgres_data_dir_for_tests):
     """
     Various mount objects needed by containers
     """
@@ -147,7 +147,9 @@ def mounts(data_dir):
         quarantine_mount,
     ]
 
-    data_mount = Mount("/var/lib/postgresql/data", data_dir, type="bind")
+    data_mount = Mount(
+        "/var/lib/postgresql/data", postgres_data_dir_for_tests, type="bind"
+    )
     ingest_mount = Mount("/ingest", f"{os.getcwd()}/mounts/ingest", type="bind")
     flowdb_mounts = [data_mount, ingest_mount]
 

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -163,6 +163,15 @@ def mounts(postgres_data_dir_for_tests, flowetl_mounts_dir):
     return {"flowetl": flowetl_mounts, "flowdb": flowdb_mounts}
 
 
+@pytest.fixture(scope="session", autouse=True)
+def pull_docker_images(docker_client, tag):
+    print("[DDD] Pulling docker images...")
+    docker_client.images.pull("postgres", tag="11.0")
+    docker_client.images.pull("flowminder/flowdb", tag=tag)
+    docker_client.images.pull("flowminder/flowetl", tag=tag)
+    print("[DDD] Done pulling docker images.")
+
+
 @pytest.fixture(scope="function")
 def flowdb_container(
     docker_client,

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -24,6 +24,8 @@ from docker.types import Mount
 from shutil import rmtree
 
 here = os.path.dirname(os.path.abspath(__file__))
+logger = logging.getLogger("flowetl-tests")
+logger.setLevel("INFO")
 
 
 @pytest.fixture(scope="session")
@@ -165,11 +167,11 @@ def mounts(postgres_data_dir_for_tests, flowetl_mounts_dir):
 
 @pytest.fixture(scope="session", autouse=True)
 def pull_docker_images(docker_client, tag):
-    print("[DDD] Pulling docker images...")
+    logger.info(f"Pulling docker images (tag='{tag}')...")
     docker_client.images.pull("postgres", tag="11.0")
     docker_client.images.pull("flowminder/flowdb", tag=tag)
     docker_client.images.pull("flowminder/flowetl", tag=tag)
-    print("[DDD] Done pulling docker images.")
+    print("Done pulling docker images.")
 
 
 @pytest.fixture(scope="function")
@@ -501,7 +503,7 @@ def flowetl_db_connection_engine(container_env, container_ports):
     Engine for flowetl_db
     """
     conn_str = f"postgresql://{container_env['flowetl_db']['POSTGRES_USER']}:{container_env['flowetl_db']['POSTGRES_PASSWORD']}@localhost:{container_ports['flowetl_db']}/{container_env['flowetl_db']['POSTGRES_DB']}"
-    logging.info(conn_str)
+    logger.info(conn_str)
     engine = create_engine(conn_str)
 
     return engine

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -393,6 +393,7 @@ def airflow_local_pipeline_run():
             stderr=DEVNULL,
             env=env,
         )
+        p.wait()
 
     yield run_func
 

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -40,7 +40,7 @@ def docker_client():
 
 
 @pytest.fixture(scope="session")
-def docker_APIClient():
+def docker_api_client():
     """
     docker APIClient object - needed to inspect containers
     """
@@ -175,7 +175,7 @@ def pull_docker_images(docker_client, tag):
 @pytest.fixture(scope="function")
 def flowdb_container(
     docker_client,
-    docker_APIClient,
+    docker_api_client,
     tag,
     container_env,
     container_ports,
@@ -203,7 +203,7 @@ def flowdb_container(
 
     healthy = False
     while not healthy:
-        container_info = docker_APIClient.inspect_container(container.id)
+        container_info = docker_api_client.inspect_container(container.id)
         healthy = container_info["State"]["Health"]["Status"] == "healthy"
 
     yield

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -50,7 +50,7 @@ def docker_api_client():
 
 
 @pytest.fixture(scope="session")
-def tag():
+def container_tag():
     """
     Get tag to use for containers
     """
@@ -166,11 +166,11 @@ def mounts(postgres_data_dir_for_tests, flowetl_mounts_dir):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def pull_docker_images(docker_client, tag):
-    logger.info(f"Pulling docker images (tag='{tag}')...")
+def pull_docker_images(docker_client, container_tag):
+    logger.info(f"Pulling docker images (tag='{container_tag}')...")
     docker_client.images.pull("postgres", tag="11.0")
-    docker_client.images.pull("flowminder/flowdb", tag=tag)
-    docker_client.images.pull("flowminder/flowetl", tag=tag)
+    docker_client.images.pull("flowminder/flowdb", tag=container_tag)
+    docker_client.images.pull("flowminder/flowetl", tag=container_tag)
     print("Done pulling docker images.")
 
 
@@ -178,7 +178,7 @@ def pull_docker_images(docker_client, tag):
 def flowdb_container(
     docker_client,
     docker_api_client,
-    tag,
+    container_tag,
     container_env,
     container_ports,
     container_network,
@@ -192,7 +192,7 @@ def flowdb_container(
     """
     user = f"{os.getuid()}:{os.getgid()}"
     container = docker_client.containers.run(
-        f"flowminder/flowdb:{tag}",
+        f"flowminder/flowdb:{container_tag}",
         environment=container_env["flowdb"],
         ports={"5432": container_ports["flowdb"]},
         name="flowdb",
@@ -238,7 +238,7 @@ def flowetl_container(
     flowdb_container,
     flowetl_db_container,
     docker_client,
-    tag,
+    container_tag,
     container_env,
     container_network,
     mounts,
@@ -251,7 +251,7 @@ def flowetl_container(
     """
     user = f"{os.getuid()}:{os.getgid()}"
     container = docker_client.containers.run(
-        f"flowminder/flowetl:{tag}",
+        f"flowminder/flowetl:{container_tag}",
         environment=container_env["flowetl"],
         name="flowetl",
         network="testing",

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -45,7 +45,7 @@ def tag():
     """
     Get tag to use for containers
     """
-    return os.environ.get("TAG", "latest")
+    return os.environ.get("FLOWETL_CONTAINERS_TAG", "latest")
 
 
 @pytest.fixture(scope="session")

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -19,7 +19,7 @@ from subprocess import DEVNULL, Popen
 from pendulum import now, Interval
 from airflow.models import DagRun
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, scoped_session
+from sqlalchemy.orm import sessionmaker
 from docker.types import Mount
 from shutil import rmtree
 

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -25,7 +25,6 @@ from shutil import rmtree
 
 here = os.path.dirname(os.path.abspath(__file__))
 logger = logging.getLogger("flowetl-tests")
-logger.setLevel("INFO")
 
 
 @pytest.fixture(scope="session")

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -434,21 +434,17 @@ def wait_for_completion():
         # you want to use - need to not pass at all if you want airflow to pick
         # up correct session using it's provide_session decorator...
         if session is None:
-            t0 = now()
-            while len(DagRun.find(dag_id, state=end_state)) != 1:
-                sleep(1)
-                t1 = now()
-                if (t1 - t0) > time_out:
-                    raise TimeoutError
-            return end_state
+            kwargs = {"dag_id": dag_id, "state": end_state}
         else:
-            t0 = now()
-            while len(DagRun.find(dag_id, state=end_state, session=session)) != 1:
-                sleep(1)
-                t1 = now()
-                if (t1 - t0) > time_out:
-                    raise TimeoutError
-            return end_state
+            kwargs = {"dag_id": dag_id, "state": end_state, "session": session}
+
+        t0 = now()
+        while len(DagRun.find(**kwargs)) != 1:
+            sleep(1)
+            t1 = now()
+            if (t1 - t0) > time_out:
+                raise TimeoutError
+        return end_state
 
     return wait_func
 

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -90,9 +90,9 @@ def container_ports():
     """
     Exposed ports for flowetl_db and flowdb (
     """
-    flowetl_airflow_host_port = 8080
-    flowetl_db_host_port = 9000
-    flowdb_host_port = 9001
+    flowetl_airflow_host_port = 28080
+    flowetl_db_host_port = 29000
+    flowdb_host_port = 29001
 
     return {
         "flowetl_airflow": flowetl_airflow_host_port,

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -429,15 +429,13 @@ def wait_for_completion():
     seems OK...) three minutes raises a TimeoutError.
     """
 
-    def wait_func(
-        end_state, dag_id, session=None, count=1, time_out=Interval(minutes=3)
-    ):
+    def wait_func(end_state, dag_id, session=None, time_out=Interval(minutes=3)):
         # if you actually pass None to DagRun.find it thinks None is the session
         # you want to use - need to not pass at all if you want airflow to pick
         # up correct session using it's provide_session decorator...
         if session is None:
             t0 = now()
-            while len(DagRun.find(dag_id, state=end_state)) != count:
+            while len(DagRun.find(dag_id, state=end_state)) != 1:
                 sleep(1)
                 t1 = now()
                 if (t1 - t0) > time_out:
@@ -445,7 +443,7 @@ def wait_for_completion():
             return end_state
         else:
             t0 = now()
-            while len(DagRun.find(dag_id, state=end_state, session=session)) != count:
+            while len(DagRun.find(dag_id, state=end_state, session=session)) != 1:
                 sleep(1)
                 t1 = now()
                 if (t1 - t0) > time_out:

--- a/flowetl/tests/integration/test_fixuid.py
+++ b/flowetl/tests/integration/test_fixuid.py
@@ -8,7 +8,7 @@ Tests that fixuid works as expected
 """
 
 
-def test_uid(docker_client, tag):
+def test_uid(docker_client, container_tag):
     """
     test that we can run the flowetl container with a specific user.
     Check UID is correct.
@@ -16,12 +16,12 @@ def test_uid(docker_client, tag):
 
     user = "1002:1003"
     out = docker_client.containers.run(
-        f"flowminder/flowetl:{tag}", "bash -c 'id -u'", user=user
+        f"flowminder/flowetl:{container_tag}", "bash -c 'id -u'", user=user
     )
     assert out.decode("utf-8").strip() == "1002"
 
 
-def test_gid(docker_client, tag):
+def test_gid(docker_client, container_tag):
     """
     test that we can run the flowetl container with a specific user.
     Check GID is correct.
@@ -29,18 +29,18 @@ def test_gid(docker_client, tag):
 
     user = "1002:1003"
     out = docker_client.containers.run(
-        f"flowminder/flowetl:{tag}", "bash -c 'id -g'", user=user
+        f"flowminder/flowetl:{container_tag}", "bash -c 'id -g'", user=user
     )
     assert out.decode("utf-8").strip() == "1003"
 
 
-def test_uid_is_airflow(docker_client, tag):
+def test_uid_is_airflow(docker_client, container_tag):
     """
     Test that the user we run the container with is the airflow user.
     """
 
     user = "1002:1003"
     out = docker_client.containers.run(
-        f"flowminder/flowetl:{tag}", "bash -c 'id -u | id -nu'", user=user
+        f"flowminder/flowetl:{container_tag}", "bash -c 'id -u | id -nu'", user=user
     )
     assert out.decode("utf-8").strip() == "airflow"


### PR DESCRIPTION
Just a few tweaks from my trying out #858, mostly just renamings to make some things a little more obvious at a glance.

### I have:

- [X] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

- Renamed `TAG` to `FLOWETL_TESTS_CONTAINERS_TAG`
- Renamed the `tag` fixture to `container_tag`
- Added a structlog logger (which also fixes a minor issue with logging messages from tests not showing up before)
- Fixed a duplicate test name which shadowed one of the tests (the second one `test_find_files_non_default_filter`).
- Currently `os.getcwd()` is used to determine the `mounts` folder, which relies on the tests being run in the correct directory. I have introduced a fixture `flowetl_mounts_dir` to make things slightly more robust.
- Switched to non-standard ports for running the tests. @greenape has pointed out that it would be better to not assign any explicit ports but I'll leave this for a separate PR.
- Renamed fixture `data_dir` to `postgres_data_dir_for_tests`
- Added a separate fixture to pull docker images (mainly so that we can print some logging messages and the tests don't appear to be hanging)
- Added a fixture to ensure that the `AIRFLOW_HOME` and `TESTING` env vars are set when running the tests.
- Renamed `test_airflow_home_dir` to `airflow_home_dir_for_tests` because the former sounds like it's a pytest test _function_.
- Removed some code duplication in `wait_for_completion `