### PR TITLE
Fix frontend tests

### DIFF
--- a/flowauth/frontend/cypress/integration/add_new_token.js
+++ b/flowauth/frontend/cypress/integration/add_new_token.js
@@ -58,15 +58,12 @@ describe("Token generation", function() {
 
   it("API permissions sub-level checkboxes checked", function() {
     cy.get("#new").click();
-    cy.get("#api-exp").click();
     //unchecked permission top level checkbox
-    cy.get("#permissions").click({ force: true });
-    cy.get("#permission")
-      .first()
-      .should("not.be.checked");
-    //checking permission top level checkbox
-    cy.get("#permissions").click({ force: true });
-
+    cy.get("#permissions")
+      .click()
+      //checking permission top level checkbox
+      .click();
+    cy.get("#api-exp").click();
     //checking first sub-level permission checkbox
     cy.get("#permission")
       .first()
@@ -139,13 +136,11 @@ describe("Token generation", function() {
   it("Aggregation unit sub-level checkboxes checked", function() {
     cy.get("#new").click();
     //unchecked aggregation unit top-level checkbox
-    cy.get("#units").click();
+    cy.get("#units")
+      .click()
+      //check aggregation unit top-level checkbox
+      .click();
     cy.get("#unit-exp").click();
-    cy.get("#unit")
-      .first()
-      .should("not.be.checked");
-    //check aggregation unit top-level checkbox
-    cy.get("#units").click({ force: true });
     cy.get("#unit")
       .first()
       .should("be.checked");

--- a/flowauth/frontend/cypress/integration/add_new_token.js
+++ b/flowauth/frontend/cypress/integration/add_new_token.js
@@ -62,7 +62,6 @@ describe("Token generation", function() {
     cy.get("#permissions")
       .click()
       //checking permission top level checkbox
-      .get("#permissions")
       .click();
     cy.get("#api-exp").click();
     //checking first sub-level permission checkbox
@@ -140,7 +139,6 @@ describe("Token generation", function() {
     cy.get("#units")
       .click()
       //check aggregation unit top-level checkbox
-      .get("#units")
       .click();
     cy.get("#unit-exp").click();
     cy.get("#unit")

--- a/flowauth/frontend/cypress/integration/add_new_token.js
+++ b/flowauth/frontend/cypress/integration/add_new_token.js
@@ -58,12 +58,15 @@ describe("Token generation", function() {
 
   it("API permissions sub-level checkboxes checked", function() {
     cy.get("#new").click();
-    //unchecked permission top level checkbox
-    cy.get("#permissions")
-      .click()
-      //checking permission top level checkbox
-      .click();
     cy.get("#api-exp").click();
+    //unchecked permission top level checkbox
+    cy.get("#permissions").click({ force: true });
+    cy.get("#permission")
+      .first()
+      .should("not.be.checked");
+    //checking permission top level checkbox
+    cy.get("#permissions").click({ force: true });
+
     //checking first sub-level permission checkbox
     cy.get("#permission")
       .first()
@@ -136,11 +139,13 @@ describe("Token generation", function() {
   it("Aggregation unit sub-level checkboxes checked", function() {
     cy.get("#new").click();
     //unchecked aggregation unit top-level checkbox
-    cy.get("#units")
-      .click()
-      //check aggregation unit top-level checkbox
-      .click();
+    cy.get("#units").click();
     cy.get("#unit-exp").click();
+    cy.get("#unit")
+      .first()
+      .should("not.be.checked");
+    //check aggregation unit top-level checkbox
+    cy.get("#units").click({ force: true });
     cy.get("#unit")
       .first()
       .should("be.checked");

--- a/flowauth/frontend/cypress/integration/add_new_token.js
+++ b/flowauth/frontend/cypress/integration/add_new_token.js
@@ -59,9 +59,11 @@ describe("Token generation", function() {
   it("API permissions sub-level checkboxes checked", function() {
     cy.get("#new").click();
     //unchecked permission top level checkbox
-    cy.get("#permissions").click();
-    //checking permission top level checkbox
-    cy.get("#permissions").click();
+    cy.get("#permissions")
+      .click()
+      //checking permission top level checkbox
+      .get("#permissions")
+      .click();
     cy.get("#api-exp").click();
     //checking first sub-level permission checkbox
     cy.get("#permission")
@@ -135,9 +137,11 @@ describe("Token generation", function() {
   it("Aggregation unit sub-level checkboxes checked", function() {
     cy.get("#new").click();
     //unchecked aggregation unit top-level checkbox
-    cy.get("#units").click();
-    //check aggregation unit top-level checkbox
-    cy.get("#units").click();
+    cy.get("#units")
+      .click()
+      //check aggregation unit top-level checkbox
+      .get("#units")
+      .click();
     cy.get("#unit-exp").click();
     cy.get("#unit")
       .first()

--- a/flowauth/frontend/cypress/support/commands.js
+++ b/flowauth/frontend/cypress/support/commands.js
@@ -30,7 +30,7 @@ function getCookieValue(a) {
 }
 
 Cypress.Commands.add("login", () =>
-  cy.request("POST", "/signin", {
+  cy.goto("/").request("POST", "/signin", {
     username: "TEST_USER",
     password: "DUMMY_PASSWORD"
   })

--- a/flowauth/frontend/src/TokenDetails.js
+++ b/flowauth/frontend/src/TokenDetails.js
@@ -134,8 +134,13 @@ class TokenDetails extends React.Component {
     const toCheck = event.target.checked;
     event.stopPropagation();
     const { uiReady } = this.state;
+    this.setState({
+      isPermissionChecked: toCheck,
+      permissionIndeterminate: false,
+      pageError: false,
+      errors: ""
+    });
     await uiReady; // Wait to make sure checkboxes exist
-    this.setState({ pageError: false, errors: "" });
     const { rights } = this.state;
 
     for (const keys in rights) {
@@ -144,14 +149,17 @@ class TokenDetails extends React.Component {
       }
     }
     this.setState({
-      rights: rights,
-      isPermissionChecked: toCheck,
-      permissionIndeterminate: false
+      rights: rights
     });
   };
   handleAggregationCheckbox = async event => {
     const toCheck = event.target.checked;
-    this.setState({ pageError: false, errors: "" });
+    this.setState({
+      pageError: false,
+      errors: "",
+      isAggregationChecked: toCheck,
+      aggregateIndeterminate: false
+    });
     event.stopPropagation();
     const { uiReady } = this.state;
     await uiReady; // Wait to make sure checkboxes exist
@@ -168,9 +176,7 @@ class TokenDetails extends React.Component {
       }
     }
     this.setState({
-      rights: rights,
-      isAggregationChecked: toCheck,
-      aggregateIndeterminate: false
+      rights: rights
     });
   };
   handleNameChange = event => {


### PR DESCRIPTION
Closes #965

### Description

Hopefully resolves the sporadic Flowauth test fails:

#### Sometimes getting stuck at the login screen

This seems to happen when a test finishes, but not all requests started by the final react page have completed or been set running. Cypress can sometimes clear the cookies, then a request (with no cookie) is triggered by react - that request returns with a 401 and instruction to clear cookies. In the time that request takes to come back with a 401, Cypress has started the next test and called the login command and successfully logged in. End result is that sometimes cypress can get logged out before the request to `/is_signed_in` is sent and hence you get stuck.

I've fixed this by making the login command begin by reloading the site, so any pending network requests get squashed and no cookie-less requests are sent.

#### Occasional fails in the token details tests

These boil down to cypress' super-human click speed. The sequence of interactions is meant to go - click the top level box (all the child boxes should now be unchecked), click the top level box again (all the child boxes should also be checked).

What can happen is that cypress clicks the top level box twice without waiting for the child boxes to change, and because the state of the top level box happens at the same time as the children, both click events are unchecks, when the second should be a check.

I've made the top level box's state happen immediately on the event getting handled, which _should_ mean this is resolved.