### PR TITLE
Allow specifying only a subset of CDR sections in FlowETL config

### DIFF
--- a/flowetl/etl/etl/config_parser.py
+++ b/flowetl/etl/etl/config_parser.py
@@ -40,7 +40,7 @@ def validate_config(*, global_config_dict: dict) -> Exception:
     if set(etl_keys).issubset(CDRType):
         exceptions.append(
             ValueError(
-                f"etl sections present in config.yml must be a subset of {[x.value for x in CDRType]}"
+                f"Etl sections present in config.yml must be a subset of {[x.value for x in CDRType]}. Got: {set(etl_keys)}"
             )
         )
 

--- a/flowetl/etl/etl/config_parser.py
+++ b/flowetl/etl/etl/config_parser.py
@@ -37,7 +37,7 @@ def validate_config(*, global_config_dict: dict) -> Exception:
         )
 
     etl_keys = global_config_dict.get("etl", {}).keys()
-    if set(etl_keys).issubset(CDRType):
+    if not set(etl_keys).issubset(CDRType):
         exceptions.append(
             ValueError(
                 f"Etl sections present in config.yml must be a subset of {[x.value for x in CDRType]}. Got: {set(etl_keys)}"

--- a/flowetl/etl/etl/config_parser.py
+++ b/flowetl/etl/etl/config_parser.py
@@ -36,6 +36,14 @@ def validate_config(*, global_config_dict: dict) -> Exception:
             ValueError("default_args must be a toplevel key in the config file")
         )
 
+    etl_keys = global_config_dict.get("etl", {}).keys()
+    if set(etl_keys).issubset(CDRType):
+        exceptions.append(
+            ValueError(
+                f"etl sections present in config.yml must be a subset of {[x.value for x in CDRType]}"
+            )
+        )
+
     for key, value in global_config_dict.get("etl", {}).items():
         if set(value.keys()) != set(["source", "concurrency"]):
             exc_msg = (

--- a/flowetl/etl/etl/config_parser.py
+++ b/flowetl/etl/etl/config_parser.py
@@ -36,12 +36,6 @@ def validate_config(*, global_config_dict: dict) -> Exception:
             ValueError("default_args must be a toplevel key in the config file")
         )
 
-    etl_keys = global_config_dict.get("etl", {}).keys()
-    if etl_keys != CDRType._value2member_map_.keys():
-        exceptions.append(
-            ValueError(f"etl section must contain subsections for {list(CDRType)}")
-        )
-
     for key, value in global_config_dict.get("etl", {}).items():
         if set(value.keys()) != set(["source", "concurrency"]):
             exc_msg = (

--- a/flowetl/etl/tests/test_config.py
+++ b/flowetl/etl/tests/test_config.py
@@ -40,7 +40,7 @@ def test_config_validation_fails_no_etl_section(sample_config_dict):
     with pytest.raises(ValueError) as raised_exception:
         validate_config(global_config_dict=bad_config)
 
-    assert len(raised_exception.value.args[0]) == 2
+    assert len(raised_exception.value.args[0]) == 1
 
 
 def test_config_validation_fails_no_default_args_section(sample_config_dict):


### PR DESCRIPTION
Closes #1062 

### I have:

- [X] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md)