### PR TITLE
Documented the information flow in FlowETL (#801)

### DIFF
--- a/docs/source/developer/developer.md
+++ b/docs/source/developer/developer.md
@@ -326,7 +326,7 @@ docker run --name flowdb_testdata -e FLOWMACHINE_FLOWDB_PASSWORD=foo -e FLOWAPI_
 This section describes the information available in the DAG code inside FlowETL.
 
 Some information is only known at runtime, in code executed by a running DAG, this cannot be passed to the python callables or accessed when creating the DAGs because it's not static and changes for each run:
-execution_date, run_id, the dag itself, ds/ts and the [default variables allowed in airflow](https://airflow.apache.org/macros.html#default-variables), the task and task_instance.
+`execution_date`, `run_id`, the dag itself, `ds`/`ts` and the [default variables allowed in airflow](https://airflow.apache.org/macros.html#default-variables), the task and task_instance.
 
 The data that is passed when the DAG is triggered, is also available at runtime in the callables under `dag_run['conf']` :
 cdr_type (a DAG is initialised for a specific cdr_type *but* this is not static because the callables are reused), cdr_date (which currently is the same as the execution_date), file_name & template_path or source_table.

--- a/docs/source/developer/developer.md
+++ b/docs/source/developer/developer.md
@@ -332,7 +332,7 @@ The data that is passed when the DAG is triggered, is also available at runtime 
 `cdr_type` (a DAG is initialised for a specific `cdr_type` *but* this is not static because the callables are reused), `cdr_date` (which currently is the same as the `execution_date`), `file_name` & `template_path` or `source_table`.
 
 Some information can be accessed when creating the DAG / not at runtime - these can be passed to the python callables because they are static and do not change:
-the SQL and config paths (because they remain fixed), the configuration that remains constant for any DAG (config.yml in /mounts/config)
+the SQL and config paths (because they remain fixed), the configuration that remains constant for any DAG (`config.yml` in `/mounts/config`)
 
 ## FlowAuth
 

--- a/docs/source/developer/developer.md
+++ b/docs/source/developer/developer.md
@@ -10,6 +10,8 @@ FlowMachine specifications are found [here](#flowmachine).
 
 FlowDB details are found [here](#flowdb).
 
+FlowETL details are found [here](#flowetl).
+
 <a href="roadmap"></a>
 
 ## Roadmap
@@ -316,6 +318,21 @@ docker run --name flowdb_testdata -e FLOWMACHINE_FLOWDB_PASSWORD=foo -e FLOWAPI_
 
     When using docker volumes, docker will manage the permissions for you.
 
+
+## FlowETL
+
+### DAG information flow
+
+This section describes the information available in the DAG code inside FlowETL.
+
+Some information is only known at runtime, in code executed by a running DAG, this cannot be passed to the python callables or accessed when creating the DAGs because it's not static and changes for each run:
+execution_date, run_id, the dag itself, ds/ts and the [default variables allowed in airflow](https://airflow.apache.org/macros.html#default-variables), the task and task_instance.
+
+The data that is passed when the DAG is triggered, is also available at runtime in the callables under `dag_run['conf']` :
+cdr_type (a DAG is initialised for a specific cdr_type *but* this is not static because the callables are reused), cdr_date (which currently is the same as the execution_date), file_name & template_path or source_table.
+
+Some information can be accessed when creating the DAG / not at runtime - these can be passed to the python callables because they are static and do not change:
+the SQL and config paths (because they remain fixed), the configuration that remains constant for any DAG (config.yml in /mounts/config)
 
 ## FlowAuth
 

--- a/docs/source/developer/developer.md
+++ b/docs/source/developer/developer.md
@@ -329,7 +329,7 @@ Some information is only known at runtime, in code executed by a running DAG, th
 `execution_date`, `run_id`, the dag itself, `ds`/`ts` and the [default variables allowed in airflow](https://airflow.apache.org/macros.html#default-variables), the task and task_instance.
 
 The data that is passed when the DAG is triggered, is also available at runtime in the callables under `dag_run['conf']` :
-cdr_type (a DAG is initialised for a specific cdr_type *but* this is not static because the callables are reused), cdr_date (which currently is the same as the execution_date), file_name & template_path or source_table.
+`cdr_type` (a DAG is initialised for a specific `cdr_type` *but* this is not static because the callables are reused), `cdr_date` (which currently is the same as the `execution_date`), `file_name` & `template_path` or `source_table`.
 
 Some information can be accessed when creating the DAG / not at runtime - these can be passed to the python callables because they are static and do not change:
 the SQL and config paths (because they remain fixed), the configuration that remains constant for any DAG (config.yml in /mounts/config)


### PR DESCRIPTION
Closes #801 

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [ ] Brought the branch up to date with master
- [ ] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This adds some documentation about the information that is available in the DAGs code and differentiates the information at run time vs creation time.