### PR TITLE
Run servers separately in CI docs build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -746,6 +746,14 @@ jobs:
             sudo dpkg -i pandoc-1.19.2.1-1-amd64.deb
       - run: pipenv install
       - run: *wait_for_flowdb
+      - run:
+          name: Start flowmachine
+          command: FLOWMACHINE_LOG_LEVEL=debug pipenv run flowmachine
+          background: true
+      - run:
+          name: Start flowapi
+          command: FLOWAPI_LOG_LEVEL=debug pipenv run hypercorn --bind 0.0.0.0:9090 "flowapi.main:create_app()"
+          background: true
       - when:
           condition: << parameters.deploy >>
           steps:

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -31,20 +31,20 @@ trap TrapQuit EXIT
 if [ "$CI" != "true" ]; then
     (pushd .. && make down && make up && popd)
     echo "Waiting for flowdb to be ready"
-    docker exec flowdb_synthetic_data bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done'
+    pipenv install
+    docker exec flowdb bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done'
+    echo "Finished pre-caching queries"
+    pipenv run flowmachine &
+    echo "Started FlowMachine."
+    pipenv run hypercorn --bind 0.0.0.0:9090 "flowapi.main:create_app()"
+    echo "Started FlowAPI."
+    sleep 5
 fi
 
-pipenv install
 echo "Pre-caching FlowMachine queries..."
 FLOWMACHINE_LOG_LEVEL=debug pipenv run python cache_queries.py
-echo "Finished pre-caching queries"
-pipenv run flowmachine &
-echo "Started FlowMachine."
-pipenv run quart run --port 9090 &
 echo "Retrieving API spec"
-sleep 5
 curl http://localhost:9090/api/0/spec/openapi-redoc.json -o source/_static/openapi-redoc.json
-echo "Started FlowAPI."
 echo "Starting build."
 
 # Note: the DOCS_BRANCH variable is used by `mkdocs.yml` to pick up the correct git repositories for building API docs


### PR DESCRIPTION
Minor tweaks to the docs build to make the Flowmachine and flowapi servers run in separate background jobs from the actual docs build on CI, to make it easier to get at their logs.