### PR TITLE
FlowETL CI tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ defaults:
       tags:
         only: /.*/
 
-
 executors:
   python_with_flowdb: # Synthetic data generation execution environment
     parameters:
@@ -85,24 +84,24 @@ executors:
         type: string
         default: "2015-01-01"
     environment:
-        POSTGRES_PASSWORD: flowflow
-        MPLBACKEND: "agg"
-        FLOWDB_PORT: 5432
-        FLOWMACHINE_FLOWDB_PASSWORD: foo
-        FLOWAPI_FLOWDB_PASSWORD: foo
-        FLOWAPI_FLOWDB_USER: flowapi
-        REDIS_PASSWORD: fm_redis
-        SYNTHETIC_DATA_DB_PORT: 5432
-        POSTGRES_USER: flowdb
-        REDIS_HOST: "localhost"
-        QUART_APP: "flowapi.main:create_app()"
-        FLOWMACHINE_FLOWDB_USER: flowmachine
-        LOG_DIRECTORY: "."
-        FLOWMACHINE_HOST: localhost
-        FLOWMACHINE_PORT: 5555
-        FLOWDB_HOST: localhost
-        JWT_SECRET_KEY: secret
-        FLOWAPI_IDENTIFIER: TEST_SERVER
+      POSTGRES_PASSWORD: flowflow
+      MPLBACKEND: "agg"
+      FLOWDB_PORT: 5432
+      FLOWMACHINE_FLOWDB_PASSWORD: foo
+      FLOWAPI_FLOWDB_PASSWORD: foo
+      FLOWAPI_FLOWDB_USER: flowapi
+      REDIS_PASSWORD: fm_redis
+      SYNTHETIC_DATA_DB_PORT: 5432
+      POSTGRES_USER: flowdb
+      REDIS_HOST: "localhost"
+      QUART_APP: "flowapi.main:create_app()"
+      FLOWMACHINE_FLOWDB_USER: flowmachine
+      LOG_DIRECTORY: "."
+      FLOWMACHINE_HOST: localhost
+      FLOWMACHINE_PORT: 5555
+      FLOWDB_HOST: localhost
+      JWT_SECRET_KEY: secret
+      FLOWAPI_IDENTIFIER: TEST_SERVER
     docker:
       - image: circleci/python:3.7
       - image: flowminder/flowdb-<<parameters.flowdb_image>>:$CIRCLE_SHA1
@@ -214,14 +213,14 @@ jobs:
             touch .synthetic-data-build-done
           background: true
       - run:
-         name: Test that not providing a superuser password causes the container to exit
-         command: |
-           if docker run -e FLOWMACHINE_FLOWDB_PASSWORD=foo -e FLOWAPI_FLOWDB_PASSWORD=foo flowminder/flowdb:$SAFE_TAG; then
-               echo "Error: could run flowdb without superuser password."
-               exit 1
-           else
-               echo "Correctly failed with no superuser password."
-           fi
+          name: Test that not providing a superuser password causes the container to exit
+          command: |
+            if docker run -e FLOWMACHINE_FLOWDB_PASSWORD=foo -e FLOWAPI_FLOWDB_PASSWORD=foo flowminder/flowdb:$SAFE_TAG; then
+                echo "Error: could run flowdb without superuser password."
+                exit 1
+            else
+                echo "Correctly failed with no superuser password."
+            fi
       - run:
           name: Create data dir
           command: |
@@ -414,7 +413,7 @@ jobs:
                         --cov=flowkit_jwt_generator/ \
                         --cov-report term --cov-report xml --durations=10 --cov-append
           environment:
-            COV_CORE_SOURCE:  flowkit_jwt_generator/
+            COV_CORE_SOURCE: flowkit_jwt_generator/
             COV_CORE_CONFIG: .coveragerc
             COV_CORE_DATAFILE: .coverage.eager
       - store_test_results:
@@ -443,8 +442,7 @@ jobs:
   run_flowauth_backend_tests:
     docker:
       - image: circleci/python:3.6
-    environment:
-      &flowauth_env
+    environment: &flowauth_env
       FLOWAUTH_FERNET_KEY: "XU-J5xNOtkaUKAoqWT7_VoT3zk2OTuoqKPBN3l0pOFg="
       FLASK_APP: flowauth
       FLOWAPI_IDENTIFIER: TEST_SERVER
@@ -534,7 +532,8 @@ jobs:
     parameters:
       component:
         type: enum
-        enum: ["flowmachine", "flowauth", "flowapi", "flowkit-examples", "flowetl"]
+        enum:
+          ["flowmachine", "flowauth", "flowapi", "flowkit-examples", "flowetl"]
       component_path:
         type: string
     docker:
@@ -565,31 +564,31 @@ jobs:
     environment:
       AIRFLOW_HOME: ./test_airflow_home
       TESTING: "true"
