### PR TITLE
Fix multiple invocations of Quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - FlowDB is now based on PostgreSQL 11.5 and PostGIS 2.5.3
 
 ### Fixed
+- Quickstart will no longer fail if it has been run previously with a different FlowDB data size and not explicitly shut down. [#900](https://github.com/Flowminder/FlowKit/issues/900)
 
 
 ### Removed

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ services := flowmachine flowapi flowauth flowdb worked_examples flowdb_testdata 
 space :=
 space +=
 DOCKER_COMPOSE := docker-compose -f $(DOCKER_COMPOSE_FILE)
+FLOWDB_SERVICE := $(filter flowdb%, $(DOCKER_SERVICES))
 
 # Check that at most one flowdb service is present in DOCKER_SERVICES
 NUM_SPECIFIED_FLOWDB_SERVICES=$(words $(filter flowdb%, $(DOCKER_SERVICES)))
@@ -40,13 +41,13 @@ ifneq ($(NUM_SPECIFIED_FLOWDB_SERVICES),0)
 endif
 
 
-ifeq ($(words $(filter flowdb_testdata, $(DOCKER_SERVICES))), 1)
-    up up-no_build : DOCKER_COMPOSE += -f $(DOCKER_COMPOSE_TESTDATA_FILE)
-    up : DOCKER_COMPOSE += -f $(DOCKER_COMPOSE_TESTDATA_FILE_BUILD)
+ifeq ($(FLOWDB_SERVICE), flowdb_testdata)
+ up up-no_build : DOCKER_COMPOSE += -f $(DOCKER_COMPOSE_TESTDATA_FILE)
+ up : DOCKER_COMPOSE += -f $(DOCKER_COMPOSE_TESTDATA_FILE_BUILD)
 endif
-ifeq ($(words $(filter flowdb_syntheticdata, $(DOCKER_SERVICES))), 1)
-	up up-no_build : DOCKER_COMPOSE += -f $(DOCKER_COMPOSE_SYNTHETICDATA_FILE)
-	up : DOCKER_COMPOSE += -f $(DOCKER_COMPOSE_SYNTHETICDATA_FILE_BUILD)
+ifeq ($(FLOWDB_SERVICE), flowdb_synthetic_data)
+ up up-no_build : DOCKER_COMPOSE += -f $(DOCKER_COMPOSE_SYNTHETICDATA_FILE)
+ up : DOCKER_COMPOSE += -f $(DOCKER_COMPOSE_SYNTHETICDATA_FILE_BUILD)
 endif
 
 all:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ DOCKER_COMPOSE_FILE ?= docker-compose.yml
 DOCKER_COMPOSE_TESTDATA_FILE ?= docker-compose-testdata.yml
 DOCKER_COMPOSE_SYNTHETICDATA_FILE ?= docker-compose-syntheticdata.yml
 DOCKER_COMPOSE_FILE_BUILD ?= docker-compose-build.yml
-DOCKER_SERVICES ?= flowdb_testdata flowapi flowmachine flowauth flowmachine_query_locker flowetl flowetl_db worked_examples
+DOCKER_COMPOSE_TESTDATA_FILE_BUILD ?= docker-compose-testdata-build.yml
+DOCKER_COMPOSE_SYNTHETICDATA_FILE_BUILD ?= docker-compose-syntheticdata-build.yml
+DOCKER_SERVICES ?= flowdb flowapi flowmachine flowauth flowmachine_query_locker flowetl flowetl_db worked_examples
 DOCKER_COMPOSE_UP = docker-compose -f $(DOCKER_COMPOSE_FILE) \
 	-f $(DOCKER_COMPOSE_SYNTHETICDATA_FILE) \
 	-f $(DOCKER_COMPOSE_TESTDATA_FILE) \
@@ -89,23 +91,23 @@ flowdb-build:
 
 
 flowdb_testdata-up: flowdb_testdata-build
-	$(DOCKER_COMPOSE_UP) flowdb_testdata
+	$(DOCKER_COMPOSE_UP) flowdb
 
 flowdb_testdata-down:
-	$(DOCKER_COMPOSE_DOWN) flowdb_testdata
+	$(DOCKER_COMPOSE_DOWN) flowdb
 
 flowdb_testdata-build: flowdb-build
-	$(DOCKER_COMPOSE_BUILD) flowdb_testdata
+	$(DOCKER_COMPOSE_BUILD) flowdb
 
 
 flowdb_synthetic_data-up: flowdb_synthetic_data-build
-	$(DOCKER_COMPOSE_UP) flowdb_synthetic_data
+	$(DOCKER_COMPOSE_UP) flowdb
 
 flowdb_synthetic_data-down:
-	$(DOCKER_COMPOSE_DOWN) flowdb_synthetic_data
+	$(DOCKER_COMPOSE_DOWN) flowdb
 
 flowdb_synthetic_data-build: flowdb-build
-	$(DOCKER_COMPOSE_BUILD) flowdb_synthetic_data
+	$(DOCKER_COMPOSE_BUILD) flowdb
 
 
 flowmachine-up:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@
 #     DOCKER_SERVICES="flowdb" make up
 #     DOCKER_SERVICES="flowdb_testdata flowetl flowetl_db" make up
 #
-# flowmachine and flowapi will connected to the first flowdb service in the list.
 
 DOCKER_COMPOSE_FILE ?= docker-compose.yml
 DOCKER_COMPOSE_TESTDATA_FILE ?= docker-compose-testdata.yml
@@ -72,103 +71,21 @@ down:
 # Note: the targets below are repetitive and could be simplified by using
 # a pattern rule as follows:
 #
-#   %-up: %-build
+#   %: %-build
 #       docker-compose -f $(DOCKER_COMPOSE_FILE) up -d --build $*
 #
 # The reason we are keeping the explicitly spelled-out versions is in order
 # to increase discoverability of the available Makefile targets and to enable
 # tab-completion of targets (which is not possible when using patterns).
 
+services := flowmachine flowapi flowauth flowdb worked_examples flowdb_testdata flowdb_synthetic_data flowetl flowetl_db
+space :=
+space +=
+$(subst $(space),-up ,$(services)):
+	$(DOCKER_COMPOSE_UP) $(subst -up,,$@)
 
-flowdb-up: flowdb-build
-	$(DOCKER_COMPOSE_UP) flowdb
-
-flowdb-down:
-	$(DOCKER_COMPOSE_DOWN) flowdb
-
-flowdb-build:
-	$(DOCKER_COMPOSE_BUILD) flowdb
-
-
-flowdb_testdata-up: flowdb_testdata-build
-	$(DOCKER_COMPOSE_UP) flowdb
-
-flowdb_testdata-down:
-	$(DOCKER_COMPOSE_DOWN) flowdb
-
-flowdb_testdata-build: flowdb-build
-	$(DOCKER_COMPOSE_BUILD) flowdb
-
-
-flowdb_synthetic_data-up: flowdb_synthetic_data-build
-	$(DOCKER_COMPOSE_UP) flowdb
-
-flowdb_synthetic_data-down:
-	$(DOCKER_COMPOSE_DOWN) flowdb
-
-flowdb_synthetic_data-build: flowdb-build
-	$(DOCKER_COMPOSE_BUILD) flowdb
-
-
-flowmachine-up:
-	$(DOCKER_COMPOSE_UP) flowmachine
-
-flowmachine-down:
-	$(DOCKER_COMPOSE_DOWN) flowmachine
-
-flowmachine-build:
-	$(DOCKER_COMPOSE_BUILD) flowmachine
-
-
-flowapi-up:
-	$(DOCKER_COMPOSE_UP) flowapi
-
-flowapi-down:
-	$(DOCKER_COMPOSE_DOWN) flowapi
-
-flowapi-build:
-	$(DOCKER_COMPOSE_BUILD) flowapi
-
-
-flowauth-up:
-	$(DOCKER_COMPOSE_UP) flowauth
-
-flowauth-down:
-	$(DOCKER_COMPOSE_DOWN) flowauth
-
-flowauth-build:
-	$(DOCKER_COMPOSE_BUILD) flowauth
-
-
-worked_examples-up: worked_examples-build
-	$(DOCKER_COMPOSE_UP) worked_examples
-
-worked_examples-down:
-	$(DOCKER_COMPOSE_DOWN) worked_examples
-
-worked_examples-build:
-	$(DOCKER_COMPOSE_BUILD) worked_examples
-
-
-flowmachine_query_locker-up:
-	$(DOCKER_COMPOSE_UP_NOBUILD) flowmachine_query_locker
-
-flowmachine_query_locker-down:
-	$(DOCKER_COMPOSE_DOWN) flowmachine_query_locker
-
-
-flowetl-up:
-	$(DOCKER_COMPOSE_UP) flowetl
-
-flowetl-down:
-	$(DOCKER_COMPOSE_DOWN) flowetl
-
-flowetl-build:
-	$(DOCKER_COMPOSE_BUILD) flowetl
-
-
-flowetl_db-up:
-	$(DOCKER_COMPOSE_UP) flowetl_db
-
-flowetl_db-down:
-	$(DOCKER_COMPOSE_DOWN) flowetl_db
+$(subst $(space),-down ,$(services)):
+	$(DOCKER_COMPOSE_DOWN) $(patsubst -down,,$@)
+	
+$(subst $(space),-build ,$(services))::
+	$(DOCKER_COMPOSE_BUILD) $(patsubst -build,,$@)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ DOCKER_COMPOSE_TESTDATA_FILE_BUILD ?= docker-compose-testdata-build.yml
 DOCKER_COMPOSE_SYNTHETICDATA_FILE_BUILD ?= docker-compose-syntheticdata-build.yml
 DOCKER_SERVICES ?= flowdb flowapi flowmachine flowauth flowmachine_query_locker flowetl flowetl_db worked_examples
 DOCKER_SERVICES_TO_START = $(patsubst flowdb%,flowdb,$(DOCKER_SERVICES))
-services := flowmachine flowapi flowauth flowdb worked_examples flowdb_testdata flowdb_synthetic_data flowetl flowetl_db
+services := flowmachine flowmachine_query_locker flowapi flowauth flowdb worked_examples flowdb_testdata flowdb_synthetic_data flowetl flowetl_db
 space :=
 space +=
 DOCKER_COMPOSE := docker-compose -f $(DOCKER_COMPOSE_FILE)
@@ -89,5 +89,5 @@ $(services:=-up):
 $(services:=-down):
 	$(DOCKER_COMPOSE) rm -f -s -v $(subst _synthetic_data,,$(subst _testdata,,$(@:-down=)))
 	
-$($(filter-out flowetl_db, services):=-build):
+$($(filter-out flowetl_db flowmachine_query_locker, services):=-build):
 	$(DOCKER_COMPOSE) build $(subst _synthetic_data,,$(subst _testdata,,$(@:-build=)))

--- a/Makefile
+++ b/Makefile
@@ -50,16 +50,21 @@ ifeq ($(FLOWDB_SERVICE), flowdb_synthetic_data)
  up : DOCKER_COMPOSE += -f $(DOCKER_COMPOSE_SYNTHETICDATA_FILE_BUILD)
 endif
 
+# Only build flowdb if a flowdb service is requested
+ifeq ($(words, $FLOWDB_SERVICE), 1)
+    FLOWDB_BUILD = flowdb-build
+endif
+
 all:
 
-up: flowdb-build
+up: $(FLOWDB_BUILD)
 	$(DOCKER_COMPOSE) up --build -d $(DOCKER_SERVICES_TO_START)
 
 up-no_build:
 	$(DOCKER_COMPOSE) up -d $(DOCKER_SERVICES_TO_START)
 
 down:
-	$(DOCKER_COMPOSE) down
+	$(DOCKER_COMPOSE) down -v
 
 
 # Per-service targets
@@ -82,7 +87,7 @@ $(services:=-up):
 	$(DOCKER_COMPOSE) up -d $(subst _synthetic_data,,$(subst _testdata,,$(@:-up=)))
 
 $(services:=-down):
-	$(DOCKER_COMPOSE) down $(subst _synthetic_data,,$(subst _testdata,,$(@:-down=)))
+	$(DOCKER_COMPOSE) rm -f -s -v $(subst _synthetic_data,,$(subst _testdata,,$(@:-down=)))
 	
 $($(filter-out flowetl_db, services):=-build):
 	$(DOCKER_COMPOSE) build $(subst _synthetic_data,,$(subst _testdata,,$(@:-build=)))

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -15,18 +15,6 @@ services:
       context: ./flowdb/
       dockerfile: Dockerfile
 
-  flowdb_testdata:
-    image: flowminder/flowdb-testdata:${CONTAINER_TAG:-latest}
-    build:
-      context: ./flowdb/testdata/
-      dockerfile: Dockerfile
-
-  flowdb_synthetic_data:
-    image: flowminder/flowdb-synthetic-data:${CONTAINER_TAG:-latest}
-    build:
-      context: ./flowdb/testdata/
-      dockerfile: Dockerfile.synthetic_data
-
   flowmachine:
     image: flowminder/flowmachine:${CONTAINER_TAG:-latest}
     build:

--- a/docker-compose-syntheticdata-build.yml
+++ b/docker-compose-syntheticdata-build.yml
@@ -2,13 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# DOCKER COMPOSE FOR FLOWKIT TEST DATA
+# DOCKER COMPOSE BUILDER FOR FLOWKIT
 #
 
 version: '3.5'
 
 services:
-
   flowdb:
-    container_name: flowdb
-    image: flowminder/flowdb-testdata:${CONTAINER_TAG:-latest}
+    image: flowminder/flowdb-synthetic-data:${CONTAINER_TAG:-latest}
+    build:
+      context: ./flowdb/testdata/
+      dockerfile: Dockerfile.synthetic_data

--- a/docker-compose-syntheticdata.yml
+++ b/docker-compose-syntheticdata.yml
@@ -7,27 +7,12 @@
 
 version: '3.5'
 
-networks:
-  db:
-
-
 services:
 
-  flowdb_synthetic_data:
-    container_name: flowdb_synthetic_data
+  flowdb:
+    container_name: flowdb
     image: flowminder/flowdb-synthetic-data:${CONTAINER_TAG:-latest}
-    ports:
-      - ${FLOWDB_PORT:?Must set FLOWDB_PORT env var}:5432
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:?Must set POSTGRES_USER env var}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Must set POSTGRES_PASSWORD env var}
-      FLOWMACHINE_FLOWDB_USER: ${FLOWMACHINE_FLOWDB_USER:?Must set FLOWMACHINE_FLOWDB_USER env var}
-      FLOWMACHINE_FLOWDB_PASSWORD: ${FLOWMACHINE_FLOWDB_PASSWORD:?Must set FLOWMACHINE_FLOWDB_PASSWORD env var}
-      FLOWAPI_FLOWDB_USER: ${FLOWAPI_FLOWDB_USER:?Must set FLOWAPI_FLOWDB_USER env var}
-      FLOWAPI_FLOWDB_PASSWORD: ${FLOWAPI_FLOWDB_PASSWORD:?Must set FLOWAPI_FLOWDB_PASSWORD env var}
-      CACHE_SIZE: ${CACHE_SIZE:-""}
-      CACHE_HALF_LIFE: ${CACHE_HALF_LIFE:?Must set CACHE_HALF_LIFE env var}
-      FLOWDB_ENABLE_POSTGRES_DEBUG_MODE: ${FLOWDB_ENABLE_POSTGRES_DEBUG_MODE:?Must set FLOWDB_ENABLE_POSTGRES_DEBUG_MODE env var}
       SYNTHETIC_DATA_GENERATOR: ${SYNTHETIC_DATA_GENERATOR:?Must set SYNTHETIC_DATA_GENERATOR env var}
       N_SITES: ${N_SITES:?Must set N_SITES env var}
       N_CELLS: ${N_CELLS:?Must set N_CELLS env var}
