### PR TITLE
Fix interevent test fails

### DIFF
--- a/flowmachine/tests/test_subscriber_distance_counterparts.py
+++ b/flowmachine/tests/test_subscriber_distance_counterparts.py
@@ -71,19 +71,19 @@ def test_distance_counterparts(get_dataframe, distance_counterparts_wanted):
     """
     query = DistanceCounterparts("2016-01-01", "2016-01-07")
     df = get_dataframe(query).set_index("subscriber")
-    got = df.sample(n=5)
+    got = df.head(n=5)
     want = distance_counterparts_wanted("2016-01-01", "2016-01-07", "both", got).mean()
     assert got.distance_avg.to_dict() == pytest.approx(want.distance.to_dict())
 
     query = DistanceCounterparts("2016-01-01", "2016-01-07", direction="out")
     df = get_dataframe(query).set_index("subscriber")
-    got = df.sample(n=5)
+    got = df.head(n=5)
     want = distance_counterparts_wanted("2016-01-01", "2016-01-07", "out", got).mean()
     assert got.distance_avg.to_dict() == pytest.approx(want.distance.to_dict())
 
     query = DistanceCounterparts("2016-01-03", "2016-01-05", direction="in")
     df = get_dataframe(query).set_index("subscriber")
-    got = df.sample(n=5)
+    got = df.head(n=5)
     want = distance_counterparts_wanted("2016-01-03", "2016-01-05", "in", got).mean()
     assert got.distance_avg.to_dict() == pytest.approx(want.distance.to_dict())
 
@@ -91,12 +91,12 @@ def test_distance_counterparts(get_dataframe, distance_counterparts_wanted):
         "2016-01-03", "2016-01-05", direction="in", subscriber_subset=got.index.values
     )
     df = get_dataframe(query).set_index("subscriber")
-    got = df.sample(n=5)
+    got = df.head(n=5)
     want = distance_counterparts_wanted("2016-01-03", "2016-01-05", "in", got).mean()
     assert got.distance_avg.to_dict() == pytest.approx(want.distance.to_dict())
 
     query = DistanceCounterparts("2016-01-01", "2016-01-05", statistic="stddev")
     df = get_dataframe(query).set_index("subscriber")
-    got = df.sample(n=5)
+    got = df.head(n=5)
     want = distance_counterparts_wanted("2016-01-01", "2016-01-05", "both", got).std()
     assert got.distance_stddev.to_dict() == pytest.approx(want.distance.to_dict())

--- a/flowmachine/tests/test_subscriber_interevent_gap.py
+++ b/flowmachine/tests/test_subscriber_interevent_gap.py
@@ -66,7 +66,7 @@ def test_interevent_period(
         time_resolution="second",
     )
     df = get_dataframe(query).set_index("subscriber")
-    sample = df.sample(n=5)
+    sample = df.head(n=5)
     want = intervent_period(
         start=start, stop=stop, direction=direction, stat=stat, subset=sample
     )
@@ -94,7 +94,7 @@ def test_interevent_interval(
         start=start, stop=stop, direction=direction, statistic=stat
     )
     df = get_dataframe(query).set_index("subscriber")
-    sample = df.sample(n=5)
+    sample = df.head(n=5)
     want = intervent_period(
         start=start, stop=stop, direction=direction, stat=stat, subset=sample
     )

--- a/flowmachine/tests/test_subscriber_interevent_gap.py
+++ b/flowmachine/tests/test_subscriber_interevent_gap.py
@@ -71,7 +71,7 @@ def test_interevent_period(
         start=start, stop=stop, direction=direction, stat=stat, subset=sample
     )
     assert query.column_names == ["subscriber", "value"]
-    assert (sample["value"]).to_dict() == pytest.approx(want)
+    assert (sample["value"]).to_dict() == pytest.approx(want, nan_ok=True)
 
 
 @pytest.mark.parametrize(
@@ -99,7 +99,9 @@ def test_interevent_interval(
         start=start, stop=stop, direction=direction, stat=stat, subset=sample
     )
     assert query.column_names == ["subscriber", "value"]
-    assert (sample["value"].astype("timedelta64[s]")).to_dict() == pytest.approx(want)
+    assert (sample["value"].astype("timedelta64[s]")).to_dict() == pytest.approx(
+        want, nan_ok=True
+    )
 
 
 @pytest.mark.parametrize("kwarg", ["direction", "statistic"])


### PR DESCRIPTION
The interevent_x tests are failing occasionally - turns out this is because you sometimes get a nan value, which doesn't compare equal to nan with pytest.approx unless you explicitly tell it to.