### PR TITLE
Remove pygraphviz as dev dependency (only load on demand)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,15 +294,15 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: flowmachine-deps-1-{{ checksum "flowmachine/Pipfile.lock" }}
+          key: flowmachine-deps-2-{{ checksum "flowmachine/Pipfile.lock" }}
       # Need to install graphviz and pygraphviz manually because it was removed from the Pipfile
       # (see https://github.com/Flowminder/FlowKit/issues/952)
+      - run: cd flowmachine && sudo apt-get install -y graphviz && pipenv run pip install pygraphviz
       - run: cd flowmachine && pipenv install --dev --deploy && pipenv run pip install -e .
       - save_cache:
-          key: flowmachine-deps-1-{{ checksum "flowmachine/Pipfile.lock" }}
+          key: flowmachine-deps-2-{{ checksum "flowmachine/Pipfile.lock" }}
           paths:
             - /home/circleci/.local/share/virtualenvs/flowmachine-caaCcVrN
-      - run: cd flowmachine && sudo apt-get install -y graphviz && pipenv run pip install pygraphviz
 
   lint_python:
     docker: *base_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,6 +295,9 @@ jobs:
       - checkout
       - restore_cache:
           key: flowmachine-deps-1-{{ checksum "flowmachine/Pipfile.lock" }}
