### PR TITLE
Remove blocking call from DistanceCounterparts init

### DIFF
--- a/flowmachine/flowmachine/features/subscriber/distance_counterparts.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_counterparts.py
@@ -103,7 +103,7 @@ class DistanceCounterparts(SubscriberFeature):
             subscriber_identifier="msisdn",
             hours=hours,
             subscriber_subset=subscriber_subset,
-        ).get_query()
+        )
 
         self.unioned_to_query = EventsTablesUnion(
             self.start,
@@ -113,7 +113,7 @@ class DistanceCounterparts(SubscriberFeature):
             subscriber_identifier="msisdn_counterpart",
             hours=hours,
             subscriber_subset=subscriber_subset,
-        ).get_query()
+        )
 
         self.distance_matrix = DistanceMatrix()
 
@@ -141,8 +141,8 @@ class DistanceCounterparts(SubscriberFeature):
         FROM
             (
                 SELECT A.subscriber, A.location_id AS location_id_from, B.location_id AS location_id_to FROM
-                ({self.unioned_from_query}) AS A
-                JOIN ({self.unioned_to_query}) AS B
+                ({self.unioned_from_query.get_query()}) AS A
+                JOIN ({self.unioned_to_query.get_query()}) AS B
                 ON A.id = B.id AND A.outgoing != B.outgoing {on_filters}
             ) U
         JOIN

--- a/flowmachine/flowmachine/features/subscriber/interevent_period.py
+++ b/flowmachine/flowmachine/features/subscriber/interevent_period.py
@@ -110,7 +110,7 @@ class IntereventPeriod(SubscriberFeature):
         sql = f"""
         SELECT
             subscriber,
-            EXTRACT(epoch FROM value/{self.time_divisor}) AS value
+            FLOOR(EXTRACT(epoch FROM value)/{self.time_divisor}) AS value
         FROM ({self.event_interval.get_query()}) AS U
         """
 


### PR DESCRIPTION
Closes #1280

Removes some calls to `get_query()` in the `__init__` method of `DistanceCounterparts` which should be in `_make_query` to avoid blocking in the constructor.