-    working_directory: /home/circleci/project/
+    working_directory: /home/circleci/project/flowetl
     steps:
       - checkout:
           path: /home/circleci/project/
       - restore_cache:
-          key: flowetl-deps-1-{{ checksum "flowetl/Pipfile.lock"}}
+          key: flowetl-deps-1-{{ checksum "Pipfile.lock"}}
       - run:
           name: Install pipenv
           command: pip install --upgrade pip pipenv
       - run:
           name: Install python dependencies
           command: |
-            PIPENV_PIPFILE=flowetl/Pipfile pipenv install --deploy --dev
+            pipenv install --deploy --dev
       - run:
           name: run flowetl integration tests
           command: |
-            cd flowetl
-            TAG=$CIRCLE_SHA1 pipenv run pytest --junit-xml=test_results/pytest/results_integration.xml ./tests
+            pipenv run pytest --junit-xml=test_results/pytest/results_integration.xml ./tests
+          environment:
+            TAG: $CIRCLE_SHA1
       - run:
           name: run etl module unit tests
           command: |
-            cd flowetl
             pipenv run pytest --junit-xml=test_results/pytest/results_unit_etl_module.xml ./etl/tests
       - store_test_results:
-          path: flowetl/test_results
+          path: test_results
 
   integration_tests:
     executor:
@@ -738,7 +737,6 @@ jobs:
           paths:
             - /home/circleci/.local/share/virtualenvs/
 
-
   build_python_wheel:
     parameters:
       project_name:
@@ -792,10 +790,6 @@ jobs:
             for IMAGE in flowapi flowmachine flowdb flowdb-synthetic-data flowdb-testdata flowauth flowkit-examples flowetl; do
               docker-retag flowminder/$IMAGE:$CIRCLE_SHA1 ${<< parameters.tag >>:-latest}
             done
-
-
-
-
 
 workflows:
   run_build_pipeline:
@@ -889,8 +883,7 @@ workflows:
           <<: *run_always_org_context
       - run_quickstart_tests:
           name: test_quickstart
-          requires:
-            &quickstart_requirements
+          requires: &quickstart_requirements
             - build_flowdb
             - build_flowapi
             - build_flowmachine
@@ -901,16 +894,15 @@ workflows:
       - run_quickstart_tests:
           name: test_quickstart_examples_with_smaller_data
           start_arguments: "examples smaller_data"
-          requires:
-            *quickstart_requirements
+          requires: *quickstart_requirements
           <<: *run_always_org_context
-#      # Synth data spinup with the 'large' data volume is very slow so not testing it right now on CI
-#      - run_quickstart_tests:
-#          name: test_quickstart_with_larger_data
-#          start_arguments: "larger_data"
-#          requires:
-#            *quickstart_requirements
-#          <<: *run_always_org_context
+      #      # Synth data spinup with the 'large' data volume is very slow so not testing it right now on CI
+      #      - run_quickstart_tests:
+      #          name: test_quickstart_with_larger_data
+      #          start_arguments: "larger_data"
+      #          requires:
+      #            *quickstart_requirements
+      #          <<: *run_always_org_context
       - integration_tests:
           requires:
             - install_flowmachine_deps
@@ -918,11 +910,10 @@ workflows:
           <<: *run_always_org_context
       - retag_images:
           name: retag_master_branch
-          requires:
-            &retag_requirements
+          requires: &retag_requirements
             - test_quickstart
             - test_quickstart_examples_with_smaller_data
-#            - test_quickstart_with_larger_data
+            #            - test_quickstart_with_larger_data
             - integration_tests
             - build_docs
             - run_flowkit_api_tests
@@ -938,8 +929,7 @@ workflows:
           <<: *master_only_org_context
       - retag_images:
           name: retag_tagged_build
-          requires:
-            *retag_requirements
+          requires: *retag_requirements
           tag: CIRCLE_TAG
           <<: *tag_only_org_context
       - push_wheel:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -917,7 +917,7 @@ workflows:
           requires: &retag_requirements
             - test_quickstart
             - test_quickstart_examples_with_smaller_data
-            #            - test_quickstart_with_larger_data
+            # - test_quickstart_with_larger_data
             - integration_tests
             - build_docs
             - run_flowkit_api_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,6 +577,10 @@ jobs:
           name: Install python dependencies
           command: |
             pipenv install --deploy --dev
+      - save_cache:
+          key: flowetl-deps1-{{ checksum "Pipfile.lock" }}
+          paths:
+            - /home/circleci/.local/share/virtualenvs/
       - run:
           name: run flowetl integration tests
           command: |


### PR DESCRIPTION
Slight simplification of the flowetl test config by setting the working directory to flowetl, meaning you don't need to cd for every command, and adds a save cache step so the restore cache step doesn't feel lonely.