+      # Need to install graphviz and pygraphviz manually because it was removed from the Pipfile
+      # (see https://github.com/Flowminder/FlowKit/issues/952)
+      - run: cd flowmachine && sudo apt-get install -y graphviz && pipenv run pip install pygraphviz
       - run: cd flowmachine && pipenv install --dev --deploy && pipenv run pip install -e .
       - save_cache:
           key: flowmachine-deps-1-{{ checksum "flowmachine/Pipfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,6 @@ jobs:
     working_directory: /home/circleci/project
     steps:
       - checkout
-      - run: cd flowmachine && sudo apt-get install -y graphviz && pipenv run pip install pygraphviz
       - restore_cache:
           key: flowmachine-deps-1-{{ checksum "flowmachine/Pipfile.lock" }}
       # Need to install graphviz and pygraphviz manually because it was removed from the Pipfile
@@ -303,6 +302,7 @@ jobs:
           key: flowmachine-deps-1-{{ checksum "flowmachine/Pipfile.lock" }}
           paths:
             - /home/circleci/.local/share/virtualenvs/flowmachine-caaCcVrN
+      - run: cd flowmachine && sudo apt-get install -y graphviz && pipenv run pip install pygraphviz
 
   lint_python:
     docker: *base_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,11 +293,11 @@ jobs:
     working_directory: /home/circleci/project
     steps:
       - checkout
+      - run: cd flowmachine && sudo apt-get install -y graphviz && pipenv run pip install pygraphviz
       - restore_cache:
           key: flowmachine-deps-1-{{ checksum "flowmachine/Pipfile.lock" }}
       # Need to install graphviz and pygraphviz manually because it was removed from the Pipfile
       # (see https://github.com/Flowminder/FlowKit/issues/952)
-      - run: cd flowmachine && sudo apt-get install -y graphviz && pipenv run pip install pygraphviz
       - run: cd flowmachine && pipenv install --dev --deploy && pipenv run pip install -e .
       - save_cache:
           key: flowmachine-deps-1-{{ checksum "flowmachine/Pipfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,7 +310,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: flowmachine-deps-1-{{ checksum "flowmachine/Pipfile.lock" }}
+          key: flowmachine-deps-2-{{ checksum "flowmachine/Pipfile.lock" }}
       - run:
           name: Linting files with black
           command: PIPENV_PIPFILE=flowmachine/Pipfile pipenv run black --check .
@@ -349,7 +349,7 @@ jobs:
       - attach_workspace:
           at: /home/circleci/
       - restore_cache:
-          key: flowmachine-deps-1-{{ checksum "Pipfile.lock" }}
+          key: flowmachine-deps-2-{{ checksum "Pipfile.lock" }}
       - run:
           name: Install graphviz
           command: sudo apt-get install -y xvfb graphviz

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -188,7 +188,7 @@ def pull_docker_images(docker_client, container_tag):
     docker_client.images.pull("postgres", tag="11.0")
     docker_client.images.pull("flowminder/flowdb", tag=container_tag)
     docker_client.images.pull("flowminder/flowetl", tag=container_tag)
-    print("Done pulling docker images.")
+    logger.info("Done pulling docker images.")
 
 
 @pytest.fixture(scope="function")

--- a/flowmachine/Pipfile
+++ b/flowmachine/Pipfile
@@ -40,7 +40,6 @@ cachey = "*"
 approvaltests = "*"
 watchdog = "*"
 ipdb = "*"
-pygraphviz = "*"
 
 [requires]
 python_version = "3.7"

--- a/flowmachine/Pipfile.lock
+++ b/flowmachine/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f82087625099b6dbb82ee5df6ab7da00c8b48b528d8fd1292fb453c4591fa198"
+            "sha256": "3265c98e4a2e887455cb4e03577541fc4252e95e555a5990ec481d4ad5065054"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -772,13 +772,6 @@
                 "sha256:881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"
             ],
             "version": "==2.4.2"
-        },
-        "pygraphviz": {
-            "hashes": [
-                "sha256:50a829a305dc5a0fd1f9590748b19fece756093b581ac91e00c2c27c651d319d"
-            ],
-            "index": "pypi",
-            "version": "==1.5"
         },
         "pyparsing": {
             "hashes": [

--- a/flowmachine/flowmachine/utils.py
+++ b/flowmachine/flowmachine/utils.py
@@ -553,6 +553,13 @@ def plot_dependency_graph(
         from IPython.display import Image, SVG
     except ImportError:
         raise ImportError("requires IPython ", "https://ipython.org/")
+    try:
+        import pygraphviz
+    except ImportError:
+        raise ImportError(
+            "requires the Python package `pygraphviz` (as well as the system package `graphviz`) - make sure both are installed ",
+            "http://pygraphviz.github.io/",
+        )
 
     G = calculate_dependency_graph(query_obj, analyse=analyse)
     A = nx.nx_agraph.to_agraph(G)

--- a/flowmachine/flowmachine/utils.py
+++ b/flowmachine/flowmachine/utils.py
@@ -562,6 +562,9 @@ def plot_dependency_graph(
             "http://pygraphviz.github.io/",
         )
 
+    if format not in ["png", "svg"]:
+        raise ValueError(f"Unsupported output format: '{format}'")
+
     G = calculate_dependency_graph(query_obj, analyse=analyse)
     A = nx.nx_agraph.to_agraph(G)
     s = BytesIO()

--- a/flowmachine/flowmachine/utils.py
+++ b/flowmachine/flowmachine/utils.py
@@ -549,11 +549,12 @@ def plot_dependency_graph(
     -------
     IPython.display.Image or IPython.display.SVG
     """
-    try:
+    try:  # pragma: no cover
         from IPython.display import Image, SVG
     except ImportError:
         raise ImportError("requires IPython ", "https://ipython.org/")
-    try:
+
+    try:  # pragma: no cover
         import pygraphviz
     except ImportError:
         raise ImportError(

--- a/flowmachine/tests/test_utils.py
+++ b/flowmachine/tests/test_utils.py
@@ -275,3 +275,6 @@ def test_plot_dependency_graph():
     assert isinstance(output_png, IPython.display.Image)
     assert output_png.width == 600
     assert output_png.height == 200
+
+    with pytest.raises(ValueError, match="Unsupported output format: 'foobar'"):
+        plot_dependency_graph(query, format="foobar")


### PR DESCRIPTION
Closes #952 

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

As suggested in #952, this PR removed `pygraphviz` as a dev dependency and raises a meaningful error (which also mentions the `graphviz` system package) if it isn't installed but needed to run `plot_dependency_graph()`. Happy to go with a different solution if there is a better way.