### PR TITLE
More useful test output for flowmachine tests, more durations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,7 @@ jobs:
                       --cov flowmachine/ \
                       --cov-report xml \
                       --cov-report term \
-                      --durations=10
+                      --durations=50
       - store_test_results:
           path: test_results
       - run:

--- a/flowdb/tests/conftest.py
+++ b/flowdb/tests/conftest.py
@@ -27,38 +27,15 @@ def pytest_configure(config):
     )
 
 
-def get_string_with_test_parameter_values(item):
-    """
-    If `item` corresponds to a parametrized pytest test, return a string
-    containing the parameter values. Otherwise return an empty string.
-    """
-    if "parametrize" in item.keywords:
-        m = re.search(
-            "(\[[^\]]*\])$", item.name
-        )  # retrieve text in square brackets at the end of the item's name
-        if m:
-            param_values_str = f" {m.group(1)}"
-        else:
-            warnings.warn(
-                f"Test is parametrized but could not extract parameter values from name: '{item.name}'"
-            )
-    else:
-        param_values_str = ""
-
-    return param_values_str
-
-
 def pytest_itemcollected(item):
     """
     Custom hook which improves stdout logging from from pytest's default.
 
     Instead of just printing the filename and no description of the test
-    (as would be the default) it prints the docstring as the description
-    and also adds info about any parameters (if the test is parametrized).
+    (as would be the default) it also prints the docstring.
     """
     if item.obj.__doc__:
-        item._nodeid = "* " + " ".join(item.obj.__doc__.split())
-        item._nodeid += get_string_with_test_parameter_values(item)
+        item._nodeid = f'{item._nodeid} ({" ".join(item.obj.__doc__.split())})'
 
 
 class DBConn:

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -68,34 +68,12 @@ def exemplar_spatial_unit_param(request):
     yield make_spatial_unit(**request.param)
 
 
-def get_string_with_test_parameter_values(item):
-    """
-    If `item` corresponds to a parametrized pytest test, return a string
-    containing the parameter values. Otherwise return an empty string.
-    """
-    if "parametrize" in item.keywords:
-        m = re.search(
-            "(\[.*\])$", item.name
-        )  # retrieve text in square brackets at the end of the item's name
-        if m:
-            param_values_str = f" {m.group(1)}"
-        else:
-            raise RuntimeError(
-                f"Test is parametrized but could not extract parameter values from name: '{item.name}'"
-            )
-    else:
-        param_values_str = ""
-
-    return param_values_str
-
-
 def pytest_itemcollected(item):
     """
     Custom hook which improves stdout logging from from pytest's default.
 
     Instead of just printing the filename and no description of the test
-    (as would be the default) it prints the docstring as the description
-    and also adds info about any parameters (if the test is parametrized).
+    (as would be the default) it also prints the docstring.
     """
     if item.obj.__doc__:
         item._nodeid = f'{item._nodeid} ({" ".join(item.obj.__doc__.split())})'

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -98,8 +98,7 @@ def pytest_itemcollected(item):
     and also adds info about any parameters (if the test is parametrized).
     """
     if item.obj.__doc__:
-        item._nodeid = "* " + " ".join(item.obj.__doc__.split())
-        item._nodeid += get_string_with_test_parameter_values(item)
+        item._nodeid = f'{item._nodeid} ({" ".join(item.obj.__doc__.split())})'
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Changes the flowmachine test output to make it easier to find _which_ test actually failed, and increases the number of longest test durations shown.