### PR TITLE
Speed

### DIFF
--- a/flowapi/flowapi/main.py
+++ b/flowapi/flowapi/main.py
@@ -113,8 +113,8 @@ def create_app():
     app.config.from_mapping(get_config())
 
     jwt = JWTManager(app)
-    app.before_first_request(connect_logger)
-    app.before_first_request(create_db)
+    app.before_serving(connect_logger)
+    app.before_serving(create_db)
     app.before_request(add_uuid)
     app.before_request(connect_zmq)
     app.teardown_request(close_zmq)

--- a/flowapi/tests/unit/test_access_control.py
+++ b/flowapi/tests/unit/test_access_control.py
@@ -24,7 +24,7 @@ async def test_protected_get_routes(route, app):
     response = await app.client.get(route)
     assert 401 == response.status_code
 
-    log_lines = log_lines = app.log_capture().access
+    log_lines = app.log_capture().access
     assert 1 == len(log_lines)  # One entry written to stdout
 
     assert "UNAUTHORISED" == log_lines[0]["event"]

--- a/flowapi/tests/unit/test_access_control.py
+++ b/flowapi/tests/unit/test_access_control.py
@@ -16,7 +16,7 @@ async def test_protected_get_routes(route, app):
     Parameters
     ----------
     app: tuple
-        Pytest fixture providing the flowapi, with a mock for the db
+        Pytest fixture providing the flowapi app
     route: str
         Route to test
     """

--- a/flowapi/tests/unit/test_access_control.py
+++ b/flowapi/tests/unit/test_access_control.py
@@ -9,7 +9,7 @@ from .utils import query_kinds, exemplar_query_params
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("route", ["/api/0/poll/foo", "/api/0/get/foo"])
-async def test_protected_get_routes(route, app, json_log):
+async def test_protected_get_routes(route, app):
     """
     Test that protected routes return a 401 without a valid token.
 
@@ -20,14 +20,12 @@ async def test_protected_get_routes(route, app, json_log):
     route: str
         Route to test
     """
-    client, db, log_dir, app = app
 
-    response = await client.get(route)
+    response = await app.client.get(route)
     assert 401 == response.status_code
 
-    log_lines = json_log().out
+    log_lines = log_lines = app.log_capture().access
     assert 1 == len(log_lines)  # One entry written to stdout
-    assert log_lines[0]["logger"] == "flowapi.access"
 
     assert "UNAUTHORISED" == log_lines[0]["event"]
 
@@ -41,7 +39,6 @@ async def test_granular_run_access(
     Test that tokens grant granular access to running queries.
 
     """
