### PR TITLE
Tasks/948 nested dict to arguments construct etl dag

### DIFF
--- a/flowetl/dags/etl.py
+++ b/flowetl/dags/etl.py
@@ -30,9 +30,7 @@ if os.environ.get("TESTING", "") == "true":
     task_callable_mapping = TEST_ETL_TASK_CALLABLES
     logger.info("running in testing environment")
     dag = construct_etl_dag(
-        task_callable_mapping=task_callable_mapping,
-        default_args=default_args,
-        cdr_type="testing",
+        **task_callable_mapping, default_args=default_args, cdr_type="testing"
     )
 else:
     task_callable_mapping = PRODUCTION_ETL_TASK_CALLABLES
@@ -50,7 +48,5 @@ else:
     for cdr_type in CDRType:
 
         globals()[f"etl_{cdr_type}"] = construct_etl_dag(
-            task_callable_mapping=task_callable_mapping,
-            default_args=default_args,
-            cdr_type=cdr_type,
+            **task_callable_mapping, default_args=default_args, cdr_type=cdr_type
         )

--- a/flowetl/etl/etl/etl_utils.py
+++ b/flowetl/etl/etl/etl_utils.py
@@ -55,30 +55,44 @@ def construct_etl_sensor_dag(*, callable: Callable, default_args: dict) -> DAG:
 
 
 def construct_etl_dag(
-    *, task_callable_mapping: dict, default_args: dict, cdr_type: str
+    *,
+    init: Callable,
+    extract: Callable,
+    transform: Callable,
+    load: Callable,
+    success_branch: Callable,
+    archive: Callable,
+    quarantine: Callable,
+    clean: Callable,
+    fail: Callable,
+    default_args: dict,
+    cdr_type: str
 ) -> DAG:
     """
     This function returns an Airflow DAG object of the structure
-    required for ETL. By passing a dictionary mapping task ID to
-    a python callable we can change the functionality of the
-    individual tasks whilst maintaining the desired structure
-    of the DAG.
+    required for ETL. The individual tasks are passed as python
+    Callables.
 
     Parameters
     ----------
-    task_callable_mapping : dict
-         Must contain the following keys;
-            "init"
-            "extract"
-            "transform"
-            "load"
-            "success_branch"
-            "archive"
-            "quarantine"
-            "clean"
-            "fail"
-        The value for each key should be a python callable with at a minimum
-        the following signature foo(*,**kwargs).
+    init : Callable
+        The init task callable.
+    extract : Callable
+        The extract task callable.
+    transform : Callable
+        The transform task callable.
+    load : Callable
+        The load task callable.
+    success_branch : Callable
+        The success_branch task callable.
+    archive : Callable
+        The archive task callable.
+    quarantine : Callable
+        The quarantine task callable.
+    clean : Callable
+        The clean task callable.
+    fail : Callable
+        The fail task callable.
     default_args : dict
         A set of default args to pass to all callables.
         Must containt at least "owner" key and "start" key (which must be a
@@ -90,30 +104,7 @@ def construct_etl_dag(
     -------
     DAG
         Specification of Airflow DAG for ETL
-
-    Raises
-    ------
-    TypeError
-        Exception raised if required keys in task_callable_mapping are not
-        present.
     """
