### PR TITLE
Stop pretty-quick getting carried away and autoformatting everything

### DIFF
--- a/flowauth/frontend/package.json
+++ b/flowauth/frontend/package.json
@@ -38,7 +38,7 @@
   ],
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged"
+      "pre-commit": "pretty-quick --staged --pattern \"**/*.*(js|jsx|json)\""
     }
   }
 }


### PR DESCRIPTION
Restrict Flowauth's code formatting pre-commit hook to auto formatting javascript.