### PR TITLE
More informative error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Flowmachine now returns more informative error messages when query parameter validation fails. [#1055](https://github.com/Flowminder/FlowKit/issues/1055)
+
 ### Fixed
 
 

--- a/flowclient/flowclient/client.py
+++ b/flowclient/flowclient/client.py
@@ -181,7 +181,10 @@ class Connection:
             try:
                 error_msg = response.json()["msg"]
                 try:
-                    payload_info = f" Payload: {response.json()['payload']}"
+                    returned_payload = response.json()["payload"]
+                    payload_info = (
+                        "" if not returned_payload else f" Payload: {returned_payload}"
+                    )
                 except KeyError:
                     payload_info = ""
             except ValueError:

--- a/flowclient/tests/unit/test_post_json.py
+++ b/flowclient/tests/unit/test_post_json.py
@@ -70,7 +70,7 @@ def test_generic_status_code_error(session_mock, token):
     connection = flowclient.connect(url="DUMMY_API", token=token)
     with pytest.raises(
         FlowclientConnectionError,
-        match="Something went wrong. API returned with status code 418. Error message: 'I AM A TEAPOT'. Payload: {}",
+        match="Something went wrong. API returned with status code 418. Error message: 'I AM A TEAPOT'.",
     ):
         connection.post_json(route="DUMMY_ROUTE", data={})
 

--- a/flowmachine/flowmachine/core/server/action_handlers.py
+++ b/flowmachine/flowmachine/core/server/action_handlers.py
@@ -15,6 +15,8 @@
 #
 
 import functools
+import json
+import textwrap
 from typing import Callable, List, Optional, Union
 
 from apispec import APISpec
@@ -103,11 +105,19 @@ def action_handler__run_query(**action_params: dict) -> ZMQReply:
         # The dictionary of marshmallow errors can contain integers as keys,
         # which will raise an error when converting to JSON (where the keys
         # must be strings). Therefore we transform the keys to strings here.
-        error_msg = "Parameter validation failed."
         validation_error_messages = convert_dict_keys_to_strings(exc.messages)
-        return ZMQReply(
-            status="error", msg=error_msg, payload=validation_error_messages
+        action_params_as_text = textwrap.indent(
+            json.dumps(action_params, indent=2), "   "
         )
+        validation_errors_as_text = textwrap.indent(
+            json.dumps(validation_error_messages, indent=2), "   "
+        )
+        error_msg = (
+            "Parameter validation failed.\n\n"
+            f"The action parameters were:\n{action_params_as_text}.\n\n"
+            f"Validation error messages:\n{validation_errors_as_text}.\n\n"
+        )
+        return ZMQReply(status="error", msg=error_msg, payload=None)
 
     q_info_lookup = QueryInfoLookup(Query.redis)
     try:

--- a/flowmachine/flowmachine/core/server/action_handlers.py
+++ b/flowmachine/flowmachine/core/server/action_handlers.py
@@ -117,7 +117,8 @@ def action_handler__run_query(**action_params: dict) -> ZMQReply:
             f"The action parameters were:\n{action_params_as_text}.\n\n"
             f"Validation error messages:\n{validation_errors_as_text}.\n\n"
         )
-        return ZMQReply(status="error", msg=error_msg, payload=None)
+        payload = {"validation_error_messages": validation_error_messages}
+        return ZMQReply(status="error", msg=error_msg, payload=payload)
 
     q_info_lookup = QueryInfoLookup(Query.redis)
     try:

--- a/flowmachine/flowmachine/core/server/query_schemas/aggregation_unit.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/aggregation_unit.py
@@ -33,6 +33,6 @@ def get_spatial_unit_obj(aggregation_unit_string) -> GeomSpatialUnit:
         spatial_unit_args = {"spatial_unit_type": "admin", "level": level}
     else:
         raise NotImplementedError(
-            f"The helper function `get_spatial_unit_obj` does not yet support aggregation units of type '{aggregation_unit_string}'."
+            f"The helper function `get_spatial_unit_obj` does not support aggregation units of type '{aggregation_unit_string}'."
         )
     return make_spatial_unit(**spatial_unit_args)

--- a/flowmachine/flowmachine/core/server/query_schemas/aggregation_unit.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/aggregation_unit.py
@@ -31,4 +31,8 @@ def get_spatial_unit_obj(aggregation_unit_string) -> GeomSpatialUnit:
     if "admin" in aggregation_unit_string:
         level = int(aggregation_unit_string[-1])
         spatial_unit_args = {"spatial_unit_type": "admin", "level": level}
+    else:
+        raise NotImplementedError(
+            f"The helper function `get_spatial_unit_obj` does not yet support aggregation units of type '{aggregation_unit_string}'."
+        )
     return make_spatial_unit(**spatial_unit_args)

--- a/flowmachine/tests/server/test_aggregation_unit.py
+++ b/flowmachine/tests/server/test_aggregation_unit.py
@@ -1,0 +1,14 @@
+import pytest
+from flowmachine.core.server.query_schemas.aggregation_unit import get_spatial_unit_obj
+
+
+# Note: most of the code in aggregation_unit.py is tested
+# via integration tests. This file only tests the "bad path"
+# in the helper function get_spatial_unit_obj() because it
+# is not hit by any of the integration tests.
+
+
+def test_get_spatial_unit_obj():
+    expected_error_msg = "The helper function `get_spatial_unit_obj` does not support aggregation units of type 'invalid_spatial_unit'"
+    with pytest.raises(NotImplementedError, match=expected_error_msg):
+        get_spatial_unit_obj("invalid_spatial_unit")

--- a/integration_tests/tests/flowmachine_server_tests/test_action_run_query.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_action_run_query.py
@@ -182,7 +182,7 @@ async def test_run_query_with_wrong_parameters(
     # expected_reason = f"Error when constructing query of kind daily_location with parameters {params}: '{expected_error_msg}'"
     # expected_reason = "Message contains unexpected key(s): ['query_kind'], 'data': {}"
     assert "error" == reply["status"]
-    assert expected_error_messages == reply["payload"]
+    assert expected_error_messages == reply["payload"]["validation_error_messages"]
 
 
 @pytest.mark.skip(reason="Cannot currently test this because the sender hangs")


### PR DESCRIPTION
Closes #1055 

### I have:

- [X] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [X] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This PR improves the error messages returned from flowmachine when query parameter validation fails. The message now includes the parameters which failed to validate, and prints them in a more readable way on the command line.

It also adds an explicit `else` clause in a helper function, to avoid random errors caused by the fact that `spatial_unit_args` is potentially undefined.

Previous error message:
```
flowclient.client.FlowclientConnectionError: Something went wrong. API returned with status code 400. Error message: 'Parameter validation failed.'. Payload: {'0': {'locations': {'0': {'aggregation_unit': ['Must be one of: admin0, admin1, admin2, admin3.']}}, 'metric': {'0': {'reference_location': {'0': {'aggregation_unit': ['Must be one of: admin0, admin1, admin2, admin3.']}}}}}}
```

New error message:
```
E           flowclient.client.FlowclientConnectionError: Something went wrong. API returned with status code 400. Error message: 'Parameter validation failed.
E           
E           The action parameters were:
E              {
E                "query_kind": "joined_spatial_aggregate",
E                "method": "avg",
E                "locations": {
E                  "query_kind": "daily_location",
E                  "date": "2016-01-01",
E                  "aggregation_unit": "lon-lat",
E                  "method": "last",
E                  "subscriber_subset": null
E                },
E                "metric": {
E                  "query_kind": "displacement",
E                  "start": "2016-01-01",
E                  "stop": "2016-01-02",
E                  "value": "avg",
E                  "reference_location": {
E                    "query_kind": "daily_location",
E                    "date": "2016-01-01",
E                    "aggregation_unit": "lon-lat",
E                    "method": "last",
E                    "subscriber_subset": null
E                  },
E                  "subscriber_subset": null
E                }
E              }.
E           
E           Validation error messages:
E              {
E                "0": {
E                  "metric": {
E                    "0": {
E                      "reference_location": {
E                        "0": {
E                          "aggregation_unit": [
E                            "Must be one of: admin0, admin1, admin2, admin3."
E                          ]
E                        }
E                      }
E                    }
E                  },
E                  "locations": {
E                    "0": {
E                      "aggregation_unit": [
E                        "Must be one of: admin0, admin1, admin2, admin3."
E                      ]
E                    }
E                  }
E                }
E              }.
E           
E           '.

../flowclient/flowclient/client.py:196: FlowclientConnectionError
```