### PR TITLE
Tasks/946 remove file move ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The quick-start script now only pulls the docker images for the services that are actually started up. [#898](https://github.com/Flowminder/FlowKit/issues/898)
 - The quick-start script now uses the environment variable `GIT_REVISION` to control the version to be deployed.
+- The flowetl mounted directories `archive, dump, ingest, quarantine` were replaced with a single `files` directory and files are no longer moved. [#946](https://github.com/Flowminder/FlowKit/issues/946)
 
 ### Fixed
 

--- a/development_environment
+++ b/development_environment
@@ -136,10 +136,7 @@ FLOWETL_POSTGRES_DB=flowetl
 FLOWETL_POSTGRES_PORT=9001
 
 HOST_CONFIG_DIR=./flowetl/mounts/config
-HOST_DUMP_DIR=./flowetl/mounts/dump
-HOST_ARCHIVE_DIR=./flowetl/mounts/archive
-HOST_QUARANTINE_DIR=./flowetl/mounts/quarantine
-HOST_INGEST_DIR=./flowetl/mounts/ingest
+HOST_FILES_DIR=./flowetl/mounts/files
 
 # Worked examples
 WORKED_EXAMPLES_PORT=8888

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,10 +195,7 @@ services:
       - ${FLOWETL_PORT:?Must set FLOWETL_PORT env var}:8080
     volumes:
       - ${HOST_CONFIG_DIR:?Must set HOST_CONFIG_DIR env var}:/mounts/config:ro
-      - ${HOST_DUMP_DIR:?Must set HOST_DUMP_DIR env var}:/mounts/dump:rw
-      - ${HOST_ARCHIVE_DIR:?Must set HOST_ARCHIVE_DIR env var}:/mounts/archive:rw
-      - ${HOST_QUARANTINE_DIR:?Must set HOST_QUARANTINE_DIR env var}:/mounts/quarantine:rw
-      - ${HOST_INGEST_DIR:?Must set HOST_INGEST_DIR env var}:/mounts/ingest:rw
+      - ${HOST_FILES_DIR:?Must set HOST_FILES_DIR env var}:/mounts/files:rw
 
     environment:
       AIRFLOW__CORE__EXECUTOR: LocalExecutor

--- a/flowetl/etl/etl/dag_task_callable_mappings.py
+++ b/flowetl/etl/etl/dag_task_callable_mappings.py
@@ -51,10 +51,7 @@ TEST_ETL_TASK_CALLABLES = {
 
 # callables to be used in production
 PRODUCTION_ETL_TASK_CALLABLES = {
-    "init": partial(
-        record_ingestion_state__callable,
-        to_state="ingest",
-    ),
+    "init": partial(record_ingestion_state__callable, to_state="ingest"),
     "extract": partial(
         render_and_run_sql__callable,
         db_hook=db_hook,
@@ -75,14 +72,8 @@ PRODUCTION_ETL_TASK_CALLABLES = {
         fixed_sql=True,
     ),
     "success_branch": success_branch__callable,
-    "archive": partial(
-        record_ingestion_state__callable,
-        to_state="archive",
-    ),
-    "quarantine": partial(
-        record_ingestion_state__callable,
-        to_state="quarantine",
-    ),
+    "archive": partial(record_ingestion_state__callable, to_state="archive"),
+    "quarantine": partial(record_ingestion_state__callable, to_state="quarantine"),
     "clean": partial(
         render_and_run_sql__callable,
         db_hook=db_hook,
@@ -95,7 +86,5 @@ PRODUCTION_ETL_TASK_CALLABLES = {
 
 TEST_ETL_SENSOR_TASK_CALLABLE = dummy_trigger__callable
 PRODUCTION_ETL_SENSOR_TASK_CALLABLE = partial(
-    trigger__callable,
-    files_path=files_path,
-    cdr_type_config=config.get("etl", {}),
+    trigger__callable, files_path=files_path, cdr_type_config=config.get("etl", {})
 )

--- a/flowetl/etl/etl/etl_utils.py
+++ b/flowetl/etl/etl/etl_utils.py
@@ -223,15 +223,15 @@ class State(str, Enum):
     QUARANTINE = "quarantine"
 
 
-def find_files(*, dump_path: Path, ignore_filenames=["README.md"]) -> List[Path]:
+def find_files(*, files_path: Path, ignore_filenames=["README.md"]) -> List[Path]:
     """
     Returns a list of Path objects for all files
-    found in the dump location.
+    found in the files location.
 
     Parameters
     ----------
-    dump_path : Path
-        The location of the dump path
+    files_path : Path
+        The location of the files path
 
     ignore_filenames : Path
         List of filenames to ignore
@@ -241,7 +241,7 @@ def find_files(*, dump_path: Path, ignore_filenames=["README.md"]) -> List[Path]
     List[Path]
         List of files found
     """
-    files = filter(lambda file: file.name not in ignore_filenames, dump_path.glob("*"))
+    files = filter(lambda file: file.name not in ignore_filenames, files_path.glob("*"))
     return list(files)
 
 

--- a/flowetl/etl/etl/production_task_callables.py
+++ b/flowetl/etl/etl/production_task_callables.py
@@ -87,9 +87,7 @@ def render_and_run_sql__callable(
 
 
 # pylint: disable=unused-argument
-def record_ingestion_state__callable(
-    *, dag_run: DagRun, to_state: str, **kwargs
-):
+def record_ingestion_state__callable(*, dag_run: DagRun, to_state: str, **kwargs):
     """
     Function to deal with recording the state of the ingestion. The actual
     change to the DB to record new state is accomplished in the

--- a/flowetl/etl/etl/production_task_callables.py
+++ b/flowetl/etl/etl/production_task_callables.py
@@ -87,41 +87,23 @@ def render_and_run_sql__callable(
 
 
 # pylint: disable=unused-argument
-def move_file_and_record_ingestion_state__callable(
-    *, dag_run: DagRun, mount_paths: dict, from_dir: str, to_dir: str, **kwargs
+def record_ingestion_state__callable(
+    *, dag_run: DagRun, to_state: str, **kwargs
 ):
     """
-    Function to deal with moving files between various mount directories along
-    with recording the state of the ingestion. Since the directory structure
-    reflects the state of ingestion we make use of the to_dir location to specify
-    the next state of the file being ingested. The actual change to the DB to record
-    new state is accomplished in the record_etl_state function.
+    Function to deal with recording the state of the ingestion. The actual
+    change to the DB to record new state is accomplished in the
+    ETLRecord.set_state function.
 
     Parameters
     ----------
     dag_run : DagRun
         Passed as part of the Dag context - contains the config.
-    mount_paths : dict
-        A dictionary that stores the locations of each of the various
-        mount directories
-    from_dir : str
-        The location from which the file should be moved
-    to_dir : str
-        The location to which the file is being moved and the resulting state
-        of the file
+    to_state : str
+        The the resulting state of the file
     """
-    from_path = mount_paths[from_dir]
-    to_path = mount_paths[to_dir]
-
-    file_name = dag_run.conf["file_name"]
     cdr_type = dag_run.conf["cdr_type"]
     cdr_date = dag_run.conf["cdr_date"]
-
-    file_to_move = from_path / file_name
-    shutil.copy(str(file_to_move), str(to_path))
-    file_to_move.unlink()
-
-    to_state = to_path.name
 
     session = get_session()
     ETLRecord.set_state(
@@ -152,23 +134,23 @@ def success_branch__callable(*, dag_run: DagRun, **kwargs):
 
 
 def trigger__callable(
-    *, dag_run: DagRun, dump_path: Path, cdr_type_config: dict, **kwargs
+    *, dag_run: DagRun, files_path: Path, cdr_type_config: dict, **kwargs
 ):
     """
-    Function that determines which files in dump should be processed
+    Function that determines which files in files/ should be processed
     and triggers the correct ETL dag with config based on filename.
 
     Parameters
     ----------
     dag_run : DagRun
         Passed as part of the Dag context - contains the config.
-    dump_path : Path
-        Location of dump directory
+    files_path : Path
+        Location of files directory
     cdr_type_config : dict
         ETL config for each cdr type
     """
 
-    found_files = find_files(dump_path=dump_path)
+    found_files = find_files(files_path=files_path)
     logger.info(found_files)
 
     # remove files that either do not match a pattern

--- a/flowetl/etl/tests/test_config.py
+++ b/flowetl/etl/tests/test_config.py
@@ -88,7 +88,7 @@ def test_find_files_default_filter(tmpdir):
 
     tmpdir_path_obj = Path(tmpdir)
 
-    files = find_files(dump_path=tmpdir_path_obj)
+    files = find_files(files_path=tmpdir_path_obj)
 
     assert set([file.name for file in files]) == set(["A.txt", "B.txt"])
 
@@ -104,7 +104,7 @@ def test_find_files_non_default_filter(tmpdir):
 
     tmpdir_path_obj = Path(tmpdir)
 
-    files = find_files(dump_path=tmpdir_path_obj, ignore_filenames=["B.txt", "A.txt"])
+    files = find_files(files_path=tmpdir_path_obj, ignore_filenames=["B.txt", "A.txt"])
 
     assert set([file.name for file in files]) == set(["README.md"])
 

--- a/flowetl/etl/tests/test_trigger__callable.py
+++ b/flowetl/etl/tests/test_trigger__callable.py
@@ -16,15 +16,15 @@ from etl.production_task_callables import trigger__callable
 
 def test_trigger__callable_bad_file_filtered(tmpdir, session, monkeypatch):
     """
-    Test that the trigger callable picks up files in dump and suitably filters
+    Test that the trigger callable picks up files in files and suitably filters
     them. In this case we have one unseen file and one file that matches no
     pattern. We expect a single call of the trigger_dag_mock for the unseen file.
     """
-    dump = tmpdir.mkdir("dump")
+    files = tmpdir.mkdir("files")
 
-    file1 = dump.join("SMS_20160101.csv.gz")
+    file1 = files.join("SMS_20160101.csv.gz")
     file1.write("blah")
-    file2 = dump.join("bad_file.bad")
+    file2 = files.join("bad_file.bad")
     file2.write("blah")
 
     cdr_type_config = config["etl"]
@@ -40,7 +40,7 @@ def test_trigger__callable_bad_file_filtered(tmpdir, session, monkeypatch):
     monkeypatch.setattr("etl.production_task_callables.trigger_dag", trigger_dag_mock)
 
     trigger__callable(
-        dag_run=fake_dag_run, cdr_type_config=cdr_type_config, dump_path=Path(dump)
+        dag_run=fake_dag_run, cdr_type_config=cdr_type_config, files_path=Path(files)
     )
 
     assert trigger_dag_mock.call_count == 1
@@ -68,13 +68,13 @@ def test_trigger__callable_bad_file_filtered(tmpdir, session, monkeypatch):
 
 def test_trigger__callable_quarantined_file_not_filtered(tmpdir, session, monkeypatch):
     """
-    Test that the trigger callable picks up files in dump and suitably filters
+    Test that the trigger callable picks up files in files and suitably filters
     them. In this case we have one previously seen and quarantined file.
     We expect a single call of the trigger_dag_mock for the quarantined file.
     """
-    dump = tmpdir.mkdir("dump")
+    files = tmpdir.mkdir("files")
 
-    file1 = dump.join("SMS_20160101.csv.gz")
+    file1 = files.join("SMS_20160101.csv.gz")
     file1.write("blah")
 
     # add a some etl records
@@ -104,7 +104,7 @@ def test_trigger__callable_quarantined_file_not_filtered(tmpdir, session, monkey
     monkeypatch.setattr("etl.production_task_callables.trigger_dag", trigger_dag_mock)
 
     trigger__callable(
-        dag_run=fake_dag_run, cdr_type_config=cdr_type_config, dump_path=Path(dump)
+        dag_run=fake_dag_run, cdr_type_config=cdr_type_config, files_path=Path(files)
     )
 
     assert trigger_dag_mock.call_count == 1
@@ -132,15 +132,15 @@ def test_trigger__callable_quarantined_file_not_filtered(tmpdir, session, monkey
 
 def test_trigger__callable_archive_file_filtered(tmpdir, session, monkeypatch):
     """
-    Test that the trigger callable picks up files in dump and suitably filters
+    Test that the trigger callable picks up files in files and suitably filters
     them. In this case we have one previously seen file and one never seen file.
     We expect a single call of the trigger_dag_mock for the unseen file.
     """
-    dump = tmpdir.mkdir("dump")
+    files = tmpdir.mkdir("files")
 
-    file1 = dump.join("SMS_20160101.csv.gz")
+    file1 = files.join("SMS_20160101.csv.gz")
     file1.write("blah")
-    file2 = dump.join("SMS_20160102.csv.gz")
+    file2 = files.join("SMS_20160102.csv.gz")
     file2.write("blah")
 
     # add a some etl records
@@ -170,7 +170,7 @@ def test_trigger__callable_archive_file_filtered(tmpdir, session, monkeypatch):
     monkeypatch.setattr("etl.production_task_callables.trigger_dag", trigger_dag_mock)
 
     trigger__callable(
-        dag_run=fake_dag_run, cdr_type_config=cdr_type_config, dump_path=Path(dump)
+        dag_run=fake_dag_run, cdr_type_config=cdr_type_config, files_path=Path(files)
     )
 
     assert trigger_dag_mock.call_count == 1
@@ -198,14 +198,14 @@ def test_trigger__callable_archive_file_filtered(tmpdir, session, monkeypatch):
 
 def test_trigger__callable_multiple_triggers(tmpdir, session, monkeypatch):
     """
-    Test that the trigger callable picks up files in dump and is able to trigger
+    Test that the trigger callable picks up files in files and is able to trigger
     multiple etl dag runs.
     """
-    dump = tmpdir.mkdir("dump")
+    files = tmpdir.mkdir("files")
 
-    file1 = dump.join("SMS_20160101.csv.gz")
+    file1 = files.join("SMS_20160101.csv.gz")
     file1.write("blah")
-    file2 = dump.join("CALLS_20160102.csv.gz")
+    file2 = files.join("CALLS_20160102.csv.gz")
     file2.write("blah")
 
     cdr_type_config = config["etl"]
@@ -221,7 +221,7 @@ def test_trigger__callable_multiple_triggers(tmpdir, session, monkeypatch):
     monkeypatch.setattr("etl.production_task_callables.trigger_dag", trigger_dag_mock)
 
     trigger__callable(
-        dag_run=fake_dag_run, cdr_type_config=cdr_type_config, dump_path=Path(dump)
+        dag_run=fake_dag_run, cdr_type_config=cdr_type_config, files_path=Path(files)
     )
 
     assert trigger_dag_mock.call_count == 2

--- a/flowetl/mounts/archive/README.md
+++ b/flowetl/mounts/archive/README.md
@@ -1,1 +1,0 @@
-# Archive location

--- a/flowetl/mounts/dump/README.md
+++ b/flowetl/mounts/dump/README.md
@@ -1,1 +1,0 @@
-# Dump location

--- a/flowetl/mounts/files/README.md
+++ b/flowetl/mounts/files/README.md
@@ -1,0 +1,1 @@
+# Files location

--- a/flowetl/mounts/ingest/README.md
+++ b/flowetl/mounts/ingest/README.md
@@ -1,1 +1,0 @@
-# Ingest location

--- a/flowetl/mounts/quarantine/README.md
+++ b/flowetl/mounts/quarantine/README.md
@@ -1,1 +1,0 @@
-# Quarantine location

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -254,7 +254,7 @@ def flowetl_container(
     """
     user = f"{os.getuid()}:{os.getgid()}"
     container = docker_client.containers.run(
-        f"flowminder/flowetl:testing12344321",
+        f"flowminder/flowetl:{container_tag}",
         environment=container_env["flowetl"],
         name="flowetl",
         network="testing",

--- a/flowetl/tests/integration/conftest.py
+++ b/flowetl/tests/integration/conftest.py
@@ -12,7 +12,6 @@ import shutil
 import structlog
 import pytest
 
-from itertools import chain
 from pathlib import Path
 from time import sleep
 from subprocess import DEVNULL, Popen
@@ -157,27 +156,14 @@ def mounts(postgres_data_dir_for_tests, flowetl_mounts_dir):
     Various mount objects needed by containers
     """
     config_mount = Mount("/mounts/config", f"{flowetl_mounts_dir}/config", type="bind")
-    archive_mount = Mount(
-        "/mounts/archive", f"{flowetl_mounts_dir}/archive", type="bind"
-    )
-    dump_mount = Mount("/mounts/dump", f"{flowetl_mounts_dir}/dump", type="bind")
-    ingest_mount = Mount("/mounts/ingest", f"{flowetl_mounts_dir}/ingest", type="bind")
-    quarantine_mount = Mount(
-        "/mounts/quarantine", f"{flowetl_mounts_dir}/quarantine", type="bind"
-    )
-    flowetl_mounts = [
-        config_mount,
-        archive_mount,
-        dump_mount,
-        ingest_mount,
-        quarantine_mount,
-    ]
+    files_mount = Mount("/mounts/files", f"{flowetl_mounts_dir}/files", type="bind")
+    flowetl_mounts = [config_mount, files_mount]
 
     data_mount = Mount(
         "/var/lib/postgresql/data", postgres_data_dir_for_tests, type="bind"
     )
-    ingest_mount = Mount("/ingest", f"{flowetl_mounts_dir}/ingest", type="bind")
-    flowdb_mounts = [data_mount, ingest_mount]
+    files_mount = Mount("/files", f"{flowetl_mounts_dir}/files", type="bind")
+    flowdb_mounts = [data_mount, files_mount]
 
     return {"flowetl": flowetl_mounts, "flowdb": flowdb_mounts}
 
@@ -268,7 +254,7 @@ def flowetl_container(
     """
     user = f"{os.getuid()}:{os.getgid()}"
     container = docker_client.containers.run(
-        f"flowminder/flowetl:{container_tag}",
+        f"flowminder/flowetl:testing12344321",
         environment=container_env["flowetl"],
         name="flowetl",
         network="testing",
@@ -304,27 +290,21 @@ def trigger_dags():
 
 
 @pytest.fixture(scope="function")
-def write_files_to_dump(flowetl_mounts_dir):
+def write_files_to_files(flowetl_mounts_dir):
     """
     Returns a function that allows for writing a list
-    of empty files to the dump location. Also cleans
-    up dump, archive and quarantine.
+    of empty files to the files location. Also cleans
+    up the files location.
     """
-    dump_dir = f"{flowetl_mounts_dir}/dump"
-    archive_dir = f"{flowetl_mounts_dir}/archive"
-    quarantine_dir = f"{flowetl_mounts_dir}/quarantine"
+    files_dir = f"{flowetl_mounts_dir}/files"
 
-    def write_files_to_dump_function(*, file_names):
+    def write_files_to_files_function(*, file_names):
         for file_name in file_names:
-            Path(f"{dump_dir}/{file_name}").touch()
+            Path(f"{files_dir}/{file_name}").touch()
 
-    yield write_files_to_dump_function
+    yield write_files_to_files_function
 
-    files_to_remove = chain(
-        Path(dump_dir).glob("*"),
-        Path(archive_dir).glob("*"),
-        Path(quarantine_dir).glob("*"),
-    )
+    files_to_remove = Path(files_dir).glob("*")
     files_to_remove = filter(lambda file: file.name != "README.md", files_to_remove)
 
     [file.unlink() for file in files_to_remove]

--- a/flowetl/tests/integration/test_full_pipeline.py
+++ b/flowetl/tests/integration/test_full_pipeline.py
@@ -8,7 +8,7 @@ from etl.model import ETLRecord
 
 def test_single_file_previously_quarantined(
     flowetl_container,
-    write_files_to_dump,
+    write_files_to_files,
     trigger_dags,
     wait_for_completion,
     flowetl_db_session,
@@ -18,7 +18,7 @@ def test_single_file_previously_quarantined(
     """
     Test for full pipeline. We want to test the following things;
 
-    1. Do files in the dump location get picked up?
+    1. Do files in the files location get picked up?
     2. Do files that do not match a configuration pattern get ignored?
     3. Do files (cdr_type, cdr_date pairs) that have a state of archive
     in etl.etl_records get ignored?
@@ -29,7 +29,7 @@ def test_single_file_previously_quarantined(
     6. Do child tables get created under the associated parent table in
     the events schema?
     """
-    write_files_to_dump(
+    write_files_to_files(
         file_names=[
             "CALLS_20160101.csv.gz",
             "CALLS_20160102.csv.gz",
@@ -76,27 +76,18 @@ def test_single_file_previously_quarantined(
 
     # make sure files are where they should be
 
-    dump_files = ["CALLS_20160101.csv.gz", "bad_file.bad"]  # should have been ignored
-    archive_files = [
+    all_files = [
+        "CALLS_20160101.csv.gz",
+        "bad_file.bad",
         "CALLS_20160102.csv.gz",
         "SMS_20160101.csv.gz",
         "MDS_20160101.csv.gz",
         "TOPUPS_20160101.csv.gz",
-    ]  # ingested so now in archive
+    ]  # all files
 
-    dump = [file.name for file in Path(f"{os.getcwd()}/mounts/dump").glob("*")]
-    archive = [file.name for file in Path(f"{os.getcwd()}/mounts/archive").glob("*")]
-    quarantine = [
-        file.name for file in Path(f"{os.getcwd()}/mounts/quarantine").glob("*")
-    ]
-    ingest = [file.name for file in Path(f"{os.getcwd()}/mounts/ingest").glob("*")]
+    files = [file.name for file in Path(f"{os.getcwd()}/mounts/files").glob("*")]
 
-    assert set(dump_files) == (set(dump) - set(["README.md"]))
-    assert set(archive_files) == (set(archive) - set(["README.md"]))
-
-    # quarantine and ingest should be empty
-    assert set() == (set(quarantine) - set(["README.md"]))
-    assert set() == (set(ingest) - set(["README.md"]))
+    assert set(all_files) == (set(files) - set(["README.md"]))
 
     # make sure tables expected exist in flowdb
     connection, _ = flowdb_connection


### PR DESCRIPTION
Closes #946
### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [ ] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This removes the `archive, dump, ingest, quarantine` directories, adds a single `files` directory instead and removes the file moving logic - the state is now solely tracked in the ETL records.