-
-    # make sure we have the correct keys
-    expected_keys = set(
-        [
-            "init",
-            "extract",
-            "transform",
-            "load",
-            "success_branch",
-            "archive",
-            "quarantine",
-            "clean",
-            "fail",
-        ]
-    )
-    if set(task_callable_mapping.keys()) != expected_keys:
-        raise TypeError("task_callable_mapping argument does not contain correct keys")
 
     with DAG(
         dag_id=f"etl_{cdr_type}", schedule_interval=None, default_args=default_args
@@ -121,49 +112,49 @@ def construct_etl_dag(
 
         init = PythonOperator(
             task_id="init",
-            python_callable=task_callable_mapping["init"],
+            python_callable=init,
             provide_context=True,
         )
         extract = PythonOperator(
             task_id="extract",
-            python_callable=task_callable_mapping["extract"],
+            python_callable=extract,
             provide_context=True,
         )
         transform = PythonOperator(
             task_id="transform",
-            python_callable=task_callable_mapping["transform"],
+            python_callable=transform,
             provide_context=True,
         )
         load = PythonOperator(
             task_id="load",
-            python_callable=task_callable_mapping["load"],
+            python_callable=load,
             provide_context=True,
         )
         success_branch = BranchPythonOperator(
             task_id="success_branch",
-            python_callable=task_callable_mapping["success_branch"],
+            python_callable=success_branch,
             provide_context=True,
             trigger_rule="all_done",
         )
         archive = PythonOperator(
             task_id="archive",
-            python_callable=task_callable_mapping["archive"],
+            python_callable=archive,
             provide_context=True,
         )
         quarantine = PythonOperator(
             task_id="quarantine",
-            python_callable=task_callable_mapping["quarantine"],
+            python_callable=quarantine,
             provide_context=True,
         )
         clean = PythonOperator(
             task_id="clean",
-            python_callable=task_callable_mapping["clean"],
+            python_callable=clean,
             provide_context=True,
             trigger_rule="all_done",
         )
         fail = PythonOperator(
             task_id="fail",
-            python_callable=task_callable_mapping["fail"],
+            python_callable=fail,
             provide_context=True,
         )
 

--- a/flowetl/etl/etl/etl_utils.py
+++ b/flowetl/etl/etl/etl_utils.py
@@ -66,7 +66,7 @@ def construct_etl_dag(
     clean: Callable,
     fail: Callable,
     default_args: dict,
-    cdr_type: str
+    cdr_type: str,
 ) -> DAG:
     """
     This function returns an Airflow DAG object of the structure
@@ -111,24 +111,16 @@ def construct_etl_dag(
     ) as dag:
 
         init = PythonOperator(
-            task_id="init",
-            python_callable=init,
-            provide_context=True,
+            task_id="init", python_callable=init, provide_context=True
         )
         extract = PythonOperator(
-            task_id="extract",
-            python_callable=extract,
-            provide_context=True,
+            task_id="extract", python_callable=extract, provide_context=True
         )
         transform = PythonOperator(
-            task_id="transform",
-            python_callable=transform,
-            provide_context=True,
+            task_id="transform", python_callable=transform, provide_context=True
         )
         load = PythonOperator(
-            task_id="load",
-            python_callable=load,
-            provide_context=True,
+            task_id="load", python_callable=load, provide_context=True
         )
         success_branch = BranchPythonOperator(
             task_id="success_branch",
@@ -137,14 +129,10 @@ def construct_etl_dag(
             trigger_rule="all_done",
         )
         archive = PythonOperator(
-            task_id="archive",
-            python_callable=archive,
-            provide_context=True,
+            task_id="archive", python_callable=archive, provide_context=True
         )
         quarantine = PythonOperator(
-            task_id="quarantine",
-            python_callable=quarantine,
-            provide_context=True,
+            task_id="quarantine", python_callable=quarantine, provide_context=True
         )
         clean = PythonOperator(
             task_id="clean",
@@ -153,9 +141,7 @@ def construct_etl_dag(
             trigger_rule="all_done",
         )
         fail = PythonOperator(
-            task_id="fail",
-            python_callable=fail,
-            provide_context=True,
+            task_id="fail", python_callable=fail, provide_context=True
         )
 
         # Define upstream/downstream relationships between airflow tasks

--- a/flowetl/etl/tests/test_construct_etl_dag.py
+++ b/flowetl/etl/tests/test_construct_etl_dag.py
@@ -30,9 +30,7 @@ def test_construct_etl_dag_with_test_callables():
     cdr_type = "spaghetti"
 
     dag = construct_etl_dag(
-        task_callable_mapping=task_callable_mapping,
-        default_args=default_args,
-        cdr_type=cdr_type,
+        **task_callable_mapping, default_args=default_args, cdr_type=cdr_type
     )
 
     assert dag.dag_id == f"etl_{cdr_type}"
@@ -52,9 +50,7 @@ def test_construct_etl_dag_with_production_callables():
     cdr_type = "spaghetti"
 
     dag = construct_etl_dag(
-        task_callable_mapping=task_callable_mapping,
-        default_args=default_args,
-        cdr_type=cdr_type,
+        **task_callable_mapping, default_args=default_args, cdr_type=cdr_type
     )
 
     assert dag.dag_id == f"etl_{cdr_type}"
@@ -74,9 +70,7 @@ def test_construct_etl_dag_fails_with_no_start_date():
     # pylint: disable=unused-variable
     with pytest.raises(AirflowException):
         dag = construct_etl_dag(
-            task_callable_mapping=task_callable_mapping,
-            default_args=default_args,
-            cdr_type=cdr_type,
+            **task_callable_mapping, default_args=default_args, cdr_type=cdr_type
         )
 
 
@@ -90,9 +84,7 @@ def test_construct_etl_dag_with_no_owner_defaults_to_airflow():
     cdr_type = "spaghetti"
 
     dag = construct_etl_dag(
-        task_callable_mapping=task_callable_mapping,
-        default_args=default_args,
-        cdr_type=cdr_type,
+        **task_callable_mapping, default_args=default_args, cdr_type=cdr_type
     )
 
     assert dag.owner == "Airflow"
@@ -109,9 +101,7 @@ def test_construct_etl_dag_fails_with_bad_start_date():
     # pylint: disable=unused-variable
     with pytest.raises(ParserError):
         dag = construct_etl_dag(
-            task_callable_mapping=task_callable_mapping,
-            default_args=default_args,
-            cdr_type=cdr_type,
+            **task_callable_mapping, default_args=default_args, cdr_type=cdr_type
         )
 
 
@@ -127,7 +117,5 @@ def test_construct_etl_dag_fails_with_incorrect_mapping_keys():
     # pylint: disable=unused-variable
     with pytest.raises(TypeError):
         dag = construct_etl_dag(
-            task_callable_mapping=task_callable_mapping,
-            default_args=default_args,
-            cdr_type=cdr_type,
+            **task_callable_mapping, default_args=default_args, cdr_type=cdr_type
         )


### PR DESCRIPTION
Closes #948 

### I have:

- [X] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [ ] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This changes the `construct_etl_dag` method to take the task callable as required named arguments instead of a dict with "name" => callable mapping and requiring that all dict keys are present.