@@ -42,11 +27,3 @@ services:
       INTERACTIONS_MULTIPLIER: ${INTERACTIONS_MULTIPLIER:?Must set INTERACTIONS_MULTIPLIER env var}
       DISASTER_START: ${DISASTER_START:?Must set DISASTER_START env var}
       DISASTER_END: ${DISASTER_END:?Must set DISASTER_END env var}
-    shm_size: 1G
-    tty: true
-    stdin_open: true
-    restart: always
-    networks:
-      db:
-        aliases:
-          - flowdb

--- a/docker-compose-testdata-build.yml
+++ b/docker-compose-testdata-build.yml
@@ -2,13 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# DOCKER COMPOSE FOR FLOWKIT TEST DATA
+# DOCKER COMPOSE BUILDER FOR FLOWKIT
 #
 
 version: '3.5'
 
 services:
-
   flowdb:
-    container_name: flowdb
     image: flowminder/flowdb-testdata:${CONTAINER_TAG:-latest}
+    build:
+      context: ./flowdb/testdata/
+      dockerfile: Dockerfile

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -69,9 +69,9 @@ fi
 
 if [ $# -gt 0 ] && [ "$1" = "larger_data" ] || [ "$2" = "larger_data" ]
 then
-    export DOCKER_FLOWDB_HOST=flowdb_synthetic_data
+    export EXTRA_COMPOSE=docker-compose-syntheticdata.yml
 else
-    export DOCKER_FLOWDB_HOST=flowdb_testdata
+    export EXTRA_COMPOSE=docker-compose-testdata.yml
 fi
 
 if [ $# -gt 0 ] && [ "$1" = "examples" ] || [ "$2" = "examples" ]
@@ -79,9 +79,9 @@ then
     export WORKED_EXAMPLES=worked_examples
     if [ $# -gt 0 ] && [ "$1" = "smaller_data" ] || [ "$2" = "smaller_data" ]
     then
-        export DOCKER_FLOWDB_HOST=flowdb_testdata
+        export EXTRA_COMPOSE=docker-compose-testdata.yml
     else
-        export DOCKER_FLOWDB_HOST=flowdb_synthetic_data
+        export EXTRA_COMPOSE=docker-compose-syntheticdata.yml
     fi
 else
     export WORKED_EXAMPLES=
@@ -118,26 +118,25 @@ curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/doc
 curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/docker-compose-testdata.yml -o "$DOCKER_WORKDIR/docker-compose-testdata.yml"
 curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/docker-compose-syntheticdata.yml -o "$DOCKER_WORKDIR/docker-compose-syntheticdata.yml"
 
-DOCKER_COMPOSE="docker-compose -p flowkit_qs -f $DOCKER_WORKDIR/docker-compose.yml -f $DOCKER_WORKDIR/docker-compose-testdata.yml -f $DOCKER_WORKDIR/docker-compose-syntheticdata.yml"
+DOCKER_COMPOSE="docker-compose -p flowkit_qs -f $DOCKER_WORKDIR/docker-compose.yml -f $DOCKER_WORKDIR/$EXTRA_COMPOSE"
 
 if [ $# -gt 0 ] && [ "$1" = "stop" ]
 then
-    export DOCKER_FLOWDB_HOST=flowdb_testdata
     echo "Stopping containers"
     source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/development_environment)"
     $DOCKER_COMPOSE down -v
 else
     source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Flowminder/FlowKit/${GIT_REVISION}/development_environment)"
     echo "Starting containers (this may take a few minutes)"
-    RUNNING=`$DOCKER_COMPOSE ps -q $DOCKER_FLOWDB_HOST flowapi flowmachine flowauth flowmachine_query_locker $WORKED_EXAMPLES`
+    RUNNING=`$DOCKER_COMPOSE ps -q flowdb flowapi flowmachine flowauth flowmachine_query_locker $WORKED_EXAMPLES`
     if [[ "$RUNNING" != "" ]]; then
         confirm "Existing containers are running and will be replaced. Are you sure?" || exit 1
     fi
-    DOCKER_SERVICES="$DOCKER_FLOWDB_HOST flowapi flowmachine flowauth flowmachine_query_locker $WORKED_EXAMPLES"
+    DOCKER_SERVICES="flowdb flowapi flowmachine flowauth flowmachine_query_locker $WORKED_EXAMPLES"
     $DOCKER_COMPOSE pull $DOCKER_SERVICES
     $DOCKER_COMPOSE up -d $DOCKER_SERVICES
     echo "Waiting for containers to be ready.."
-    docker exec ${DOCKER_FLOWDB_HOST} bash -c 'i=0; until { [ $i -ge 24 ] && exit_status=1; } || { (pg_isready -h 127.0.0.1 -p 5432) && exit_status=0; }; do let i=i+1; echo Waiting 10s; sleep 10; done; exit $exit_status' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including the output of running 'docker logs flowdb'" && exit 1)
+    docker exec flowdb bash -c 'i=0; until { [ $i -ge 24 ] && exit_status=1; } || { (pg_isready -h 127.0.0.1 -p 5432) && exit_status=0; }; do let i=i+1; echo Waiting 10s; sleep 10; done; exit $exit_status' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including the output of running 'docker logs flowdb'" && exit 1)
     echo "FlowDB ready."
     (i=0; until { [ $i -ge 24 ] && exit_status=1; } || { (netstat -an | grep -q $FLOWMACHINE_PORT) && exit_status=0; } ; do let i=i+1; echo Waiting 10s; sleep 10; done; exit $exit_status) || (>&2 echo "FlowMachine failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowMachine,bug including the output of running 'docker logs flowmachine'" && exit 1)
     echo "FlowMachine ready"

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -147,8 +147,8 @@ else
     if [[ "$WORKED_EXAMPLES" = "worked_examples" ]]
     then
         (i=0; until { [ $i -ge 24 ] && exit_status=1; } || { (curl -s http://localhost:$WORKED_EXAMPLES_PORT > /dev/null) && exit_status=0; } ; do let i=i+1; echo Waiting 10s; sleep 10; done; exit $exit_status) || (>&2 echo "Worked examples failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=docs,bug including the output of running 'docker logs worked_examples'" && exit 1)
+        echo "Worked examples ready."
     fi
-    echo "Worked examples ready."
     echo "All containers ready!"
     echo "Access FlowDB using 'PGHOST=$FLOWDB_HOST PGPORT=$FLOWDB_PORT PGDATABASE=flowdb PGUSER=$FLOWMACHINE_FLOWDB_USER PGPASSWORD=$FLOWMACHINE_FLOWDB_PASSWORD psql'"
     echo "Access FlowAPI using FlowClient at http://localhost:$FLOWAPI_PORT"

--- a/quick_start.sh
+++ b/quick_start.sh
@@ -134,7 +134,7 @@ else
     fi
     DOCKER_SERVICES="flowdb flowapi flowmachine flowauth flowmachine_query_locker $WORKED_EXAMPLES"
     $DOCKER_COMPOSE pull $DOCKER_SERVICES
-    $DOCKER_COMPOSE up -d $DOCKER_SERVICES
+    $DOCKER_COMPOSE up -d --renew-anon-volumes $DOCKER_SERVICES
     echo "Waiting for containers to be ready.."
     docker exec flowdb bash -c 'i=0; until { [ $i -ge 24 ] && exit_status=1; } || { (pg_isready -h 127.0.0.1 -p 5432) && exit_status=0; }; do let i=i+1; echo Waiting 10s; sleep 10; done; exit $exit_status' || (>&2 echo "FlowDB failed to start :( Please open an issue at https://github.com/Flowminder/FlowKit/issues/new?template=bug_report.md&labels=FlowDB,bug including the output of running 'docker logs flowdb'" && exit 1)
     echo "FlowDB ready."


### PR DESCRIPTION
Closes #900

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [x] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

- Simplifies the makefile a touch
- Makes all the compose files give FlowDB the same name, so that they work as overrides on the base compose
- Makes the Quickstart up recreate all anonymous volumes

Result being you can run Quickstart and happily switch between data volumes.