### PR TITLE
Show Flowauth version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- FlowAuth now makes version information available at `/version` and displays it in the web ui. [#835](https://github.com/Flowminder/FlowKit/issues/835)
 
 ### Changed
 
 ### Fixed
+
 
 ### Removed
 

--- a/flowauth/backend/flowauth/__init__.py
+++ b/flowauth/backend/flowauth/__init__.py
@@ -28,6 +28,7 @@ from .admin import blueprint as admin_blueprint
 from .token_management import blueprint as token_management_blueprint
 from .login import blueprint as login_blueprint
 from .spatial_aggregation import blueprint as aggregation_unit_blueprint
+from .version import blueprint as version_blueprint
 
 
 def create_app(test_config=None):
@@ -54,6 +55,7 @@ def create_app(test_config=None):
     csrf = CSRFProtect()
     csrf.init_app(app)
     csrf.exempt(login_blueprint)
+    csrf.exempt(version_blueprint)
 
     app.register_blueprint(login_blueprint)
     app.register_blueprint(admin_blueprint, url_prefix="/admin")
@@ -61,6 +63,7 @@ def create_app(test_config=None):
     app.register_blueprint(
         aggregation_unit_blueprint, url_prefix="/spatial_aggregation"
     )
+    app.register_blueprint(version_blueprint)
 
     # Set the log level
     app.before_first_request(partial(app.logger.setLevel, app.config["LOG_LEVEL"]))

--- a/flowauth/backend/flowauth/version.py
+++ b/flowauth/backend/flowauth/version.py
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from flask import jsonify, Blueprint
+from flowauth._version import get_versions
+
+blueprint = Blueprint(__name__, __name__)
+
+
+@blueprint.route("/version")
+def get_version():
+    return jsonify({"version": get_versions()["version"]})

--- a/flowauth/backend/tests/test_version_route.py
+++ b/flowauth/backend/tests/test_version_route.py
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import flowauth
+
+
+def test_version(client):
+    """Test the correct version is returned."""
+
+    response = client.get("/version")
+    assert response.status_code == 200  # Should get an OK
+
+    assert response.get_json() == {"version": flowauth.__version__}

--- a/flowauth/frontend/cypress/integration/version.js
+++ b/flowauth/frontend/cypress/integration/version.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+describe("Login screen", function() {
+  beforeEach(function() {
+    // Go to login screen
+    cy.goto("/");
+  });
+
+  it("Should show the version on the login screen", function() {
+    cy.exec(
+      'git describe --tags --dirty --always | sed s/"-"/"+"/ | sed s/"-"/"."/g'
+    ).then(result => {
+      cy.get("#flowauth_version").should(
+        "contain",
+        "FlowAuth v" + result.stdout
+      );
+    });
+  });
+
+  it("Should show the version after logging in", function() {
+    cy.exec(
+      'git describe --tags --dirty --always | sed s/"-"/"+"/ | sed s/"-"/"."/g'
+    ).then(result => {
+      cy.login_admin()
+        .goto("/")
+        .get("#flowauth_version")
+        .should("contain", "FlowAuth v" + result.stdout);
+    });
+  });
+});

--- a/flowauth/frontend/src/App.js
+++ b/flowauth/frontend/src/App.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import Login from "./Login";
 import Dashboard from "./Dashboard";
 import { logout } from "./util/api";
+import Version from "./Version";
 
 class App extends Component {
   constructor(props) {
@@ -33,11 +34,20 @@ class App extends Component {
     if (this.state.hasError) throw this.state.error;
 
     const { loggedIn, is_admin } = this.state;
+    let component;
     if (loggedIn) {
-      return <Dashboard setLoggedOut={this.setLoggedOut} is_admin={is_admin} />;
+      component = (
+        <Dashboard setLoggedOut={this.setLoggedOut} is_admin={is_admin} />
+      );
     } else {
-      return <Login setLoggedIn={this.setLoggedIn} />;
+      component = <Login setLoggedIn={this.setLoggedIn} />;
     }
+    return (
+      <>
+        {component}
+        <Version />
+      </>
+    );
   }
 }
 

--- a/flowauth/frontend/src/Version.js
+++ b/flowauth/frontend/src/Version.js
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from "react";
+import { withStyles } from "@material-ui/core/styles";
+import Paper from "@material-ui/core/Paper";
+import Typography from "@material-ui/core/Typography";
+import { getVersion } from "./util/api";
+import PropTypes from "prop-types";
+
+const styles = theme => ({
+  root: {
+    position: "absolute",
+    display: "block",
+    bottom: 0,
+    right: 0,
+    opacity: 0.8,
+    zIndex: 1300,
+    padding: 2
+  }
+});
+
+class Version extends React.Component {
+  state = {
+    version: null
+  };
+
+  async componentDidMount() {
+    this.setState(await getVersion());
+  }
+
+  render() {
+    const { classes } = this.props;
+    const { version } = this.state;
+
+    return (
+      <>
+        <Paper className={classes.root} id="flowauth_version">
+          <Typography variant="body2" gutterBottom>
+            FlowAuth v{version}
+          </Typography>
+        </Paper>
+      </>
+    );
+  }
+}
+
+Version.propTypes = {
+  classes: PropTypes.object.isRequired
+};
+
+export default withStyles(styles)(Version);

--- a/flowauth/frontend/src/util/api.js
+++ b/flowauth/frontend/src/util/api.js
@@ -330,6 +330,10 @@ export async function isLoggedIn() {
   return await getResponseDefault("/is_signed_in");
 }
 
+export async function getVersion() {
+  return await getResponseDefault("/version");
+}
+
 export async function logout() {
   try {
     return await getResponseDefault("/signout");


### PR DESCRIPTION
Closes #835

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [x] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

- Adds a `/version` route to FlowAuth which returns the version `{'version': x.x.x}`
- Adds a floating display of this to the web ui