### PR TITLE
Add config option to specify SQL snippet for determining available dates in FlowETL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Random sampling is now exposed via the API, for all non-aggregated query kinds. [#1007](https://github.com/Flowminder/FlowKit/issues/1007)
 - New aggregate added to FlowMachine - `HistogramAggregation`, which constructs histograms over the results of other queries. [#1075](https://github.com/Flowminder/FlowKit/issues/1075)
 - New `IntereventInterval` query class - returns stats over the gap between events as a time interval.
+- New config option `sql_find_available_dates` in FlowETL to provide SQL code to determine the available dates. [#1295](https://github.com/Flowminder/FlowKit/issues/1295)
 
 ### Changed
 - FlowDB is now based on PostgreSQL 11.5 and PostGIS 2.5.3

--- a/flowetl/dags/etl.py
+++ b/flowetl/dags/etl.py
@@ -20,7 +20,11 @@ from etl.dag_task_callable_mappings import (
     PRODUCTION_ETL_TASK_CALLABLES,
 )
 from etl.etl_utils import construct_etl_dag, CDRType
-from etl.config_parser import validate_config, get_config_from_file
+from etl.config_parser import (
+    get_config_from_file,
+    validate_config,
+    fill_config_default_values,
+)
 
 logger = structlog.get_logger("flowetl")
 default_args = {"owner": "flowminder", "start_date": parse("1900-01-01")}
@@ -49,6 +53,9 @@ elif flowetl_runtime_config == "production":
         config_filepath=Path("/mounts/config/config.yml")
     )
     validate_config(global_config_dict=global_config_dict)
+    global_config_dict = fill_config_default_values(
+        global_config_dict=global_config_dict
+    )
 
     default_args = global_config_dict["default_args"]
 

--- a/flowetl/dags/etl.py
+++ b/flowetl/dags/etl.py
@@ -52,7 +52,7 @@ elif flowetl_runtime_config == "production":
     global_config_dict = get_config_from_file(
         config_filepath=Path("/mounts/config/config.yml")
     )
-    validate_config(global_config_dict=global_config_dict)
+    validate_config(global_config_dict)
     global_config_dict = fill_config_default_values(
         global_config_dict=global_config_dict
     )

--- a/flowetl/dags/etl.py
+++ b/flowetl/dags/etl.py
@@ -53,9 +53,7 @@ elif flowetl_runtime_config == "production":
         config_filepath=Path("/mounts/config/config.yml")
     )
     validate_config(global_config_dict)
-    global_config_dict = fill_config_default_values(
-        global_config_dict=global_config_dict
-    )
+    global_config_dict = fill_config_default_values(global_config_dict)
 
     default_args = global_config_dict["default_args"]
 

--- a/flowetl/deployment_example/README.md
+++ b/flowetl/deployment_example/README.md
@@ -171,8 +171,21 @@ for these changes to be picked up.
 Run the following from within `flowdb` (you can connect to flowdb by running `make connect-flowdb`).
 ```
 CREATE EXTENSION IF NOT EXISTS postgres_fdw;
-CREATE SERVER IF NOT EXISTS ingestion_db_server FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'ingestion_db', port '5432', dbname 'ingestion_db');
-CREATE USER MAPPING IF NOT EXISTS FOR flowdb SERVER ingestion_db_server OPTIONS (user 'ingestion_db', password 'etletl');
+
+CREATE SERVER IF NOT EXISTS ingestion_db_server
+    FOREIGN DATA WRAPPER postgres_fdw
+    OPTIONS (
+        host 'ingestion_db',
+        port '5432',
+        dbname 'ingestion_db'
+    );
+
+CREATE USER MAPPING IF NOT EXISTS FOR flowdb
+    SERVER ingestion_db_server
+    OPTIONS (
+        user 'ingestion_db',
+        password 'etletl'
+    );
 
 CREATE FOREIGN TABLE sample_data_fdw (
         event_time TIMESTAMPTZ,

--- a/flowetl/deployment_example/mounts/config/config.yml
+++ b/flowetl/deployment_example/mounts/config/config.yml
@@ -7,6 +7,7 @@ etl:
     source:
       source_type: sql
       table_name: "sample_data_fdw"
+      event_time_column: "event_time"
   sms:
     concurrency: 2
     source:

--- a/flowetl/deployment_example/mounts/config/config.yml
+++ b/flowetl/deployment_example/mounts/config/config.yml
@@ -7,7 +7,6 @@ etl:
     source:
       source_type: sql
       table_name: "sample_data_fdw"
-      event_time_column: "event_time"
   sms:
     concurrency: 2
     source:

--- a/flowetl/etl/etl/config_parser.py
+++ b/flowetl/etl/etl/config_parser.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from etl.etl_utils import CDRType
 
 
-def validate_config(*, global_config_dict: dict) -> None:
+def validate_config(global_config_dict: dict) -> None:
     """
     Function used to validate the config.yml file. Makes sure we
     have entries for each CDR type in CDRType enum and that each

--- a/flowetl/etl/etl/config_parser.py
+++ b/flowetl/etl/etl/config_parser.py
@@ -77,6 +77,25 @@ def validate_config(global_config_dict: dict) -> None:
 
 
 def fill_config_default_values(*, global_config_dict: dict) -> dict:
+    """
+    Fill the given config dict with default value, in case they
+    were not provided by the user.
+
+    Note that this returns a new copy of the config dict with
+    the additional values filled in, i.e. the input config dict
+    is not modified.
+
+    Parameters
+    ----------
+    global_config_dict : dict
+        dict containing global config for ETL
+
+    Returns
+    -------
+    dict
+        A copy of the config dict with any missing default values
+        filled in.
+    """
     global_config_dict = deepcopy(global_config_dict)
 
     for cdr_type, value in global_config_dict["etl"].items():

--- a/flowetl/etl/etl/config_parser.py
+++ b/flowetl/etl/etl/config_parser.py
@@ -38,9 +38,11 @@ def validate_config(*, global_config_dict: dict) -> Exception:
 
     etl_keys = global_config_dict.get("etl", {}).keys()
     if not set(etl_keys).issubset(CDRType):
+        unexpected_keys = list(set(etl_keys).difference(CDRType))
         exceptions.append(
             ValueError(
-                f"Etl sections present in config.yml must be a subset of {[x.value for x in CDRType]}. Got: {set(etl_keys)}"
+                f"Etl sections present in config.yml must be a subset of {[x.value for x in CDRType]}. "
+                f"Unexpected keys: {unexpected_keys}"
             )
         )
 

--- a/flowetl/etl/etl/config_parser.py
+++ b/flowetl/etl/etl/config_parser.py
@@ -73,5 +73,5 @@ def get_config_from_file(*, config_filepath: Path) -> dict:
     dict
         Yaml config loaded into a python dict
     """
-    content = open(config_filepath, "r").read()
+    content = config_filepath.open("r").read()
     return yaml.load(content, Loader=yaml.SafeLoader)

--- a/flowetl/etl/etl/config_parser.py
+++ b/flowetl/etl/etl/config_parser.py
@@ -76,7 +76,7 @@ def validate_config(global_config_dict: dict) -> None:
         raise ValueError(exceptions)
 
 
-def fill_config_default_values(*, global_config_dict: dict) -> dict:
+def fill_config_default_values(global_config_dict: dict) -> dict:
     """
     Fill the given config dict with default value, in case they
     were not provided by the user.

--- a/flowetl/etl/etl/etl_utils.py
+++ b/flowetl/etl/etl/etl_utils.py
@@ -266,26 +266,3 @@ def extract_date_from_filename(filename: str, filename_pattern: str) -> pendulum
         )
     date_str = m.group(1)
     return pendulum.parse(date_str).date()
-
-
-def find_distinct_dates_in_table(
-    session: sqlalchemy.orm.Session, source_table: str, event_time_column: str
-) -> List[pendulum.Date]:
-    """
-
-    Parameters
-    ----------
-    session : sqlalchemy.orm.Session
-        SQLAlchemy session to use.
-    source_table : str
-        Name of the table in which to look for dates.
-    event_time_column : str
-        The column in which to look for dates.
-    """
-    dates_found = [
-        pendulum.parse(row["date"].strftime("%Y-%m-%d"))
-        for row in session.execute(
-            f"SELECT DISTINCT date FROM (SELECT {event_time_column}::date as date FROM {source_table}) tmp"
-        ).fetchall()
-    ]
-    return dates_found

--- a/flowetl/etl/etl/etl_utils.py
+++ b/flowetl/etl/etl/etl_utils.py
@@ -269,9 +269,7 @@ def extract_date_from_filename(filename: str, filename_pattern: str) -> pendulum
 
 
 def find_distinct_dates_in_table(
-    session: sqlalchemy.orm.Session,
-    source_table: str,
-    event_time_col: str = "event_time",
+    session: sqlalchemy.orm.Session, source_table: str, event_time_column: str
 ) -> List[pendulum.Date]:
     """
 
@@ -281,13 +279,13 @@ def find_distinct_dates_in_table(
         SQLAlchemy session to use.
     source_table : str
         Name of the table in which to look for dates.
-    event_time_col : str
+    event_time_column : str
         The column in which to look for dates.
     """
     dates_found = [
         pendulum.parse(row["date"].strftime("%Y-%m-%d"))
         for row in session.execute(
-            f"SELECT DISTINCT date FROM (SELECT {event_time_col}::date as date FROM {source_table}) tmp"
+            f"SELECT DISTINCT date FROM (SELECT {event_time_column}::date as date FROM {source_table}) tmp"
         ).fetchall()
     ]
     return dates_found

--- a/flowetl/etl/etl/production_task_callables.py
+++ b/flowetl/etl/etl/production_task_callables.py
@@ -177,10 +177,7 @@ def production_trigger__callable(
                 )
         elif source_type == "sql":
             source_table = cfg["source"]["table_name"]
-            sql_find_available_dates = cfg["source"].get(
-                "sql_find_available_dates",
-                f"SELECT DISTINCT event_time::date as date FROM {source_table}",
-            )
+            sql_find_available_dates = cfg["source"]["sql_find_available_dates"]
 
             dates_present = [
                 pendulum.parse(row["date"].strftime("%Y-%m-%d"))

--- a/flowetl/etl/etl/production_task_callables.py
+++ b/flowetl/etl/etl/production_task_callables.py
@@ -179,17 +179,12 @@ def production_trigger__callable(
                 )
         elif source_type == "sql":
             source_table = cfg["source"]["table_name"]
-            event_time_column = cfg["source"]["event_time_column"]
+            sql_find_available_dates = cfg["source"]["sql_find_available_dates"]
 
-            # Extract unprocessed dates from source_table
-
-            # TODO: this requires a full parse of the existing data so may not be
-            # the most be efficient if a lot of data is present (esp. data that has
-            # already been processed). If it turns out too sluggish might be good to
-            # think about a more efficient way to determine dates with unprocessed data.
-            dates_present = find_distinct_dates_in_table(
-                session, source_table, event_time_column=event_time_column
-            )
+            dates_present = [
+                pendulum.parse(row["date"].strftime("%Y-%m-%d"))
+                for row in session.execute(sql_find_available_dates).fetchall()
+            ]
             unprocessed_dates = [
                 date
                 for date in dates_present

--- a/flowetl/etl/etl/production_task_callables.py
+++ b/flowetl/etl/etl/production_task_callables.py
@@ -7,7 +7,6 @@
 Contains the definition of callables to be used in the production ETL dag.
 """
 import pendulum
-import re
 import structlog
 
 from pathlib import Path
@@ -22,7 +21,6 @@ from etl.etl_utils import (
     get_session,
     find_files_matching_pattern,
     extract_date_from_filename,
-    find_distinct_dates_in_table,
 )
 
 logger = structlog.get_logger("flowetl")

--- a/flowetl/etl/etl/production_task_callables.py
+++ b/flowetl/etl/etl/production_task_callables.py
@@ -179,6 +179,7 @@ def production_trigger__callable(
                 )
         elif source_type == "sql":
             source_table = cfg["source"]["table_name"]
+            event_time_column = cfg["source"]["event_time_column"]
 
             # Extract unprocessed dates from source_table
 
@@ -187,7 +188,7 @@ def production_trigger__callable(
             # already been processed). If it turns out too sluggish might be good to
             # think about a more efficient way to determine dates with unprocessed data.
             dates_present = find_distinct_dates_in_table(
-                session, source_table, event_time_col="event_time"
+                session, source_table, event_time_column=event_time_column
             )
             unprocessed_dates = [
                 date

--- a/flowetl/etl/etl/production_task_callables.py
+++ b/flowetl/etl/etl/production_task_callables.py
@@ -179,7 +179,10 @@ def production_trigger__callable(
                 )
         elif source_type == "sql":
             source_table = cfg["source"]["table_name"]
-            sql_find_available_dates = cfg["source"]["sql_find_available_dates"]
+            sql_find_available_dates = cfg["source"].get(
+                "sql_find_available_dates",
+                f"SELECT DISTINCT event_time::date as date FROM {source_table}",
+            )
 
             dates_present = [
                 pendulum.parse(row["date"].strftime("%Y-%m-%d"))

--- a/flowetl/etl/tests/test_config.py
+++ b/flowetl/etl/tests/test_config.py
@@ -30,7 +30,7 @@ def test_config_validation(sample_config_dict):
     """
     Check that with valid config dict we get no exception
     """
-    validate_config(global_config_dict=sample_config_dict)
+    validate_config(sample_config_dict)
 
 
 def test_config_validation_fails_no_etl_section(sample_config_dict):
@@ -43,7 +43,7 @@ def test_config_validation_fails_no_etl_section(sample_config_dict):
     bad_config.pop("etl")
 
     with pytest.raises(ValueError) as raised_exception:
-        validate_config(global_config_dict=bad_config)
+        validate_config(bad_config)
 
     assert len(raised_exception.value.args[0]) == 1
 
@@ -57,7 +57,7 @@ def test_config_validation_fails_for_invalid_etl_section(sample_config_dict):
         "Unexpected keys: \['foobar'\]"
     )
     with pytest.raises(ValueError, match=expected_error_msg):
-        validate_config(global_config_dict=bad_config)
+        validate_config(bad_config)
 
 
 def test_config_validation_fails_no_default_args_section(sample_config_dict):
@@ -69,7 +69,7 @@ def test_config_validation_fails_no_default_args_section(sample_config_dict):
     bad_config.pop("default_args")
 
     with pytest.raises(ValueError) as raised_exception:
-        validate_config(global_config_dict=bad_config)
+        validate_config(bad_config)
 
     assert len(raised_exception.value.args[0]) == 1
 
@@ -83,7 +83,7 @@ def test_config_validation_fails_bad_etl_subsection(sample_config_dict):
     bad_config["etl"]["calls"].pop("source")
 
     with pytest.raises(ValueError) as raised_exception:
-        validate_config(global_config_dict=bad_config)
+        validate_config(bad_config)
 
     assert len(raised_exception.value.args[0]) == 1
 
@@ -100,7 +100,7 @@ def test_config_validation_fails_for_missing_source_type(sample_config_dict):
         "Subsection 'source' is is missing the 'source_type' key for cdr_type 'calls'."
     )
     with pytest.raises(ValueError, match=expected_error_msg):
-        validate_config(global_config_dict=bad_config)
+        validate_config(bad_config)
 
 
 def test_config_validation_fails_for_invalid_source_type(sample_config_dict):
@@ -113,7 +113,7 @@ def test_config_validation_fails_for_invalid_source_type(sample_config_dict):
 
     expected_error_msg = "Invalid source type: 'foobar'. Allowed values: 'csv', 'sql'"
     with pytest.raises(ValueError, match=expected_error_msg):
-        validate_config(global_config_dict=bad_config)
+        validate_config(bad_config)
 
 
 def test_config_validation_fails_if_table_name_key_is_missing(sample_config_dict):
@@ -128,7 +128,7 @@ def test_config_validation_fails_if_table_name_key_is_missing(sample_config_dict
         "Missing 'table_name' key in 'source' subsection of cdr type 'mds'"
     )
     with pytest.raises(ValueError, match=expected_error_msg):
-        validate_config(global_config_dict=bad_config)
+        validate_config(bad_config)
 
 
 def test_find_files_default_filter(tmpdir):

--- a/flowetl/etl/tests/test_config.py
+++ b/flowetl/etl/tests/test_config.py
@@ -171,7 +171,7 @@ def test_extract_date_from_filename():
         extract_date_from_filename(filename, filename_pattern)
 
 
-def test_error_foobar(tmpdir):
+def test_error_invalid_etl_section(tmpdir):
     config_file = tmpdir.join("config.yml")
     config_file.write(
         textwrap.dedent(
@@ -184,7 +184,7 @@ def test_error_foobar(tmpdir):
                 concurrency: 4
                 source:
                   source_type: csv
-                  filename_pattern: CALLS_(\d{4}[01]\d[0123]\d).csv.gz
+                  filename_pattern: CALLS_(\d{8}).csv.gz
             """
         )
     )

--- a/flowetl/etl/tests/test_config.py
+++ b/flowetl/etl/tests/test_config.py
@@ -251,6 +251,6 @@ def test_sql_find_available_dates(sample_config_dict):
     )
     config_dict = yaml.safe_load(config_without_explicit_sql)
 
-    config_dict = fill_config_default_values(global_config_dict=config_dict)
+    config_dict = fill_config_default_values(config_dict)
     sql = config_dict["etl"]["calls"]["source"]["sql_find_available_dates"]
     assert sql == "SELECT DISTINCT event_time::date as date FROM calls_raw_data_dump"

--- a/flowetl/mounts/config/config.yml
+++ b/flowetl/mounts/config/config.yml
@@ -1,3 +1,5 @@
+# This is an example flowetl config file which
+# is also used in the flowetl unit tests.
 default_args:
   owner: flowminder
   start_date: '1900-01-01'

--- a/flowetl/mounts/config/config.yml
+++ b/flowetl/mounts/config/config.yml
@@ -19,7 +19,11 @@ etl:
     source:
       source_type: sql
       table_name: "mds_raw_data_dump"
-      event_time_column: "event_time"
+      sql_find_available_dates: |
+          SELECT DISTINCT date
+          FROM (
+              SELECT event_time::date as date FROM mds_raw_data_dump
+          ) tmp
   topups:
     concurrency: 4
     source:

--- a/flowetl/mounts/config/config.yml
+++ b/flowetl/mounts/config/config.yml
@@ -17,6 +17,7 @@ etl:
     source:
       source_type: sql
       table_name: "mds_raw_data_dump"
+      event_time_column: "event_time"
   topups:
     concurrency: 4
     source:

--- a/flowetl/mounts/config/config.yml
+++ b/flowetl/mounts/config/config.yml
@@ -20,10 +20,7 @@ etl:
       source_type: sql
       table_name: "mds_raw_data_dump"
       sql_find_available_dates: |
-          SELECT DISTINCT date
-          FROM (
-              SELECT event_time::date as date FROM mds_raw_data_dump
-          ) tmp
+          SELECT DISTINCT event_time::date as date FROM mds_raw_data_dump
   topups:
     concurrency: 4
     source:


### PR DESCRIPTION
Closes #1295 

### I have:

- [X] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [X] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [X] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

The main addition of this PR is a config option called `sql_find_available_dates` which can be provided in the FlowETL `config/config.yml`. This can be used to specify a custom SQL snippet which is run to determine the dates available for ingestion, so that FlowETL can start ingestion processes for them (if not specified, the default for this is `"SELECT DISTINCT event_time::date as date FROM <source_table>"`, but this can be _very_ slow - see #1295).

The helper function `find_distinct_dates_in_table` in `etl_utils.py` has been removed because it is now superseded by this config setting.