### PR TITLE
Remove MOUNT_HOME env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -564,6 +564,7 @@ jobs:
     environment:
       AIRFLOW_HOME: ./test_airflow_home
       TESTING: "true"
+      FLOWETL_TESTS_CONTAINER_TAG: $CIRCLE_SHA1
     working_directory: /home/circleci/project/flowetl
     steps:
       - checkout:
@@ -585,8 +586,6 @@ jobs:
           name: run flowetl integration tests
           command: |
             pipenv run pytest --junit-xml=test_results/pytest/results_integration.xml ./tests
-          environment:
-            FLOWETL_TESTS_CONTAINER_TAG: $CIRCLE_SHA1
       - run:
           name: run etl module unit tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -564,7 +564,6 @@ jobs:
     environment:
       AIRFLOW_HOME: ./test_airflow_home
       TESTING: "true"
-      FLOWETL_TESTS_CONTAINER_TAG: $CIRCLE_SHA1
     working_directory: /home/circleci/project/flowetl
     steps:
       - checkout:
@@ -582,6 +581,10 @@ jobs:
           key: flowetl-deps1-{{ checksum "Pipfile.lock" }}
           paths:
             - /home/circleci/.local/share/virtualenvs/
+      - run:
+          name: Set FLOWETL_TESTS_CONTAINER_TAG env var
+          command: |
+            echo "export FLOWETL_TESTS_CONTAINER_TAG=${CIRCLE_SHA1}" >> $BASH_ENV
       - run:
           name: run flowetl integration tests
           command: |
@@ -627,11 +630,13 @@ jobs:
     machine:
       image: circleci/classic:201808-01
     working_directory: /home/circleci/project
-    environment:
-      GIT_REVISION: $CIRCLE_SHA1
     steps:
       - checkout:
           path: /home/circleci/project/
+      - run:
+          name: Set GIT_REVISION env var
+          command: |
+            echo "export GIT_REVISION=${CIRCLE_SHA1}" >> $BASH_ENV
       - run: ./quick_start.sh <<parameters.start_arguments>>
       - run: ./quick_start.sh stop
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -582,7 +582,7 @@ jobs:
           paths:
             - /home/circleci/.local/share/virtualenvs/
       - run:
-          name: Set FLOWETL_TESTS_CONTAINER_TAG env var
+          name: Set FLOWETL_TESTS_CONTAINER_TAG environment variable
           command: |
             echo "export FLOWETL_TESTS_CONTAINER_TAG=${CIRCLE_SHA1}" >> $BASH_ENV
       - run:
@@ -634,7 +634,7 @@ jobs:
       - checkout:
           path: /home/circleci/project/
       - run:
-          name: Set GIT_REVISION env var
+          name: Set GIT_REVISION environment variable
           command: |
             echo "export GIT_REVISION=${CIRCLE_SHA1}" >> $BASH_ENV
       - run: ./quick_start.sh <<parameters.start_arguments>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -586,7 +586,7 @@ jobs:
           command: |
             pipenv run pytest --junit-xml=test_results/pytest/results_integration.xml ./tests
           environment:
-            FLOWETL_TESTS_CONTAINERS_TAG: $CIRCLE_SHA1
+            FLOWETL_TESTS_CONTAINER_TAG: $CIRCLE_SHA1
       - run:
           name: run etl module unit tests
           command: |

--- a/development_environment
+++ b/development_environment
@@ -135,7 +135,6 @@ FLOWETL_POSTGRES_HOST=flowetl_db
 FLOWETL_POSTGRES_DB=flowetl
 FLOWETL_POSTGRES_PORT=9001
 
-MOUNT_HOME=/mounts
 HOST_CONFIG_DIR=./flowetl/mounts/config
 HOST_DUMP_DIR=./flowetl/mounts/dump
 HOST_ARCHIVE_DIR=./flowetl/mounts/archive

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,11 +194,11 @@ services:
     ports:
       - ${FLOWETL_PORT:?Must set FLOWETL_PORT env var}:8080
     volumes:
-      - ${HOST_CONFIG_DIR:?Must set HOST_CONFIG_DIR env var}:${MOUNT_HOME:?Must set MOUNT_HOME env var}/config:ro
-      - ${HOST_DUMP_DIR:?Must set HOST_DUMP_DIR env var}:${MOUNT_HOME:?Must set MOUNT_HOME env var}/dump:rw
-      - ${HOST_ARCHIVE_DIR:?Must set HOST_ARCHIVE_DIR env var}:${MOUNT_HOME:?Must set MOUNT_HOME env var}/archive:rw
-      - ${HOST_QUARANTINE_DIR:?Must set HOST_QUARANTINE_DIR env var}:${MOUNT_HOME:?Must set MOUNT_HOME env var}/quarantine:rw
-      - ${HOST_INGEST_DIR:?Must set HOST_INGEST_DIR env var}:${MOUNT_HOME:?Must set MOUNT_HOME env var}/ingest:rw
+      - ${HOST_CONFIG_DIR:?Must set HOST_CONFIG_DIR env var}:/mounts/config:ro
+      - ${HOST_DUMP_DIR:?Must set HOST_DUMP_DIR env var}:/mounts/dump:rw
+      - ${HOST_ARCHIVE_DIR:?Must set HOST_ARCHIVE_DIR env var}:/mounts/archive:rw
+      - ${HOST_QUARANTINE_DIR:?Must set HOST_QUARANTINE_DIR env var}:/mounts/quarantine:rw
+      - ${HOST_INGEST_DIR:?Must set HOST_INGEST_DIR env var}:/mounts/ingest:rw
 
     environment:
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
@@ -209,7 +209,6 @@ services:
       POSTGRES_PASSWORD: ${FLOWETL_POSTGRES_PASSWORD:?Must set FLOWETL_POSTGRES_PASSWORD env var}
       POSTGRES_HOST: ${FLOWETL_POSTGRES_HOST:?Must set FLOWETL_POSTGRES_HOST env var}
       POSTGRES_DB: ${FLOWETL_POSTGRES_DB:?Must set FLOWETL_POSTGRES_DB env var}