-    client, db, log_dir, app = app
     token = access_token_builder(
         {
             query_kind: {
@@ -62,7 +59,7 @@ async def test_granular_run_access(
     responses = {}
     for q_kind in query_kinds:
         q_params = exemplar_query_params[q_kind]
-        response = await client.post(
+        response = await app.client.post(
             f"/api/0/run", headers={"Authorization": f"Bearer {token}"}, json=q_params
         )
         responses[q_kind] = response.status_code
@@ -78,7 +75,6 @@ async def test_granular_poll_access(
     Test that tokens grant granular access to checking query status.
 
     """
-    client, db, log_dir, app = app
     token = access_token_builder(
         {
             query_kind: {
@@ -113,7 +109,7 @@ async def test_granular_poll_access(
                 },
             },
         )
-        response = await client.get(
+        response = await app.client.get(
             f"/api/0/poll/DUMMY_QUERY_ID",
             headers={"Authorization": f"Bearer {token}"},
             json={"query_kind": q_kind},
@@ -131,7 +127,6 @@ async def test_granular_json_access(
     Test that tokens grant granular access to query output.
 
     """
-    client, db, log_dir, app = app
     token = access_token_builder(
         {
             query_kind: {
@@ -161,7 +156,7 @@ async def test_granular_json_access(
                 "payload": {"query_id": "DUMMY_QUERY_ID", "sql": "SELECT 1;"},
             },
         )
-        response = await client.get(
+        response = await app.client.get(
             f"/api/0/get/DUMMY_QUERY_ID",
             headers={"Authorization": f"Bearer {token}"},
             json={},
@@ -193,7 +188,6 @@ async def test_no_result_access_without_both_claims(
     Test that tokens grant granular access to query output.
 
     """
-    client, db, log_dir, app = app
     token = access_token_builder({"DUMMY_QUERY_KIND": claims})
     dummy_zmq_server.side_effect = (
         {
@@ -213,7 +207,7 @@ async def test_no_result_access_without_both_claims(
             "payload": {"query_id": "DUMMY_QUERY_ID", "sql": "SELECT 1;"},
         },
     )
-    response = await client.get(
+    response = await app.client.get(
         f"/api/0/get/DUMMY_QUERY_ID", headers={"Authorization": f"Bearer {token}"}
     )
     assert 403 == response.status_code
@@ -225,13 +219,12 @@ async def test_no_result_access_without_both_claims(
     "route", ["/api/0/poll/DUMMY_QUERY_ID", "/api/0/get/DUMMY_QUERY_ID"]
 )
 async def test_access_logs_gets(
-    query_kind, route, app, access_token_builder, dummy_zmq_server, json_log
+    query_kind, route, app, access_token_builder, dummy_zmq_server
 ):
     """
     Test that access logs are written for attempted unauthorized access to 'poll' and get' routes.
 
     """
-    client, db, log_dir, app = app
     token = access_token_builder({query_kind: {"permissions": {}}})
     dummy_zmq_server.side_effect = (
         {
@@ -250,45 +243,38 @@ async def test_access_logs_gets(
             "payload": {"query_id": "DUMMY_QUERY_ID", "query_kind": "dummy_query_kind"},
         },
     )
-    response = await client.get(route, headers={"Authorization": f"Bearer {token}"})
+    response = await app.client.get(route, headers={"Authorization": f"Bearer {token}"})
     assert 403 == response.status_code
-    log_lines = json_log().out
-    assert 3 == len(log_lines)  # One access log, two query logs
-    assert log_lines[0]["logger"] == "flowapi.access"
-    assert log_lines[1]["logger"] == "flowapi.access"
-    assert log_lines[2]["logger"] == "flowapi.access"
-    assert "CLAIMS_VERIFICATION_FAILED" == log_lines[2]["event"]
-    assert "test" == log_lines[0]["user"]
-    assert "test" == log_lines[1]["user"]
-    assert "test" == log_lines[2]["user"]
-    assert log_lines[0]["request_id"] == log_lines[1]["request_id"]
+    access_logs = app.log_capture().access
+    assert 3 == len(access_logs)  # One access log, two query logs
+    assert "CLAIMS_VERIFICATION_FAILED" == access_logs[2]["event"]
+    assert "test" == access_logs[0]["user"]
+    assert "test" == access_logs[1]["user"]
+    assert "test" == access_logs[2]["user"]
+    assert access_logs[0]["request_id"] == access_logs[1]["request_id"]
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("query_kind", query_kinds)
 async def test_access_logs_post(
-    query_kind, app, access_token_builder, dummy_zmq_server, json_log
+    query_kind, app, access_token_builder, dummy_zmq_server
 ):
     """
     Test that access logs are written for attempted unauthorized access to 'run' route.
 
     """
-    client, db, log_dir, app = app
     token = access_token_builder(
         {query_kind: {"permissions": {}, "spatial_aggregation": []}}
     )
-    response = await client.post(
+    response = await app.client.post(
         f"/api/0/run",
         headers={"Authorization": f"Bearer {token}"},
         json={"query_kind": query_kind, "aggregation_unit": "admin3"},
     )
     assert 403 == response.status_code
 
-    log_lines = json_log().out
+    log_lines = app.log_capture().access
     assert 3 == len(log_lines)  # One access log, two query logs
-    assert log_lines[0]["logger"] == "flowapi.access"
-    assert log_lines[1]["logger"] == "flowapi.access"
-    assert log_lines[2]["logger"] == "flowapi.access"
     assert log_lines[2]["json_payload"]["query_kind"] == query_kind
     assert "CLAIMS_VERIFICATION_FAILED" == log_lines[2]["event"]
     assert "test" == log_lines[0]["user"]
@@ -365,7 +351,6 @@ async def test_no_joined_aggregate_result_access_without_both_claims(
     units of _both_ is required for joined_spatial_aggregate.
     """
 
-    client, db, log_dir, app = app
     token = access_token_builder(
         {
             "DUMMY_METRIC_QUERY_KIND": metric_claims,
@@ -394,7 +379,7 @@ async def test_no_joined_aggregate_result_access_without_both_claims(
             "payload": {"query_id": "DUMMY_QUERY_ID", "sql": "SELECT 1;"},
         },
     )
-    response = await client.get(
+    response = await app.client.get(
         f"/api/0/get/DUMMY_QUERY_ID", headers={"Authorization": f"Bearer {token}"}
     )
     assert response.status_code == expected_status_code

--- a/flowapi/tests/unit/test_access_logging.py
+++ b/flowapi/tests/unit/test_access_logging.py
@@ -22,7 +22,7 @@ async def test_invalid_token(app):
     Parameters
     ----------
     app: tuple
-        Pytest fixture providing the flowapi, with a mock for the db
+        Pytest fixture providing the flowapi app
     """
 
     await app.client.get("/")  # Need to trigger setup
@@ -45,7 +45,7 @@ async def test_expired_token(app):
     Parameters
     ----------
     app: tuple
-        Pytest fixture providing the flowapi, with a mock for the db
+        Pytest fixture providing the flowapi app
     """
 
     await app.client.get("/")  # Need to trigger setup
@@ -83,7 +83,7 @@ async def test_claims_verify_fail(app):
     Parameters
     ----------
     app: tuple
-        Pytest fixture providing the flowapi, with a mock for the db
+        Pytest fixture providing the flowapi app
     """
 
     await app.client.get("/")  # Need to trigger setup
@@ -106,7 +106,7 @@ async def test_revoked_token(app):
     Parameters
     ----------
     app: tuple
-        Pytest fixture providing the flowapi, with a mock for the db
+        Pytest fixture providing the flowapi app
     """
 
     await app.client.get("/")  # Need to trigger setup

--- a/flowapi/tests/unit/test_list_queries.py
+++ b/flowapi/tests/unit/test_list_queries.py
@@ -8,11 +8,10 @@ import pytest
 @pytest.mark.asyncio
 async def test_unknown_query_type(app, dummy_zmq_server, access_token_builder):
     """Test that a query type which doesn't exist returns a 404."""
-    client, db, log_dir, app = app
 
     token = access_token_builder({"read_queries": ["nosuchquery"]})
     dummy_zmq_server.return_value = {"status": "awol", "query_kind": "nosuchquery"}
-    response = await client.get(
+    response = await app.client.get(
         f"/api/0/nosuchquery", headers={"Authorization": f"Bearer {token}"}
     )
     assert 404 == response.status_code

--- a/flowapi/tests/unit/test_main.py
+++ b/flowapi/tests/unit/test_main.py
@@ -13,7 +13,7 @@ async def test_app(app):
     Parameters
     ----------
     app: tuple
-        Pytest fixture providing the flowapi, with a mock for the db
+        Pytest fixture providing the flowapi app
     """
 
     response = await app.client.get("/")

--- a/flowapi/tests/unit/test_main.py
+++ b/flowapi/tests/unit/test_main.py
@@ -15,7 +15,6 @@ async def test_app(app):
     app: tuple
         Pytest fixture providing the flowapi, with a mock for the db
     """
-    client, db, log_dir, app = app
 
-    response = await client.get("/")
+    response = await app.client.get("/")
     assert response.status_code == 200

--- a/flowapi/tests/unit/test_poll_query.py
+++ b/flowapi/tests/unit/test_poll_query.py
@@ -13,7 +13,6 @@ async def test_poll_bad_query(app, access_token_builder, dummy_zmq_server):
     """
     Test that correct status code and any redirect is returned when polling a running query
     """
-    client, db, log_dir, app = app
 
     token = access_token_builder(
         {
@@ -31,7 +30,7 @@ async def test_poll_bad_query(app, access_token_builder, dummy_zmq_server):
             payload={"query_id": "DUMMY_QUERY_ID", "query_state": "awol"},
         )
     )
-    response = await client.get(
+    response = await app.client.get(
         f"/api/0/poll/DUMMY_QUERY_ID", headers={"Authorization": f"Bearer {token}"}
     )
     assert response.status_code == 404
@@ -55,7 +54,6 @@ async def test_poll_query(
     """
     Test that correct status code and any redirect is returned when polling a running query
     """
-    client, db, log_dir, app = app
 
     token = access_token_builder(
         {
@@ -89,7 +87,7 @@ async def test_poll_query(
             payload={"query_id": "DUMMY_QUERY_ID", "query_state": query_state},
         ),
     )
-    response = await client.get(
+    response = await app.client.get(
         f"/api/0/poll/DUMMY_QUERY_ID", headers={"Authorization": f"Bearer {token}"}
     )
     assert response.status_code == http_code
@@ -102,7 +100,6 @@ async def test_poll_query_query_error(app, access_token_builder, dummy_zmq_serve
     """
     Test that correct status code and any redirect is returned when polling a query that errored
     """
-    client, db, log_dir, app = app
 
     token = access_token_builder({"modal_location": {"permissions": {"poll": True}}})
 
@@ -117,7 +114,7 @@ async def test_poll_query_query_error(app, access_token_builder, dummy_zmq_serve
             payload={"query_id": "DUMMY_QUERY_ID", "query_state": "error"},
         ),
     )
-    response = await client.get(
+    response = await app.client.get(
         f"/api/0/poll/DUMMY_QUERY_ID", headers={"Authorization": f"Bearer {token}"}
     )
     assert response.status_code == 500

--- a/flowapi/tests/unit/test_run_query.py
+++ b/flowapi/tests/unit/test_run_query.py
@@ -12,7 +12,6 @@ async def test_post_query(app, dummy_zmq_server, access_token_builder):
     """
     Test that correct status of 202 & redirect is returned when sending a query.
     """
-    client, db, log_dir, app = app
 
     token = access_token_builder(
         {
@@ -25,7 +24,7 @@ async def test_post_query(app, dummy_zmq_server, access_token_builder):
     dummy_zmq_server.return_value = ZMQReply(
         status="success", payload={"query_id": "DUMMY_QUERY_ID"}
     )
-    response = await client.post(
+    response = await app.client.post(
         f"/api/0/run",
         headers={"Authorization": f"Bearer {token}"},
         json={
@@ -92,11 +91,10 @@ async def test_post_query_error(
     """
     Test that correct status of 400 is returned for a broken query.
     """
-    client, db, log_dir, app = app
 
     token = access_token_builder({"daily_location": {"permissions": {"run": True}}})
     dummy_zmq_server.return_value = ZMQReply(status="error", msg="Broken query")
-    response = await client.post(
+    response = await app.client.post(
         f"/api/0/run", headers={"Authorization": f"Bearer {token}"}, json=query
     )
     json = await response.get_json()

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -35,7 +35,6 @@ import structlog
 logger = structlog.get_logger("flowmachine.debug", submodule=__name__)
 
 
-@profile
 def write_query_to_cache(
     *,
     name: str,
@@ -141,7 +140,6 @@ def write_query_to_cache(
         raise StoreFailedException(query.md5)
 
 
-@profile
 def write_cache_metadata(
     connection: "Connection", query: "Query", compute_time: Optional[float] = None
 ):

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -196,7 +196,6 @@ def write_cache_metadata(
                 ),
             )
             con.execute("SELECT touch_cache(%s);", query.md5)
-            con.execute("SELECT pg_notify(%s, 'Done.')", query.md5)
             logger.debug("{} added to cache.".format(query.fully_qualified_table_name))
             if not in_cache:
                 for dep in query._get_stored_dependencies(exclude_self=True):

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -194,13 +194,16 @@ def write_cache_metadata(
                 ),
             )
             con.execute("SELECT touch_cache(%s);", query.md5)
-            logger.debug("{} added to cache.".format(query.fully_qualified_table_name))
+
             if not in_cache:
                 for dep in query._get_stored_dependencies(exclude_self=True):
                     con.execute(
                         "INSERT INTO cache.dependencies values (%s, %s) ON CONFLICT DO NOTHING",
                         (query.md5, dep.md5),
                     )
+                logger.debug(f"{query.fully_qualified_table_name} added to cache.")
+            else:
+                logger.debug(f"Touched cache for {query.fully_qualified_table_name}.")
     except NotImplementedError:
         logger.debug("Table has no standard name.")
 

--- a/flowmachine/flowmachine/core/connection.py
+++ b/flowmachine/flowmachine/core/connection.py
@@ -275,9 +275,6 @@ class Connection:
             if x.isnumeric()
         )
 
-    @cached(
-        TTLCache(1024, 120)
-    )  # Many dates to cache, two minutes seems reasonable to balance db access against speed boost
     def has_date(self, date, table, strictness=2, schema="events"):
         """
         Check against the database tables with varying strictness whether there

--- a/flowmachine/flowmachine/core/init.py
+++ b/flowmachine/flowmachine/core/init.py
@@ -11,7 +11,6 @@ From a developer perspective, this is where one-time operations
 should live - for example configuring loggers.
 """
 
-import os
 import redis
 import structlog
 import warnings

--- a/flowmachine/flowmachine/core/init.py
+++ b/flowmachine/flowmachine/core/init.py
@@ -153,6 +153,7 @@ def connect(
             host=redis_host, port=redis_port, password=redis_password
         )
         _start_threadpool(thread_pool_size=flowdb_connection_pool_size)
+        conn.available_dates(table="all", strictness=1, schema="events")
 
         print(f"FlowMachine version: {flowmachine.__version__}")
 

--- a/flowmachine/flowmachine/core/query_state.py
+++ b/flowmachine/flowmachine/core/query_state.py
@@ -102,38 +102,40 @@ class QueryStateMachine:
     def __init__(self, redis_client: StrictRedis, query_id: str):
         self.redis_client = redis_client
         self.query_id = query_id
+        must_populate = redis_client.get(f"finist:{query_id}-state") is None
         self.state_machine = Finist(redis_client, f"{query_id}-state", QueryState.KNOWN)
-        self.state_machine.on(QueryEvent.QUEUE, QueryState.KNOWN, QueryState.QUEUED)
-        self.state_machine.on(
-            QueryEvent.EXECUTE, QueryState.QUEUED, QueryState.EXECUTING
-        )
-        self.state_machine.on(
-            QueryEvent.ERROR, QueryState.EXECUTING, QueryState.ERRORED
-        )
-        self.state_machine.on(
-            QueryEvent.FINISH, QueryState.EXECUTING, QueryState.COMPLETED
-        )
-        self.state_machine.on(
-            QueryEvent.CANCEL, QueryState.QUEUED, QueryState.CANCELLED
-        )
-        self.state_machine.on(
-            QueryEvent.CANCEL, QueryState.EXECUTING, QueryState.CANCELLED
-        )
-        self.state_machine.on(
-            QueryEvent.RESET, QueryState.CANCELLED, QueryState.RESETTING
-        )
-        self.state_machine.on(
-            QueryEvent.RESET, QueryState.ERRORED, QueryState.RESETTING
-        )
-        self.state_machine.on(
-            QueryEvent.RESET, QueryState.COMPLETED, QueryState.RESETTING
-        )
-        self.state_machine.on(
-            QueryEvent.RESET, QueryState.COMPLETED, QueryState.RESETTING
-        )
-        self.state_machine.on(
-            QueryEvent.FINISH_RESET, QueryState.RESETTING, QueryState.KNOWN
-        )
+        if must_populate:  # Need to create the state machine for this query
+            self.state_machine.on(QueryEvent.QUEUE, QueryState.KNOWN, QueryState.QUEUED)
+            self.state_machine.on(
+                QueryEvent.EXECUTE, QueryState.QUEUED, QueryState.EXECUTING
+            )
+            self.state_machine.on(
+                QueryEvent.ERROR, QueryState.EXECUTING, QueryState.ERRORED
+            )
+            self.state_machine.on(
+                QueryEvent.FINISH, QueryState.EXECUTING, QueryState.COMPLETED
+            )
+            self.state_machine.on(
+                QueryEvent.CANCEL, QueryState.QUEUED, QueryState.CANCELLED
+            )
+            self.state_machine.on(
+                QueryEvent.CANCEL, QueryState.EXECUTING, QueryState.CANCELLED
+            )
+            self.state_machine.on(
+                QueryEvent.RESET, QueryState.CANCELLED, QueryState.RESETTING
+            )
+            self.state_machine.on(
+                QueryEvent.RESET, QueryState.ERRORED, QueryState.RESETTING
+            )
+            self.state_machine.on(
+                QueryEvent.RESET, QueryState.COMPLETED, QueryState.RESETTING
+            )
+            self.state_machine.on(
+                QueryEvent.RESET, QueryState.COMPLETED, QueryState.RESETTING
+            )
+            self.state_machine.on(
+                QueryEvent.FINISH_RESET, QueryState.RESETTING, QueryState.KNOWN
+            )
 
     @property
     def current_query_state(self) -> QueryState:

--- a/flowmachine/flowmachine/core/server/server.py
+++ b/flowmachine/flowmachine/core/server/server.py
@@ -76,7 +76,7 @@ async def update_available_dates(
     return avail
 
 
-async def get_reply_for_message(msg_str: str) -> ZMQReply:
+def get_reply_for_message(msg_str: str) -> ZMQReply:
     """
     Parse the zmq message string, perform the desired action and return the result in JSON format.
 
@@ -101,7 +101,7 @@ async def get_reply_for_message(msg_str: str) -> ZMQReply:
             params=action_request.params,
         )
 
-        reply = await perform_action(action_request.action, action_request.params)
+        reply = perform_action(action_request.action, action_request.params)
 
         query_run_log.info(
             f"Action completed with status: '{reply.status}'",
@@ -203,7 +203,7 @@ async def calculate_and_send_reply_for_message(socket, return_address, msg_conte
         JSON string with the message contents.
     """
     try:
-        reply_json = await get_reply_for_message(msg_contents)
+        reply_json = get_reply_for_message(msg_contents)
     except Exception as exc:
         # Catch and log any unhandled errors, and send a generic error response to the API
         # TODO: Ensure that FlowAPI always returns the correct error code when receiving an error reply

--- a/flowmachine/flowmachine/core/server/server.py
+++ b/flowmachine/flowmachine/core/server/server.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import os
+from concurrent.futures import Executor
 from json import JSONDecodeError
 import traceback
 
@@ -19,6 +20,7 @@ from marshmallow import ValidationError
 from zmq.asyncio import Context
 
 import flowmachine
+from flowmachine.core import Query, Connection
 from flowmachine.utils import convert_dict_keys_to_strings
 from .exceptions import FlowmachineServerError
 from .zmq_helpers import ZMQReply
@@ -29,7 +31,52 @@ logger = structlog.get_logger("flowmachine.debug", submodule=__name__)
 query_run_log = structlog.get_logger("flowmachine.query_run_log")
 
 
-def get_reply_for_message(msg_str: str) -> ZMQReply:
+async def update_available_dates(
+    *,
+    flowdb_connection: Connection,
+    pool: Executor,
+    sleep_time: int = 1800,
+    loop: bool = True,
+) -> None:
+    """
+    Background task to periodically refresh the cache entries for available dates
+    based on the content of the database.
+
+    Parameters
+    ----------
+    flowdb_connection : Connection
+        Flowdb connection to check dates on
+    pool : Executor
+        Executor to run the date check with
+    sleep_time : int, default 1800
+        Number of seconds to sleep for between checks
+    loop : bool, default True
+        Set to false to return after the first check
+
+    Returns
+    -------
+    None
+
+    """
+    check_func = partial(
+        flowdb_connection.available_dates.__wrapped__,
+        flowdb_connection,
+        table="all",
+        strictness=1,
+        schema="events",
+    )
+    while True:
+        logger.debug("Checking available dates.")
+        avail = await asyncio.get_running_loop().run_in_executor(
+            pool, check_func
+        )  # Note we're calling the uncached version here.
+        if not loop:
+            break
+        await asyncio.sleep(sleep_time)
+    return avail
+
+
+async def get_reply_for_message(msg_str: str) -> ZMQReply:
     """
     Parse the zmq message string, perform the desired action and return the result in JSON format.
 
@@ -54,7 +101,7 @@ def get_reply_for_message(msg_str: str) -> ZMQReply:
             params=action_request.params,
         )
 
-        reply = perform_action(action_request.action, action_request.params)
+        reply = await perform_action(action_request.action, action_request.params)
 
         query_run_log.info(
             f"Action completed with status: '{reply.status}'",
@@ -156,7 +203,7 @@ async def calculate_and_send_reply_for_message(socket, return_address, msg_conte
         JSON string with the message contents.
     """
     try:
-        reply_json = get_reply_for_message(msg_contents)
+        reply_json = await get_reply_for_message(msg_contents)
     except Exception as exc:
         # Catch and log any unhandled errors, and send a generic error response to the API
         # TODO: Ensure that FlowAPI always returns the correct error code when receiving an error reply
@@ -184,7 +231,7 @@ def shutdown(socket):
     logger.debug("Cancelled all remaining tasks.")
 
 
-async def recv(port):
+async def recv(*, port, flowdb_connection):
     """
     Main receive-and-reply loop. Listens to zmq messages on the given port,
     processes them and sends back a reply with the result or an error message.
@@ -199,6 +246,11 @@ async def recv(port):
     main_loop = asyncio.get_event_loop()
     main_loop.add_signal_handler(signal.SIGTERM, partial(shutdown, socket=socket))
 
+    main_loop.create_task(
+        update_available_dates(
+            flowdb_connection=flowdb_connection, pool=Query.thread_pool_executor
+        )
+    )
     try:
         while True:
             await receive_next_zmq_message_and_send_back_reply(socket)
@@ -213,7 +265,7 @@ async def recv(port):
 
 def main():
     # Set up internals and connect to flowdb
-    flowmachine.connect()
+    flowdb_connection = flowmachine.connect()
 
     # Set debug mode if required
     debug_mode = "true" == os.getenv("FLOWMACHINE_SERVER_DEBUG_MODE", "false").lower()
@@ -223,7 +275,7 @@ def main():
     # Run receive loop which receives zmq messages and sends back replies
     port = os.getenv("FLOWMACHINE_PORT", 5555)
     asyncio.run(
-        recv(port), debug=debug_mode
+        recv(port=port, flowdb_connection=flowdb_connection), debug=debug_mode
     )  # note: asyncio.run() requires Python 3.7+
 
 

--- a/flowmachine/flowmachine/core/table.py
+++ b/flowmachine/flowmachine/core/table.py
@@ -7,7 +7,6 @@
 Simple utility class that represents arbitrary tables in the
 database.
 """
-
 from typing import List
 
 from flowmachine.core.query_state import QueryStateMachine

--- a/flowmachine/flowmachine/core/table.py
+++ b/flowmachine/flowmachine/core/table.py
@@ -119,10 +119,11 @@ class Table(Query):
         super().__init__()
         # Table is immediately in a 'finished executing' state
         q_state_machine = QueryStateMachine(self.redis, self.md5)
-        q_state_machine.enqueue()
-        q_state_machine.execute()
-        write_cache_metadata(self.connection, self, compute_time=0)
-        q_state_machine.finish()
+        if not q_state_machine.is_completed:
+            q_state_machine.enqueue()
+            q_state_machine.execute()
+            write_cache_metadata(self.connection, self, compute_time=0)
+            q_state_machine.finish()
 
     def __format__(self, fmt):
         return f"<Table: '{self.schema}.{self.name}', query_id: '{self.md5}'>"

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -18,7 +18,7 @@ from approvaltests.reporters.generic_diff_reporter_factory import (
 )
 
 import flowmachine
-from flowmachine.core import Query, make_spatial_unit
+from flowmachine.core import Query, make_spatial_unit, Connection
 from flowmachine.core.cache import reset_cache
 from flowmachine.features import EventTableSubset
 
@@ -142,13 +142,14 @@ def mocked_connections(monkeypatch):
         Mocks for init_logging, Connection, StrictRedis and _start_threadpool
 
     """
+
     logging_mock = Mock()
-    connection_mock = Mock(return_value=None)
+    connection_mock = Mock(spec=Connection)
     redis_mock = Mock()
     tp_mock = Mock()
     monkeypatch.delattr("flowmachine.core.query.Query.connection", raising=False)
     monkeypatch.setattr(flowmachine.core.init, "set_log_level", logging_mock)
-    monkeypatch.setattr(flowmachine.core.Connection, "__init__", connection_mock)
+    monkeypatch.setattr(flowmachine.core.init, "Connection", connection_mock)
     monkeypatch.setattr("redis.StrictRedis", redis_mock)
     monkeypatch.setattr(flowmachine.core.init, "_start_threadpool", tp_mock)
     yield logging_mock, connection_mock, redis_mock, tp_mock

--- a/flowmachine/tests/test_update_available_dates.py
+++ b/flowmachine/tests/test_update_available_dates.py
@@ -1,0 +1,23 @@
+import asyncio
+
+import pytest
+
+from flowmachine.core import Query, Table
+from flowmachine.core.cache import reset_cache
+from flowmachine.core.server.server import update_available_dates
+
+
+@pytest.mark.asyncio
+async def test_available_dates_updates(flowmachine_connect):
+    reset_cache(flowmachine_connect, Query.redis, protect_table_objects=False)
+    assert len(list(Table.get_stored())) == 0
+    task = asyncio.create_task(
+        update_available_dates(
+            flowdb_connection=flowmachine_connect,
+            pool=Query.thread_pool_executor,
+            sleep_time=100,
+            loop=False,
+        )
+    )
+    avail = await task
+    assert len(list(Table.get_stored())) == 15

--- a/flowmachine/tests/test_update_available_dates.py
+++ b/flowmachine/tests/test_update_available_dates.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import asyncio
 
 import pytest
@@ -9,6 +13,10 @@ from flowmachine.core.server.server import update_available_dates
 
 @pytest.mark.asyncio
 async def test_available_dates_updates(flowmachine_connect):
+    """
+    Test the looping async task which updates the available dates on a loop
+    as part of the server process.
+    """
     reset_cache(flowmachine_connect, Query.redis, protect_table_objects=False)
     assert len(list(Table.get_stored())) == 0
     task = asyncio.create_task(


### PR DESCRIPTION
Towards #1256 but doesn't _solve_ it.

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [x] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Several small tweaks which speed up creating query objects.

- Runs `available_dates` when first connecting to FlowDB to pre-create `Table` objects
- Runs `available_dates` periodically as a background thread in the server to keep that fresh
- Skips creating the state machine transitions if the state machine already exists
- Skips fast forwarding `Table` state machines if they're already complete
- Skips dumping a pickle if the object is already in cache
- Removes an inline import of `__version__` in `write_cache_metadata` - originally necessary to avoid a circular import, but not now
- Removes a call to `pg_notify` that isn't used