### PR TITLE
Rename .md5 .query_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Flowmachine's default random sampling method is now `random_ids` rather than the non-reproducible `system_rows`. [#1263](https://github.com/Flowminder/FlowKit/issues/1263)
 - `IntereventPeriod` now returns stats over the gap between events in fractional time units, instead of time intervals. [#1265](https://github.com/Flowminder/FlowKit/issues/1265)
 - In the FlowETL deployment example, the external ingestion database is now set up separately from the FlowKit components and connected to FlowDB via a docker overlay network. [#1276](https://github.com/Flowminder/FlowKit/issues/1276)
-- The `md5` attribute of the `Query` class has been renamed to `query_id`.
+- The `md5` attribute of the `Query` class has been renamed to `query_id` [#1288](https://github.com/Flowminder/FlowKit/issues/1288).
+
 
 ### Fixed
 - Quickstart will no longer fail if it has been run previously with a different FlowDB data size and not explicitly shut down. [#900](https://github.com/Flowminder/FlowKit/issues/900)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Flowmachine's default random sampling method is now `random_ids` rather than the non-reproducible `system_rows`. [#1263](https://github.com/Flowminder/FlowKit/issues/1263)
 - `IntereventPeriod` now returns stats over the gap between events in fractional time units, instead of time intervals. [#1265](https://github.com/Flowminder/FlowKit/issues/1265)
 - In the FlowETL deployment example, the external ingestion database is now set up separately from the FlowKit components and connected to FlowDB via a docker overlay network. [#1276](https://github.com/Flowminder/FlowKit/issues/1276)
+- The `md5` attribute of the `Query` class has been renamed to `query_id`.
 
 ### Fixed
 - Quickstart will no longer fail if it has been run previously with a different FlowDB data size and not explicitly shut down. [#900](https://github.com/Flowminder/FlowKit/issues/900)

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -218,7 +218,7 @@ def touch_cache(connection: "Connection", query_id: str) -> float:
     ----------
     connection : Connection
     query_id : str
-        query_id id of the query to touch
+        Unique id of the query to touch
 
     Returns
     -------
@@ -323,7 +323,7 @@ def invalidate_cache_by_id(
     ----------
     connection : Connection
     query_id : str
-        query_id id of the query
+        Unique id of the query
     cascade : bool, default False
         Set to true to remove any queries that depend on the one being removed
 
@@ -346,7 +346,7 @@ def get_query_object_by_id(connection: "Connection", query_id: str) -> "Query":
     ----------
     connection : Connection
     query_id : str
-        query_id id of the query
+        Unique id of the query
 
     Returns
     -------
@@ -604,7 +604,7 @@ def get_compute_time(connection: "Connection", query_id: str) -> float:
     ----------
     connection : "Connection"
     query_id : str
-        query_id identifier of the query
+        Unique id of the query
 
     Returns
     -------
@@ -631,7 +631,7 @@ def get_score(connection: "Connection", query_id: str) -> float:
     ----------
     connection: "Connection"
     query_id : str
-        query_id id of the cached query
+        Unique id of the cached query
 
     Returns
     -------
@@ -659,7 +659,7 @@ def cache_table_exists(connection: "Connection", query_id: str) -> bool:
     ----------
     connection: "Connection"
     query_id : str
-        query_id id of the cached query
+        Unique id of the cached query
 
     Returns
     -------

--- a/flowmachine/flowmachine/core/dummy_query.py
+++ b/flowmachine/flowmachine/core/dummy_query.py
@@ -15,10 +15,10 @@ class DummyQuery(Query):
         self.dummy_param = dummy_param
 
     @property
-    def md5(self):
-        # Prefix the usual md5 hash with 'dummy_query' to make it obvious
+    def query_id(self):
+        # Prefix the usual query_id hash with 'dummy_query' to make it obvious
         # that this is not a regular query.
-        md5_hash = super().md5
+        md5_hash = super().query_id
         return f"dummy_query_{md5_hash}"
 
     def _make_query(self):
@@ -32,7 +32,7 @@ class DummyQuery(Query):
         logger.debug(
             "Storing dummy query by marking the query state as 'finished' (but without actually writing to the database)."
         )
-        q_state_machine = QueryStateMachine(self.redis, self.md5)
+        q_state_machine = QueryStateMachine(self.redis, self.query_id)
         q_state_machine.enqueue()
         q_state_machine.execute()
         q_state_machine.finish()

--- a/flowmachine/flowmachine/core/model_result.py
+++ b/flowmachine/flowmachine/core/model_result.py
@@ -156,14 +156,14 @@ class ModelResult(Query):
 
         def write_model_result(query_ddl_ops: List[str], connection: Engine) -> float:
             self._df.to_sql(name, connection, schema=schema, index=False)
-            QueryStateMachine(self.redis, self.md5).finish()
+            QueryStateMachine(self.redis, self.query_id).finish()
             return self._runtime
 
         current_state, changed_to_queue = QueryStateMachine(
-            self.redis, self.md5
+            self.redis, self.query_id
         ).enqueue()
         logger.debug(
-            f"Attempted to enqueue query '{self.md5}', query state is now {current_state} and change happened {'here and now' if changed_to_queue else 'elsewhere'}."
+            f"Attempted to enqueue query '{self.query_id}', query state is now {current_state} and change happened {'here and now' if changed_to_queue else 'elsewhere'}."
         )
         # name, redis, query, connection, ddl_ops_func, write_func, schema = None, sleep_duration = 1
         store_future = self.thread_pool_executor.submit(

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -62,7 +62,7 @@ class Query(metaclass=ABCMeta):
     _QueryPool = weakref.WeakValueDictionary()
 
     def __init__(self, cache=True):
-        obj = Query._QueryPool.get(self.md5)
+        obj = Query._QueryPool.get(self.query_id)
         if obj is None:
             try:
                 self.connection
@@ -70,12 +70,12 @@ class Query(metaclass=ABCMeta):
                 raise NotConnectedError()
 
             self._cache = cache
-            Query._QueryPool[self.md5] = self
+            Query._QueryPool[self.query_id] = self
         else:
             self.__dict__ = obj.__dict__
 
     @property
-    def md5(self):
+    def query_id(self):
         """
         Generate a uniquely identifying hash of this query,
         based on the parameters of it and the subqueries it is
@@ -84,21 +84,21 @@ class Query(metaclass=ABCMeta):
         Returns
         -------
         str
-            md5 hash string
+            query_id hash string
         """
         try:
             return self._md5
         except:
             dependencies = self.dependencies
             state = self.__getstate__()
-            hashes = sorted([x.md5 for x in dependencies])
+            hashes = sorted([x.query_id for x in dependencies])
             for key, item in sorted(state.items()):
                 if isinstance(item, Query) and item in dependencies:
                     # this item is already included in `hashes`
                     continue
                 elif isinstance(item, list) or isinstance(item, tuple):
                     item = sorted(
-                        item, key=lambda x: x.md5 if isinstance(x, Query) else x
+                        item, key=lambda x: x.query_id if isinstance(x, Query) else x
                     )
                 elif isinstance(item, dict):
                     item = json.dumps(item, sort_keys=True, default=str)
@@ -111,8 +111,6 @@ class Query(metaclass=ABCMeta):
             hashes.sort()
             self._md5 = md5(str(hashes).encode()).hexdigest()
             return self._md5
-
-    query_id = md5  # alias which is more meaningful to users than 'md5'
 
     @abstractmethod
     def _make_query(self):
@@ -230,7 +228,7 @@ class Query(metaclass=ABCMeta):
         flowmachine.core.query_state.QueryState
             The current query state
         """
-        state_machine = QueryStateMachine(self.redis, self.md5)
+        state_machine = QueryStateMachine(self.redis, self.query_id)
         return state_machine.current_query_state
 
     @property
@@ -260,13 +258,13 @@ class Query(metaclass=ABCMeta):
         try:
             table_name = self.fully_qualified_table_name
             schema, name = table_name.split(".")
-            state_machine = QueryStateMachine(self.redis, self.md5)
+            state_machine = QueryStateMachine(self.redis, self.query_id)
             state_machine.wait_until_complete()
             if state_machine.is_completed and self.connection.has_table(
                 schema=schema, name=name
             ):
                 try:
-                    touch_cache(self.connection, self.md5)
+                    touch_cache(self.connection, self.query_id)
                 except ValueError:
                     pass  # Cache record not written yet, which can happen for Models
                     # which will call through to this method from their `_make_query` method while writing metadata.
@@ -589,10 +587,10 @@ class Query(metaclass=ABCMeta):
             return plan_time
 
         current_state, changed_to_queue = QueryStateMachine(
-            self.redis, self.md5
+            self.redis, self.query_id
         ).enqueue()
         logger.debug(
-            f"Attempted to enqueue query '{self.md5}', query state is now {current_state} and change happened {'here and now' if changed_to_queue else 'elsewhere'}."
+            f"Attempted to enqueue query '{self.query_id}', query state is now {current_state} and change happened {'here and now' if changed_to_queue else 'elsewhere'}."
         )
         # name, redis, query, connection, ddl_ops_func, write_func, schema = None, sleep_duration = 1
         store_future = self.thread_pool_executor.submit(
@@ -667,7 +665,7 @@ class Query(metaclass=ABCMeta):
         str
             String form of the table's fqn
         """
-        return f"x{self.md5}"
+        return f"x{self.query_id}"
 
     @property
     def is_stored(self):
@@ -788,7 +786,7 @@ class Query(metaclass=ABCMeta):
         drop : bool
             Set to false to remove the cache record without dropping the table
         """
-        q_state_machine = QueryStateMachine(self.redis, self.md5)
+        q_state_machine = QueryStateMachine(self.redis, self.query_id)
         current_state, this_thread_is_owner = q_state_machine.reset()
         if this_thread_is_owner:
             con = self.connection.engine
@@ -805,12 +803,12 @@ class Query(metaclass=ABCMeta):
                     """SELECT obj FROM cache.cached LEFT JOIN cache.dependencies
                     ON cache.cached.query_id=cache.dependencies.query_id
                     WHERE depends_on='{}'""".format(
-                        self.md5
+                        self.query_id
                     )
                 )
                 with con.begin():
                     con.execute(
-                        "DELETE FROM cache.cached WHERE query_id=%s", (self.md5,)
+                        "DELETE FROM cache.cached WHERE query_id=%s", (self.query_id,)
                     )
                     logger.debug(
                         "Deleted cache record for {}.".format(
@@ -853,12 +851,12 @@ class Query(metaclass=ABCMeta):
             q_state_machine.finish_resetting()
         elif q_state_machine.is_resetting:
             logger.debug(
-                f"Query '{self.md5}' is being reset from elsewhere, waiting for reset to finish."
+                f"Query '{self.query_id}' is being reset from elsewhere, waiting for reset to finish."
             )
             while q_state_machine.is_resetting:
                 _sleep(1)
         if not q_state_machine.is_known:
-            raise QueryResetFailedException(self.md5)
+            raise QueryResetFailedException(self.query_id)
 
     @property
     def index_cols(self):

--- a/flowmachine/flowmachine/core/query_state.py
+++ b/flowmachine/flowmachine/core/query_state.py
@@ -90,7 +90,7 @@ class QueryStateMachine:
     redis_client : StrictRedis
         Client for redis
     query_id : str
-        query_id query identifier
+        Unique query identifier
 
     Notes
     -----

--- a/flowmachine/flowmachine/core/query_state.py
+++ b/flowmachine/flowmachine/core/query_state.py
@@ -90,7 +90,7 @@ class QueryStateMachine:
     redis_client : StrictRedis
         Client for redis
     query_id : str
-        md5 query identifier
+        query_id query identifier
 
     Notes
     -----

--- a/flowmachine/flowmachine/core/random.py
+++ b/flowmachine/flowmachine/core/random.py
@@ -218,7 +218,7 @@ class SeedableRandom(RandomBase, metaclass=ABCMeta):
     def table_name(self) -> str:
         if self.seed is None:
             raise NotImplementedError("Unseeded random samples cannot be stored.")
-        return f"x{self.md5}"
+        return f"x{self.query_id}"
 
 
 class RandomTablesample(SeedableRandom):

--- a/flowmachine/flowmachine/core/server/query_schemas/base_exposed_query.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/base_exposed_query.py
@@ -50,7 +50,7 @@ class BaseExposedQuery(metaclass=ABCMeta):
         q = self._flowmachine_query_obj
         q.store()
 
-        query_id = q.md5
+        query_id = q.query_id
 
         return query_id
 
@@ -61,6 +61,6 @@ class BaseExposedQuery(metaclass=ABCMeta):
         #    return md5(json.dumps(self.query_params, sort_keys=True).encode()).hexdigest()
         #
         # However, the resulting md5 hash is different from the one produced internally
-        # by flowmachine.core.Query.md5, and the latter is currently being used by
+        # by flowmachine.core.Query.query_id, and the latter is currently being used by
         # the QueryStateMachine, so we need to use it to check the query state.
-        return self._flowmachine_query_obj.md5
+        return self._flowmachine_query_obj.query_id

--- a/flowmachine/flowmachine/core/spatial_unit.py
+++ b/flowmachine/flowmachine/core/spatial_unit.py
@@ -294,13 +294,13 @@ class GeomSpatialUnit(SpatialUnitMixin, Query):
 
     def __eq__(self, other):
         try:
-            return self.md5 == other.md5
+            return self.query_id == other.query_id
         except AttributeError:
             return False
 
     def __hash__(self):
         # Must define this because we explicitly define self.__eq__
-        return hash(self.md5)
+        return hash(self.query_id)
 
     def _get_aliased_geom_table_cols(self, table_alias: str) -> List[str]:
         return [f"{table_alias}.{c}" for c in self._geom_table_cols]

--- a/flowmachine/flowmachine/core/subscriber_subsetter.py
+++ b/flowmachine/flowmachine/core/subscriber_subsetter.py
@@ -25,7 +25,7 @@ class SubscriberSubsetterBase:
     """
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} (md5='{self.md5}')>"
+        return f"<{self.__class__.__name__} (query_id='{self.query_id}')>"
 
     @property
     @abstractmethod
@@ -35,12 +35,12 @@ class SubscriberSubsetterBase:
         )
 
     @property
-    def md5(self):
+    def query_id(self):
         try:
             return self._md5
         except AttributeError:
             raise NotImplementedError(
-                f"Class {self.__class__.__name__} does not implement 'md5'"
+                f"Class {self.__class__.__name__} does not implement 'query_id'"
             )
 
     @abstractmethod
@@ -108,7 +108,7 @@ class SubscriberSubsetterForFlowmachineQuery(SubscriberSubsetterBase):
 
         self._verify_that_subscriber_column_is_present(flowmachine_query)
         self.flowmachine_query = flowmachine_query
-        self._md5 = self.flowmachine_query.md5
+        self._md5 = self.flowmachine_query.query_id
         super().__init__()
 
     def _verify_that_subscriber_column_is_present(self, flowmachine_query):

--- a/flowmachine/flowmachine/core/table.py
+++ b/flowmachine/flowmachine/core/table.py
@@ -114,11 +114,11 @@ class Table(Query):
                     )
                 )
 
-        # Record provided columns to ensure that md5 differs with different columns
+        # Record provided columns to ensure that query_id differs with different columns
         self.columns = columns
         super().__init__()
         # Table is immediately in a 'finished executing' state
-        q_state_machine = QueryStateMachine(self.redis, self.md5)
+        q_state_machine = QueryStateMachine(self.redis, self.query_id)
         if not q_state_machine.is_completed:
             q_state_machine.enqueue()
             q_state_machine.execute()
@@ -126,7 +126,7 @@ class Table(Query):
             q_state_machine.finish()
 
     def __format__(self, fmt):
-        return f"<Table: '{self.schema}.{self.name}', query_id: '{self.md5}'>"
+        return f"<Table: '{self.schema}.{self.name}', query_id: '{self.query_id}'>"
 
     @property
     def column_names(self) -> List[str]:
@@ -143,7 +143,7 @@ class Table(Query):
         with self.connection.engine.begin():
             self.connection.engine.execute(
                 "UPDATE cache.cached SET last_accessed = NOW(), access_count = access_count + 1 WHERE query_id ='{}'".format(
-                    self.md5
+                    self.query_id
                 )
             )
         return self._make_query()

--- a/flowmachine/flowmachine/features/utilities/feature_collection.py
+++ b/flowmachine/flowmachine/features/utilities/feature_collection.py
@@ -134,8 +134,8 @@ def _join_queries(queries, dropna):
         append = "_" + q.__class__.__name__.lower() + "_{}".format(i + 2)
         running_join = running_join.join(q, on_left=col, right_append=append, how=how)
         # Trigger memoization
-        _ = q.md5
-        _ = running_join.md5
+        _ = q.query_id
+        _ = running_join.query_id
         _ = running_join.column_names
 
     return running_join

--- a/flowmachine/flowmachine/utils.py
+++ b/flowmachine/flowmachine/utils.py
@@ -347,7 +347,7 @@ def print_dependency_tree(query_obj, show_stored=False, stream=None, indent_leve
     prefix = "" if indent_level == 0 else "- "
     fmt = "query_id" if not show_stored else "query_id,is_stored"
     stream.write(f"{indent}{prefix}{query_obj:{fmt}}\n")
-    deps_sorted_by_query_id = sorted(query_obj.dependencies, key=lambda q: q.md5)
+    deps_sorted_by_query_id = sorted(query_obj.dependencies, key=lambda q: q.query_id)
     for dep in deps_sorted_by_query_id:
         print_dependency_tree(
             dep, indent_level=indent_level + 1, stream=stream, show_stored=show_stored
@@ -457,11 +457,11 @@ def calculate_dependency_graph(query_obj, analyse=False):
         if attrs["stored"]:
             attrs["fillcolor"] = "#b3de69"  # light green
             attrs["style"] = "filled"
-        g.add_node(f"x{n.md5}", **attrs)
+        g.add_node(f"x{n.query_id}", **attrs)
 
     for x, y in deps:
         if x != 0:
-            g.add_edge(*[f"x{z.md5}" for z in (x, y)])
+            g.add_edge(*[f"x{z.query_id}" for z in (x, y)])
 
     return g
 

--- a/flowmachine/tests/test_async.py
+++ b/flowmachine/tests/test_async.py
@@ -64,7 +64,7 @@ def test_get_query_blocks_on_store():
     timer = []
 
     def unlock(timer):
-        qsm = QueryStateMachine(dl.redis, dl.md5)
+        qsm = QueryStateMachine(dl.redis, dl.query_id)
         qsm.enqueue()
         for i in range(101):
             timer.append(i)
@@ -91,7 +91,7 @@ def test_blocks_on_store_cascades():
     timer = []
 
     def unlock(timer):
-        qsm = QueryStateMachine(dl.redis, dl.md5)
+        qsm = QueryStateMachine(dl.redis, dl.query_id)
         qsm.enqueue()
         for i in range(101):
             timer.append(i)

--- a/flowmachine/tests/test_cache.py
+++ b/flowmachine/tests/test_cache.py
@@ -19,10 +19,10 @@ def test_table_records_removed(flowmachine_connect):
     dl.store().result()
     assert dl.is_stored
     table = dl.get_table()
-    assert cache_table_exists(flowmachine_connect, table.md5)
+    assert cache_table_exists(flowmachine_connect, table.query_id)
 
     dl.invalidate_db_cache()
-    assert not cache_table_exists(flowmachine_connect, table.md5)
+    assert not cache_table_exists(flowmachine_connect, table.query_id)
 
 
 def test_do_cache_simple(flowmachine_connect):
@@ -32,7 +32,7 @@ def test_do_cache_simple(flowmachine_connect):
     """
     dl1 = daily_location("2016-01-01")
     write_cache_metadata(flowmachine_connect, dl1)
-    assert cache_table_exists(flowmachine_connect, dl1.md5)
+    assert cache_table_exists(flowmachine_connect, dl1.query_id)
 
 
 def test_do_cache_multi(flowmachine_connect):
@@ -44,7 +44,7 @@ def test_do_cache_multi(flowmachine_connect):
     hl1 = ModalLocation(daily_location("2016-01-01"), daily_location("2016-01-02"))
     write_cache_metadata(flowmachine_connect, hl1)
 
-    assert cache_table_exists(flowmachine_connect, hl1.md5)
+    assert cache_table_exists(flowmachine_connect, hl1.query_id)
 
 
 def test_do_cache_nested(flowmachine_connect):
@@ -57,7 +57,7 @@ def test_do_cache_nested(flowmachine_connect):
     flow = Flows(hl1, hl2)
     write_cache_metadata(flowmachine_connect, flow)
 
-    assert cache_table_exists(flowmachine_connect, flow.md5)
+    assert cache_table_exists(flowmachine_connect, flow.query_id)
 
 
 def test_store_cache_simple(flowmachine_connect):
@@ -70,7 +70,7 @@ def test_store_cache_simple(flowmachine_connect):
     # Should be stored
     assert dl1.is_stored
 
-    assert cache_table_exists(flowmachine_connect, dl1.md5)
+    assert cache_table_exists(flowmachine_connect, dl1.query_id)
 
 
 def test_store_cache_multi(flowmachine_connect):
@@ -83,7 +83,7 @@ def test_store_cache_multi(flowmachine_connect):
     # Should be stored
     assert hl1.is_stored
 
-    assert cache_table_exists(flowmachine_connect, hl1.md5)
+    assert cache_table_exists(flowmachine_connect, hl1.query_id)
 
 
 def test_store_cache_nested(flowmachine_connect):
@@ -97,7 +97,7 @@ def test_store_cache_nested(flowmachine_connect):
     flow.store().result()
     # Should be stored
     assert flow.is_stored
-    assert cache_table_exists(flowmachine_connect, flow.md5)
+    assert cache_table_exists(flowmachine_connect, flow.query_id)
 
 
 def test_invalidate_cache_simple(flowmachine_connect):
@@ -111,7 +111,7 @@ def test_invalidate_cache_simple(flowmachine_connect):
     assert dl1.is_stored
     dl1.invalidate_db_cache()
     assert not dl1.is_stored
-    assert not cache_table_exists(flowmachine_connect, dl1.md5)
+    assert not cache_table_exists(flowmachine_connect, dl1.query_id)
 
 
 def test_invalidate_cache_multi(flowmachine_connect):
@@ -130,8 +130,8 @@ def test_invalidate_cache_multi(flowmachine_connect):
     dl1.invalidate_db_cache()
     assert not dl1.is_stored
     assert not hl1.is_stored
-    assert not cache_table_exists(flowmachine_connect, dl1.md5)
-    assert not cache_table_exists(flowmachine_connect, hl1.md5)
+    assert not cache_table_exists(flowmachine_connect, dl1.query_id)
+    assert not cache_table_exists(flowmachine_connect, hl1.query_id)
     has_deps = bool(flowmachine_connect.fetch("SELECT * FROM cache.dependencies"))
     assert has_deps  # the remaining dependencies are due to underlying Table objects
 
@@ -156,9 +156,9 @@ def test_invalidate_cache_midchain(flowmachine_connect):
     assert dl1.is_stored
     assert not hl1.is_stored
     assert not flow.is_stored
-    assert cache_table_exists(flowmachine_connect, dl1.md5)
-    assert not cache_table_exists(flowmachine_connect, hl1.md5)
-    assert not cache_table_exists(flowmachine_connect, flow.md5)
+    assert cache_table_exists(flowmachine_connect, dl1.query_id)
+    assert not cache_table_exists(flowmachine_connect, hl1.query_id)
+    assert not cache_table_exists(flowmachine_connect, flow.query_id)
     has_deps = bool(flowmachine_connect.fetch("SELECT * FROM cache.dependencies"))
     assert has_deps  # Daily location deps should remain
 
@@ -182,8 +182,8 @@ def test_invalidate_cascade(flowmachine_connect):
     assert not dl1.is_stored
     assert hl1.is_stored
     assert flow.is_stored
-    assert not cache_table_exists(flowmachine_connect, dl1.md5)
-    assert cache_table_exists(flowmachine_connect, hl1.md5)
+    assert not cache_table_exists(flowmachine_connect, dl1.query_id)
+    assert cache_table_exists(flowmachine_connect, hl1.query_id)
     has_deps = bool(flowmachine_connect.fetch("SELECT * FROM cache.dependencies"))
     assert has_deps
 
@@ -196,9 +196,9 @@ def test_deps_cache_multi():
     dl1 = daily_location("2016-01-01")
     dl1.store().result()
     hl1 = ModalLocation(daily_location("2016-01-01"), daily_location("2016-01-02"))
-    dep = dl1.md5
+    dep = dl1.query_id
     assert 4 == len(hl1._get_stored_dependencies())
-    assert dep in [x.md5 for x in hl1._get_stored_dependencies()]
+    assert dep in [x.query_id for x in hl1._get_stored_dependencies()]
 
 
 def test_deps_cache_chain():
@@ -212,11 +212,11 @@ def test_deps_cache_chain():
     hl1.store().result()
     hl2 = ModalLocation(daily_location("2016-01-03"), daily_location("2016-01-04"))
     flow = Flows(hl1, hl2)
-    bad_dep = dl1.md5
-    good_dep = hl1.md5
+    bad_dep = dl1.query_id
+    good_dep = hl1.query_id
     assert 6 == len(flow._get_stored_dependencies())
-    assert good_dep in [x.md5 for x in flow._get_stored_dependencies()]
-    assert bad_dep not in [x.md5 for x in flow._get_stored_dependencies()]
+    assert good_dep in [x.query_id for x in flow._get_stored_dependencies()]
+    assert bad_dep not in [x.query_id for x in flow._get_stored_dependencies()]
 
 
 def test_deps_cache_broken_chain():
@@ -230,9 +230,9 @@ def test_deps_cache_broken_chain():
     hl1 = ModalLocation(daily_location("2016-01-01"), daily_location("2016-01-02"))
     hl2 = ModalLocation(daily_location("2016-01-03"), daily_location("2016-01-04"))
     flow = Flows(hl1, hl2)
-    dep = dl1.md5
+    dep = dl1.query_id
     assert 8 == len(flow._get_stored_dependencies())
-    assert dep in [x.md5 for x in flow._get_stored_dependencies()]
+    assert dep in [x.query_id for x in flow._get_stored_dependencies()]
 
 
 def test_retrieve(get_dataframe):
@@ -243,9 +243,9 @@ def test_retrieve(get_dataframe):
     dl1 = daily_location("2016-01-01")
     dl1.store().result()
     local_df = get_dataframe(dl1)
-    from_cache = {x.md5: x for x in dl1.get_stored()}
-    assert dl1.md5 in from_cache
-    assert get_dataframe(from_cache[dl1.md5]).equals(local_df)
+    from_cache = {x.query_id: x for x in dl1.get_stored()}
+    assert dl1.query_id in from_cache
+    assert get_dataframe(from_cache[dl1.query_id]).equals(local_df)
 
 
 def test_df_not_pickled():
@@ -275,7 +275,7 @@ def test_retrieve_all():
     flow = Flows(hl1, hl2)
     flow.store().result()
 
-    from_cache = [obj.md5 for obj in Query.get_stored()]
-    assert dl1.md5 in from_cache
-    assert hl1.md5 in from_cache
-    assert flow.md5 in from_cache
+    from_cache = [obj.query_id for obj in Query.get_stored()]
+    assert dl1.query_id in from_cache
+    assert hl1.query_id in from_cache
+    assert flow.query_id in from_cache

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -49,24 +49,24 @@ def test_scoring(flowmachine_connect):
     Test that score updating algorithm is correct by comparing to cachey as reference implementation
     """
     dl = daily_location("2016-01-01").store().result()
-    dl_time = get_compute_time(flowmachine_connect, dl.md5)
+    dl_time = get_compute_time(flowmachine_connect, dl.query_id)
     dl_size = get_size_of_table(flowmachine_connect, dl.table_name, "cache")
-    initial_score = get_score(flowmachine_connect, dl.md5)
+    initial_score = get_score(flowmachine_connect, dl.query_id)
     cachey_scorer = Scorer(halflife=1000.0)
     cache_score = cachey_scorer.touch("dl", dl_time / dl_size)
     assert cache_score == pytest.approx(initial_score)
 
     # Touch again
-    new_score = touch_cache(flowmachine_connect, dl.md5)
+    new_score = touch_cache(flowmachine_connect, dl.query_id)
     updated_cache_score = cachey_scorer.touch("dl")
     assert updated_cache_score == pytest.approx(new_score)
 
     # Add another unrelated cache record, which should have a higher initial score
     dl_2 = daily_location("2016-01-02").store().result()
-    dl_time = get_compute_time(flowmachine_connect, dl_2.md5)
+    dl_time = get_compute_time(flowmachine_connect, dl_2.query_id)
     dl_size = get_size_of_table(flowmachine_connect, dl_2.table_name, "cache")
     cache_score = cachey_scorer.touch("dl_2", dl_time / dl_size)
-    assert cache_score == pytest.approx(get_score(flowmachine_connect, dl_2.md5))
+    assert cache_score == pytest.approx(get_score(flowmachine_connect, dl_2.query_id))
 
 
 def test_touch_cache_record_for_query(flowmachine_connect):
@@ -78,17 +78,17 @@ def test_touch_cache_record_for_query(flowmachine_connect):
     assert (
         1
         == flowmachine_connect.fetch(
-            f"SELECT access_count FROM cache.cached WHERE query_id='{table.md5}'"
+            f"SELECT access_count FROM cache.cached WHERE query_id='{table.query_id}'"
         )[0][0]
     )
     accessed_at = flowmachine_connect.fetch(
-        f"SELECT last_accessed FROM cache.cached WHERE query_id='{table.md5}'"
+        f"SELECT last_accessed FROM cache.cached WHERE query_id='{table.query_id}'"
     )[0][0]
-    touch_cache(flowmachine_connect, table.md5)
+    touch_cache(flowmachine_connect, table.query_id)
     assert (
         2
         == flowmachine_connect.fetch(
-            f"SELECT access_count FROM cache.cached WHERE query_id='{table.md5}'"
+            f"SELECT access_count FROM cache.cached WHERE query_id='{table.query_id}'"
         )[0][0]
     )
     # Two cache touches should have been recorded
@@ -98,7 +98,7 @@ def test_touch_cache_record_for_query(flowmachine_connect):
     assert (
         accessed_at
         < flowmachine_connect.fetch(
-            f"SELECT last_accessed FROM cache.cached WHERE query_id='{table.md5}'"
+            f"SELECT last_accessed FROM cache.cached WHERE query_id='{table.query_id}'"
         )[0][0]
     )
 
@@ -109,24 +109,24 @@ def test_touch_cache_record_for_table(flowmachine_connect):
     """
     table = Table("events.calls_20160101")
     flowmachine_connect.engine.execute(
-        f"UPDATE cache.cached SET compute_time = 1 WHERE query_id=%s", table.md5
+        f"UPDATE cache.cached SET compute_time = 1 WHERE query_id=%s", table.query_id
     )  # Compute time for tables is zero, so set to 1 to avoid zeroing out
-    assert 0 == get_score(flowmachine_connect, table.md5)
+    assert 0 == get_score(flowmachine_connect, table.query_id)
     assert (
         1
         == flowmachine_connect.fetch(
-            f"SELECT access_count FROM cache.cached WHERE query_id='{table.md5}'"
+            f"SELECT access_count FROM cache.cached WHERE query_id='{table.query_id}'"
         )[0][0]
     )
     accessed_at = flowmachine_connect.fetch(
-        f"SELECT last_accessed FROM cache.cached WHERE query_id='{table.md5}'"
+        f"SELECT last_accessed FROM cache.cached WHERE query_id='{table.query_id}'"
     )[0][0]
-    touch_cache(flowmachine_connect, table.md5)
-    assert 0 == get_score(flowmachine_connect, table.md5)
+    touch_cache(flowmachine_connect, table.query_id)
+    assert 0 == get_score(flowmachine_connect, table.query_id)
     assert (
         2
         == flowmachine_connect.fetch(
-            f"SELECT access_count FROM cache.cached WHERE query_id='{table.md5}'"
+            f"SELECT access_count FROM cache.cached WHERE query_id='{table.query_id}'"
         )[0][0]
     )
     # No cache touch should be recorded
@@ -136,7 +136,7 @@ def test_touch_cache_record_for_table(flowmachine_connect):
     assert (
         accessed_at
         < flowmachine_connect.fetch(
-            f"SELECT last_accessed FROM cache.cached WHERE query_id='{table.md5}'"
+            f"SELECT last_accessed FROM cache.cached WHERE query_id='{table.query_id}'"
         )[0][0]
     )
 
@@ -161,8 +161,8 @@ def test_get_cached_query_objects_ordered_by_score(flowmachine_connect):
     # Should prefer the larger, but slower to calculate and more used dl over the aggregation
     cached_queries = get_cached_query_objects_ordered_by_score(flowmachine_connect)
     assert 2 == len(cached_queries)
-    assert dl_agg.md5 == cached_queries[0][0].md5
-    assert dl.md5 == cached_queries[1][0].md5
+    assert dl_agg.query_id == cached_queries[0][0].query_id
+    assert dl.query_id == cached_queries[1][0].query_id
     assert 2 == len(cached_queries[0])
 
 
@@ -173,13 +173,13 @@ def test_shrink_one(flowmachine_connect):
     dl = daily_location("2016-01-01").store().result()
     dl_aggregate = dl.aggregate().store().result()
     flowmachine_connect.engine.execute(
-        f"UPDATE cache.cached SET cache_score_multiplier = 1 WHERE query_id='{dl_aggregate.md5}'"
+        f"UPDATE cache.cached SET cache_score_multiplier = 1 WHERE query_id='{dl_aggregate.query_id}'"
     )
     flowmachine_connect.engine.execute(
-        f"UPDATE cache.cached SET cache_score_multiplier = 0.5 WHERE query_id='{dl.md5}'"
+        f"UPDATE cache.cached SET cache_score_multiplier = 0.5 WHERE query_id='{dl.query_id}'"
     )
     removed_query, table_size = shrink_one(flowmachine_connect)
-    assert dl.md5 == removed_query.md5
+    assert dl.query_id == removed_query.query_id
     assert not dl.is_stored
     assert dl_aggregate.is_stored
 
@@ -231,8 +231,8 @@ def test_shrink_to_size_dry_run_reflects_wet_run(flowmachine_connect):
         flowmachine_connect, shrink_to, dry_run=True
     )
     removed_queries = shrink_below_size(flowmachine_connect, shrink_to, dry_run=False)
-    assert [q.md5 for q in removed_queries] == [
-        q.md5 for q in queries_that_would_be_removed
+    assert [q.query_id for q in removed_queries] == [
+        q.query_id for q in queries_that_would_be_removed
     ]
 
 
@@ -243,10 +243,10 @@ def test_shrink_to_size_uses_score(flowmachine_connect):
     dl = daily_location("2016-01-01").store().result()
     dl_aggregate = dl.aggregate().store().result()
     flowmachine_connect.engine.execute(
-        f"UPDATE cache.cached SET cache_score_multiplier = 100 WHERE query_id='{dl_aggregate.md5}'"
+        f"UPDATE cache.cached SET cache_score_multiplier = 100 WHERE query_id='{dl_aggregate.query_id}'"
     )
     flowmachine_connect.engine.execute(
-        f"UPDATE cache.cached SET cache_score_multiplier = 0.5 WHERE query_id='{dl.md5}'"
+        f"UPDATE cache.cached SET cache_score_multiplier = 0.5 WHERE query_id='{dl.query_id}'"
     )
     table_size = get_size_of_table(flowmachine_connect, dl.table_name, "cache")
     removed_queries = shrink_below_size(flowmachine_connect, table_size)
@@ -262,13 +262,13 @@ def test_shrink_one(flowmachine_connect):
     dl = daily_location("2016-01-01").store().result()
     dl_aggregate = dl.aggregate().store().result()
     flowmachine_connect.engine.execute(
-        f"UPDATE cache.cached SET cache_score_multiplier = 100 WHERE query_id='{dl_aggregate.md5}'"
+        f"UPDATE cache.cached SET cache_score_multiplier = 100 WHERE query_id='{dl_aggregate.query_id}'"
     )
     flowmachine_connect.engine.execute(
-        f"UPDATE cache.cached SET cache_score_multiplier = 0.5 WHERE query_id='{dl.md5}'"
+        f"UPDATE cache.cached SET cache_score_multiplier = 0.5 WHERE query_id='{dl.query_id}'"
     )
     removed_query, table_size = shrink_one(flowmachine_connect)
-    assert dl.md5 == removed_query.md5
+    assert dl.query_id == removed_query.query_id
     assert not dl.is_stored
     assert dl_aggregate.is_stored
 
@@ -339,21 +339,21 @@ def test_cache_miss_value_error_score():
 
 def test_get_query_object_by_id(flowmachine_connect):
     """
-    Test that we can get a query object back out of the database by the md5 id
+    Test that we can get a query object back out of the database by the query_id id
     """
     dl = daily_location("2016-01-01").store().result()
-    retrieved_query = get_query_object_by_id(flowmachine_connect, dl.md5)
-    assert dl.md5 == retrieved_query.md5
+    retrieved_query = get_query_object_by_id(flowmachine_connect, dl.query_id)
+    assert dl.query_id == retrieved_query.query_id
     assert dl.get_query() == retrieved_query.get_query()
 
 
 def test_delete_query_by_id(flowmachine_connect):
     """
-    Test that we can remove a query from cache by the md5 id
+    Test that we can remove a query from cache by the query_id id
     """
     dl = daily_location("2016-01-01").store().result()
-    retrieved_query = invalidate_cache_by_id(flowmachine_connect, dl.md5)
-    assert dl.md5 == retrieved_query.md5
+    retrieved_query = invalidate_cache_by_id(flowmachine_connect, dl.query_id)
+    assert dl.query_id == retrieved_query.query_id
     assert not dl.is_stored
 
 
@@ -363,8 +363,8 @@ def test_delete_query_by_id_does_not_cascade_by_default(flowmachine_connect):
     """
     dl = daily_location("2016-01-01").store().result()
     dl_agg = dl.aggregate().store().result()
-    retrieved_query = invalidate_cache_by_id(flowmachine_connect, dl.md5)
-    assert dl.md5 == retrieved_query.md5
+    retrieved_query = invalidate_cache_by_id(flowmachine_connect, dl.query_id)
+    assert dl.query_id == retrieved_query.query_id
     assert not dl.is_stored
     assert dl_agg.is_stored
 
@@ -375,8 +375,10 @@ def test_delete_query_by_id_can_cascade(flowmachine_connect):
     """
     dl = daily_location("2016-01-01").store().result()
     dl_agg = dl.aggregate().store().result()
-    retrieved_query = invalidate_cache_by_id(flowmachine_connect, dl.md5, cascade=True)
-    assert dl.md5 == retrieved_query.md5
+    retrieved_query = invalidate_cache_by_id(
+        flowmachine_connect, dl.query_id, cascade=True
+    )
+    assert dl.query_id == retrieved_query.query_id
     assert not dl.is_stored
     assert not dl_agg.is_stored
 
@@ -421,7 +423,7 @@ def test_cache_table_exists(flowmachine_connect):
     """
     assert not cache_table_exists(flowmachine_connect, "NONEXISTENT_CACHE_ID")
     assert cache_table_exists(
-        flowmachine_connect, daily_location("2016-01-01").store().result().md5
+        flowmachine_connect, daily_location("2016-01-01").store().result().query_id
     )
 
 
@@ -431,19 +433,19 @@ def test_redis_resync(flowmachine_connect):
     """
     stored_query = daily_location("2016-01-01").store().result()
     assert (
-        QueryStateMachine(Table.redis, stored_query.md5).current_query_state
+        QueryStateMachine(Table.redis, stored_query.query_id).current_query_state
         == QueryState.COMPLETED
     )
     assert stored_query.is_stored
     Table.redis.flushdb()
     assert stored_query.is_stored
     assert (
-        QueryStateMachine(Table.redis, stored_query.md5).current_query_state
+        QueryStateMachine(Table.redis, stored_query.query_id).current_query_state
         == QueryState.KNOWN
     )
     resync_redis_with_cache(flowmachine_connect, Table.redis)
     assert (
-        QueryStateMachine(Table.redis, stored_query.md5).current_query_state
+        QueryStateMachine(Table.redis, stored_query.query_id).current_query_state
         == QueryState.COMPLETED
     )
 
@@ -454,13 +456,13 @@ def test_cache_reset(flowmachine_connect):
     """
     stored_query = daily_location("2016-01-01").store().result()
     assert (
-        QueryStateMachine(Table.redis, stored_query.md5).current_query_state
+        QueryStateMachine(Table.redis, stored_query.query_id).current_query_state
         == QueryState.COMPLETED
     )
     assert stored_query.is_stored
     reset_cache(flowmachine_connect, Table.redis)
     assert (
-        QueryStateMachine(Table.redis, stored_query.md5).current_query_state
+        QueryStateMachine(Table.redis, stored_query.query_id).current_query_state
         == QueryState.KNOWN
     )
     assert not stored_query.is_stored
@@ -474,7 +476,7 @@ def test_cache_reset_protects_tables(flowmachine_connect):
     dl_query = daily_location(date="2016-01-03", method="last")
     reset_cache(flowmachine_connect, dl_query.redis)
     for dep in dl_query._get_stored_dependencies():
-        assert dep.md5 in [x.md5 for x in Query.get_stored()]
+        assert dep.query_id in [x.query_id for x in Query.get_stored()]
     dl_query.store().result()  # Original bug caused this to error
 
 
@@ -484,7 +486,7 @@ def test_redis_resync_runtimeerror(flowmachine_connect, dummy_redis):
     """
     stored_query = daily_location("2016-01-01").store().result()
     assert (
-        QueryStateMachine(Table.redis, stored_query.md5).current_query_state
+        QueryStateMachine(Table.redis, stored_query.query_id).current_query_state
         == QueryState.COMPLETED
     )
     dummy_redis.allow_flush = False
@@ -508,7 +510,7 @@ def test_cache_metadata_write_error(flowmachine_connect, dummy_redis, monkeypatc
         store_future.result()
     assert not dl_query.is_stored
     assert (
-        QueryStateMachine(dl_query.redis, dl_query.md5).current_query_state
+        QueryStateMachine(dl_query.redis, dl_query.query_id).current_query_state
         == QueryState.ERRORED
     )
 

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -339,7 +339,7 @@ def test_cache_miss_value_error_score():
 
 def test_get_query_object_by_id(flowmachine_connect):
     """
-    Test that we can get a query object back out of the database by the query_id id
+    Test that we can get a query object back out of the database by the query's id
     """
     dl = daily_location("2016-01-01").store().result()
     retrieved_query = get_query_object_by_id(flowmachine_connect, dl.query_id)
@@ -349,7 +349,7 @@ def test_get_query_object_by_id(flowmachine_connect):
 
 def test_delete_query_by_id(flowmachine_connect):
     """
-    Test that we can remove a query from cache by the query_id id
+    Test that we can remove a query from cache by the query's id
     """
     dl = daily_location("2016-01-01").store().result()
     retrieved_query = invalidate_cache_by_id(flowmachine_connect, dl.query_id)

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -520,7 +520,7 @@ def test_cache_ddl_op_error(dummy_redis):
     Test that errors when generating SQL leave the query state machine in error state.
     """
 
-    query_mock = Mock(md5="DUMMY_MD5")
+    query_mock = Mock(query_id="DUMMY_MD5")
     qsm = QueryStateMachine(dummy_redis, "DUMMY_MD5")
     qsm.enqueue()
 

--- a/flowmachine/tests/test_custom_query.py
+++ b/flowmachine/tests/test_custom_query.py
@@ -10,5 +10,5 @@ def test_custom_query_hash():
                                  FROM foo""",
         [],
     )
-    assert base.md5 == case_mismatch.md5
-    assert base.md5 == space_mismatch.md5
+    assert base.query_id == case_mismatch.query_id
+    assert base.query_id == space_mismatch.query_id

--- a/flowmachine/tests/test_query.py
+++ b/flowmachine/tests/test_query.py
@@ -117,10 +117,10 @@ def test_exception_on_unstored():
 def test_iteration():
     """Test that we can iterate and it doesn't break hashing"""
     dl = daily_location("2016-01-01")
-    md5 = dl.md5
+    md5 = dl.query_id
     for _ in dl:
         pass
-    assert md5 == dl.md5
+    assert md5 == dl.query_id
 
 
 def test_limited_head():

--- a/flowmachine/tests/test_query_object_construction.test_construct_query.approved.txt
+++ b/flowmachine/tests/test_query_object_construction.test_construct_query.approved.txt
@@ -1,5 +1,5 @@
 {
-  "0f2106014fee8e717c72d30b14fad8ab": {
+  "e4babc523792bb7942e23573656dbdbd": {
     "query_kind": "spatial_aggregate",
     "locations": {
       "query_kind": "daily_location",
@@ -16,7 +16,7 @@
       }
     }
   },
-  "75d67100b0382c34b4661a5ec8950fa6": {
+  "b6e172a4d83fc10be1e2cfbbb2f4a587": {
     "query_kind": "spatial_aggregate",
     "locations": {
       "query_kind": "daily_location",
@@ -27,7 +27,7 @@
       "sampling": null
     }
   },
-  "1a1e4e159d05f2ec1f081ac9c2bfd6d5": {
+  "d434d6a85c9ce3901668e3304b600d2d": {
     "query_kind": "location_event_counts",
     "start_date": "2016-01-01",
     "end_date": "2016-01-02",
@@ -37,7 +37,7 @@
     "event_types": null,
     "subscriber_subset": null
   },
-  "19419d8079d9c8e90afd057eb0871488": {
+  "d32b47b7f88ba4ad0b92a6b2dabce216": {
     "query_kind": "spatial_aggregate",
     "locations": {
       "query_kind": "modal_location",
@@ -64,7 +64,7 @@
     "query_kind": "geography",
     "aggregation_unit": "admin3"
   },
-  "de6836685ca2805baa1081c09f387e50": {
+  "65c6fef5077df4e3c3a3d712523f4cda": {
     "query_kind": "meaningful_locations_aggregate",
     "aggregation_unit": "admin1",
     "start_date": "2016-01-01",
@@ -157,7 +157,7 @@
     "tower_cluster_call_threshold": 0,
     "subscriber_subset": null
   },
-  "639b435514358b3e2319333e5016f56e": {
+  "47cae966b0bcf8bd3b9cb6d6d2192674": {
     "query_kind": "meaningful_locations_between_label_od_matrix",
     "aggregation_unit": "admin1",
     "start_date": "2016-01-01",
@@ -251,7 +251,7 @@
     "tower_cluster_call_threshold": 0,
     "subscriber_subset": null
   },
-  "98dad1d308b631753b3d4e37c7a63861": {
+  "77ac7078086f2cb74fa3af95e2b6b6b5": {
     "query_kind": "meaningful_locations_between_dates_od_matrix",
     "aggregation_unit": "admin1",
     "start_date_a": "2016-01-01",

--- a/flowmachine/tests/test_query_state.py
+++ b/flowmachine/tests/test_query_state.py
@@ -143,7 +143,7 @@ def test_query_cancellation(start_state, succeeds, dummy_redis):
 def test_store_exceptions(fail_event, expected_exception):
     """Test that exceptions are raised when watching a store op triggered elsewhere."""
     q = DummyQuery(dummy_id=1, sleep_time=5)
-    qsm = QueryStateMachine(q.redis, q.md5)
+    qsm = QueryStateMachine(q.redis, q.query_id)
     # Mark the query as having begun executing elsewhere
     qsm.enqueue()
     qsm.execute()
@@ -159,7 +159,7 @@ def test_drop_query_blocks(monkeypatch):
         flowmachine.core.query, "_sleep", Mock(side_effect=BlockingIOError)
     )
     q = DummyQuery(dummy_id=1, sleep_time=5)
-    qsm = QueryStateMachine(q.redis, q.md5)
+    qsm = QueryStateMachine(q.redis, q.query_id)
     # Mark the query as in the process of resetting
     qsm.enqueue()
     qsm.execute()
@@ -172,7 +172,7 @@ def test_drop_query_blocks(monkeypatch):
 def test_drop_query_errors():
     """Test that resetting a query's cache will error if in a state where that isn't possible."""
     q = DummyQuery(dummy_id=1, sleep_time=5)
-    qsm = QueryStateMachine(q.redis, q.md5)
+    qsm = QueryStateMachine(q.redis, q.query_id)
     # Mark the query as in the process of resetting
     qsm.enqueue()
     qsm.execute()

--- a/flowmachine/tests/test_random.py
+++ b/flowmachine/tests/test_random.py
@@ -295,4 +295,4 @@ def test_pickling():
     )
     for ss in [ss1, ss2]:
         assert ss.get_query() == pickle.loads(pickle.dumps(ss)).get_query()
-        assert ss.md5 == pickle.loads(pickle.dumps(ss)).md5
+        assert ss.query_id == pickle.loads(pickle.dumps(ss)).query_id

--- a/flowmachine/tests/test_table.py
+++ b/flowmachine/tests/test_table.py
@@ -82,7 +82,7 @@ def test_dependencies():
     t2 = Table("events.calls", columns=["id"])
     assert len(t2.dependencies) == 1
     t2_parent = t2.dependencies.pop()
-    assert "057addedac04dbeb1dcbbb6b524b43f0" == t2_parent.md5
+    assert "057addedac04dbeb1dcbbb6b524b43f0" == t2_parent.query_id
 
 
 def test_subset():
@@ -103,4 +103,4 @@ def test_pickling():
         "id", ["5wNJA-PdRJ4-jxEdG-yOXpZ", "5wNJA-PdRJ4-jxEdG-yOXpZ"]
     )
     assert ss.get_query() == pickle.loads(pickle.dumps(ss)).get_query()
-    assert ss.md5 == pickle.loads(pickle.dumps(ss)).md5
+    assert ss.query_id == pickle.loads(pickle.dumps(ss)).query_id

--- a/flowmachine/tests/test_utils.py
+++ b/flowmachine/tests/test_utils.py
@@ -189,9 +189,9 @@ def test_print_dependency_tree():
     expected_output = textwrap.dedent(
         """\
         <Query of type: MostFrequentLocation, query_id: 'xxxxx'>
+          - <Query of type: PolygonSpatialUnit, query_id: 'xxxxx'>
+             - <Table: 'geography.admin3', query_id: 'xxxxx'>
           - <Query of type: SubscriberLocations, query_id: 'xxxxx'>
-             - <Query of type: PolygonSpatialUnit, query_id: 'xxxxx'>
-                - <Table: 'geography.admin3', query_id: 'xxxxx'>
              - <Query of type: JoinToLocation, query_id: 'xxxxx'>
                 - <Query of type: PolygonSpatialUnit, query_id: 'xxxxx'>
                    - <Table: 'geography.admin3', query_id: 'xxxxx'>
@@ -204,8 +204,8 @@ def test_print_dependency_tree():
                       - <Query of type: CustomQuery, query_id: 'xxxxx'>
                       - <Table: 'events.calls', query_id: 'xxxxx'>
                          - <Table: 'events.calls', query_id: 'xxxxx'>
-          - <Query of type: PolygonSpatialUnit, query_id: 'xxxxx'>
-             - <Table: 'geography.admin3', query_id: 'xxxxx'>
+             - <Query of type: PolygonSpatialUnit, query_id: 'xxxxx'>
+                - <Table: 'geography.admin3', query_id: 'xxxxx'>
         """
     )
 

--- a/flowmachine/tests/test_utils.py
+++ b/flowmachine/tests/test_utils.py
@@ -228,8 +228,8 @@ def test_calculate_dependency_graph():
         stop="2016-01-02",
         columns=["msisdn", "datetime", "location_id"],
     )
-    assert f"x{sd.md5}" in G.nodes()
-    assert G.nodes[f"x{sd.md5}"]["query_object"].md5 == sd.md5
+    assert f"x{sd.query_id}" in G.nodes()
+    assert G.nodes[f"x{sd.query_id}"]["query_object"].query_id == sd.query_id
 
 
 def test_plot_dependency_graph():

--- a/integration_tests/tests/flowmachine_server_tests/test_action_get_sql.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_action_get_sql.py
@@ -40,7 +40,7 @@ async def test_get_sql(zmq_port, zmq_host):
             subscriber_subset=None,
         )
     )
-    expected_query_id = q.md5
+    expected_query_id = q.query_id
 
     reply = send_zmq_message_and_receive_reply(msg, port=zmq_port, host=zmq_host)
     # assert reply["status"] in ("executing", "queued", "completed")

--- a/integration_tests/tests/flowmachine_server_tests/test_action_run_query.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_action_run_query.py
@@ -38,7 +38,7 @@ async def test_run_query(zmq_port, zmq_host, fm_conn, redis):
             subscriber_subset=None,
         )
     )
-    expected_query_id = q.md5
+    expected_query_id = q.query_id
 
     #
     # Check that we are starting with a clean slate (no cache tables, empty redis).

--- a/integration_tests/tests/flowmachine_server_tests/test_helper_functions.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_helper_functions.py
@@ -41,7 +41,7 @@ def test_send_zmq_message_and_receive_reply(zmq_host, zmq_port):
             subscriber_subset=None,
         )
     )
-    expected_query_id = q.md5
+    expected_query_id = q.query_id
 
     # Check that the flowmachine server sends the expected reply
     reply = send_zmq_message_and_receive_reply(

--- a/integration_tests/tests/flowmachine_server_tests/test_server.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.py
@@ -115,7 +115,7 @@ def test_run_daily_location_query(send_zmq_message_and_receive_reply):
             subscriber_subset=None,
         )
     )
-    expected_query_id = q.md5
+    expected_query_id = q.query_id
 
     assert "success" == reply["status"]
     assert expected_query_id == reply["payload"]["query_id"]
@@ -172,7 +172,7 @@ def test_run_modal_location_query(send_zmq_message_and_receive_reply):
             ),
         )
     )
-    expected_query_id = q.md5
+    expected_query_id = q.query_id
 
     assert "success" == reply["status"]
     assert expected_query_id == reply["payload"]["query_id"]
@@ -202,7 +202,7 @@ def test_run_dfs_metric_total_amount_query(send_zmq_message_and_receive_reply):
         end_date="2016-01-05",
         aggregation_unit="admin2",
     )
-    expected_query_id = q.md5
+    expected_query_id = q.query_id
 
     assert "success" == reply["status"]
     assert expected_query_id == reply["payload"]["query_id"]


### PR DESCRIPTION
Closes #1288 

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Renames query's `.md5` attribute to `.query_id`.