-      MOUNT_HOME: ${MOUNT_HOME:?Must set MOUNT_HOME env var}
 
     networks:
       - db

--- a/flowetl/dags/etl.py
+++ b/flowetl/dags/etl.py
@@ -40,7 +40,7 @@ else:
 
     # read and validate the config file before creating the DAGs
     global_config_dict = get_config_from_file(
-        config_filepath=os.environ["MOUNT_HOME"] / Path("config/config.yml")
+        config_filepath=Path("/mounts/config/config.yml")
     )
     validate_config(global_config_dict=global_config_dict)
 

--- a/flowetl/etl/etl/dag_task_callable_mappings.py
+++ b/flowetl/etl/etl/dag_task_callable_mappings.py
@@ -27,14 +27,14 @@ from etl.production_task_callables import (
 )
 
 mount_paths = {
-    "dump": Path(f"{os.environ.get('MOUNT_HOME','')}/dump"),
-    "ingest": Path(f"{os.environ.get('MOUNT_HOME','')}/ingest"),
-    "archive": Path(f"{os.environ.get('MOUNT_HOME','')}/archive"),
-    "quarantine": Path(f"{os.environ.get('MOUNT_HOME','')}/quarantine"),
+    "dump": Path("/mounts/dump"),
+    "ingest": Path("/mounts/ingest"),
+    "archive": Path("/mounts/archive"),
+    "quarantine": Path("/mounts/quarantine"),
 }
 
 db_hook = PostgresHook(postgres_conn_id="flowdb")
-config_path = Path(f"{os.environ.get('MOUNT_HOME','')}/config")
+config_path = Path("/mounts/config")
 try:
     config = get_config_from_file(config_filepath=config_path / "config.yml")
 except FileNotFoundError:

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -82,7 +82,6 @@ def container_env():
         "AIRFLOW__CORE__FERNET_KEY": "ssgBqImdmQamCrM9jNhxI_IXSzvyVIfqvyzES67qqVU=",
         "AIRFLOW__CORE__SQL_ALCHEMY_CONN": f"postgres://{flowetl_db['POSTGRES_USER']}:{flowetl_db['POSTGRES_PASSWORD']}@flowetl_db:5432/{flowetl_db['POSTGRES_DB']}",
         "AIRFLOW_CONN_FLOWDB": f"postgres://{flowdb['POSTGRES_USER']}:{flowdb['POSTGRES_PASSWORD']}@flowdb:5432/flowdb",
-        "MOUNT_HOME": "/mounts",
         "POSTGRES_USER": "flowetl",
         "POSTGRES_PASSWORD": "flowetl",
         "POSTGRES_DB": "flowetl",

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -27,6 +27,25 @@ here = os.path.dirname(os.path.abspath(__file__))
 logger = logging.getLogger("flowetl-tests")
 
 
+@pytest.fixture(scope="session", autouse=True)
+def ensure_required_env_vars_are_set():
+    if "AIRFLOW_HOME" not in os.environ:
+        raise RuntimeError(
+            "Must set environment variable AIRFLOW_HOME to run the flowetl tests."
+        )
+
+    if "true" != os.getenv("TESTING", "false").lower():
+        raise RuntimeError(
+            "Must set environment variable TESTING='true' to run the flowetl tests."
+        )
+
+    if "FLOWETL_TESTS_CONTAINER_TAG" not in os.environ:
+        raise RuntimeError(
+            "Must explicitly set environment variable FLOWETL_TESTS_CONTAINER_TAG to run the flowetl tests. "
+            "(Use `FLOWETL_TESTS_CONTAINER_TAG=latest` if you don't need a specific version.)"
+        )
+
+
 @pytest.fixture(scope="session")
 def flowetl_mounts_dir():
     return os.path.abspath(os.path.join(here, "..", "..", "mounts"))
@@ -53,7 +72,7 @@ def container_tag():
     """
     Get tag to use for containers
     """
-    return os.environ.get("FLOWETL_TESTS_CONTAINER_TAG", "latest")
+    return os.environ["FLOWETL_TESTS_CONTAINER_TAG"]
 
 
 @pytest.fixture(scope="session")
@@ -309,19 +328,6 @@ def write_files_to_dump(flowetl_mounts_dir):
     files_to_remove = filter(lambda file: file.name != "README.md", files_to_remove)
 
     [file.unlink() for file in files_to_remove]
-
-
-@pytest.fixture(scope="session", autouse=True)
-def ensure_required_env_vars_are_set():
-    if "AIRFLOW_HOME" not in os.environ:
-        raise RuntimeError(
-            "Must set environment variable AIRFLOW_HOME to run the flowetl tests."
-        )
-
-    if "true" != os.getenv("TESTING", "false").lower():
-        raise RuntimeError(
-            "Must set environment variable TESTING='true' to run the flowetl tests."
-        )
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### I have:

- [X] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This PR removes the `MOUNT_HOME` env var from flowetl. The only reason I can see we might want this is if it needs to be configured to a different value during testing, but AFAICT the variable is only relevant for paths inside the docker container where the value is hard-coded to `/mounts/` anyway.