### PR TITLE
Distance matrix speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Attempting to store a query that does not have a standard table name (e.g. `EventTableSubset` or unseeded random sample) will now raise an `UnstorableQueryError` instead of `ValueError`.
 - In the FlowETL deployment example, the external ingestion database is now set up separately from the FlowKit components and connected to FlowDB via a docker overlay network. [#1276](https://github.com/Flowminder/FlowKit/issues/1276)
 - The `md5` attribute of the `Query` class has been renamed to `query_id` [#1288](https://github.com/Flowminder/FlowKit/issues/1288).
-- `DistanceMatrix` no longer returns rows for zero distances, e.g. cells on the same site.
 - Previously, `Displacement` defaulted to returning `NaN` for subscribers who have a location in the reference location but were not seen in the time period for the displacment query. These subscribers are no longer returned unless the `return_subscribers_not_seen` argument is set to `True`.
+- `DistanceMatrix` no longer returns duplicate rows for the lon-lat spatial unit.
+- Previously, `Displacement` defaulted to returning `NaN` for subscribers who have a location in the reference location but were not seen in the time period for the displacement query. These subscribers are no longer returned unless the `return_subscribers_not_seen` argument is set to `True`.
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Attempting to store a query that does not have a standard table name (e.g. `EventTableSubset` or unseeded random sample) will now raise an `UnstorableQueryError` instead of `ValueError`.
 - In the FlowETL deployment example, the external ingestion database is now set up separately from the FlowKit components and connected to FlowDB via a docker overlay network. [#1276](https://github.com/Flowminder/FlowKit/issues/1276)
 - The `md5` attribute of the `Query` class has been renamed to `query_id` [#1288](https://github.com/Flowminder/FlowKit/issues/1288).
-- Previously, `Displacement` defaulted to returning `NaN` for subscribers who have a location in the reference location but were not seen in the time period for the displacment query. These subscribers are no longer returned unless the `return_subscribers_not_seen` argument is set to `True`.
 - `DistanceMatrix` no longer returns duplicate rows for the lon-lat spatial unit.
 - Previously, `Displacement` defaulted to returning `NaN` for subscribers who have a location in the reference location but were not seen in the time period for the displacement query. These subscribers are no longer returned unless the `return_subscribers_not_seen` argument is set to `True`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Attempting to store a query that does not have a standard table name (e.g. `EventTableSubset` or unseeded random sample) will now raise an `UnstorableQueryError` instead of `ValueError`.
 - In the FlowETL deployment example, the external ingestion database is now set up separately from the FlowKit components and connected to FlowDB via a docker overlay network. [#1276](https://github.com/Flowminder/FlowKit/issues/1276)
 - The `md5` attribute of the `Query` class has been renamed to `query_id` [#1288](https://github.com/Flowminder/FlowKit/issues/1288).
+- `DistanceMatrix` no longer returns rows for zero distances, e.g. cells on the same site.
+- Previously, `Displacement` defaulted to returning `NaN` for subscribers who have a location in the reference location but were not seen in the time period for the displacment query. These subscribers are no longer returned unless the `return_subscribers_not_seen` argument is set to `True`.
 
 
 ### Fixed

--- a/flowmachine/flowmachine/features/spatial/distance_matrix.py
+++ b/flowmachine/flowmachine/features/spatial/distance_matrix.py
@@ -96,7 +96,7 @@ class DistanceMatrix(GraphMixin, Query):
         return col_names
 
     def _make_query(self):
-        if self.spatial_unit.md5 == LonLatSpatialUnit().md5:
+        if self.spatial_unit == LonLatSpatialUnit():
             if self.return_geometry:
                 return_geometry_statement = """
                     ,

--- a/flowmachine/flowmachine/features/spatial/distance_matrix.py
+++ b/flowmachine/flowmachine/features/spatial/distance_matrix.py
@@ -83,6 +83,10 @@ class DistanceMatrix(GraphMixin, Query):
         super().__init__()
 
     @property
+    def table_name(self):
+        raise NotImplementedError("Store this object's geom_matrix instead.")
+
+    @property
     def column_names(self) -> List[str]:
         col_names = [f"{c}_from" for c in self.spatial_unit.location_id_columns]
         col_names += [f"{c}_to" for c in self.spatial_unit.location_id_columns]

--- a/flowmachine/flowmachine/features/spatial/distance_matrix.py
+++ b/flowmachine/flowmachine/features/spatial/distance_matrix.py
@@ -86,12 +86,13 @@ class DistanceMatrix(GraphMixin, Query):
                 A.geom AS geom_origin,
                 B.geom AS geom_destination
             """
+            outer_geom_statement = ", geom_origin, geom_destination"
         else:
             return_geometry_statement = ""
 
         sql = f"""
             SELECT {", ".join(f"unnest({col}_{direction}) as {col}_{direction}" for col in self.spatial_unit.location_id_columns for direction in ("to", "from"))}, 
-            distance {return_geometry_statement}
+            distance{outer_geom_statement}
             FROM
             (SELECT
                 {cols_A},

--- a/flowmachine/flowmachine/features/spatial/distance_matrix.py
+++ b/flowmachine/flowmachine/features/spatial/distance_matrix.py
@@ -17,8 +17,8 @@ from ...core.spatial_unit import LonLatSpatialUnit
 
 
 class _GeomDistanceMatrix(Query):
-    def __init__(self):
-        self.geom_table = Table("infrastructure.cells", columns=["geom_point"])
+    def __init__(self, *, geom_table):
+        self.geom_table = geom_table
         super().__init__()
 
     @property
@@ -77,7 +77,7 @@ class DistanceMatrix(GraphMixin, Query):
             self.spatial_unit = spatial_unit
 
         self.spatial_unit.verify_criterion("has_lon_lat_columns")
-        self.geom_matrix = _GeomDistanceMatrix()
+        self.geom_matrix = _GeomDistanceMatrix(geom_table=self.spatial_unit.geom_table)
         self.return_geometry = return_geometry
 
         super().__init__()

--- a/flowmachine/flowmachine/features/spatial/distance_matrix.py
+++ b/flowmachine/flowmachine/features/spatial/distance_matrix.py
@@ -89,9 +89,15 @@ class DistanceMatrix(GraphMixin, Query):
             outer_geom_statement = ", geom_origin, geom_destination"
         else:
             return_geometry_statement = ""
+            outer_geom_statement = ""
 
+        unnested = ", ".join(
+            f"unnest({col}_{direction}) as {col}_{direction}"
+            for col in self.spatial_unit.location_id_columns
+            for direction in ("to", "from")
+        )
         sql = f"""
-            SELECT {", ".join(f"unnest({col}_{direction}) as {col}_{direction}" for col in self.spatial_unit.location_id_columns for direction in ("to", "from"))}, 
+            SELECT {unnested}, 
             distance{outer_geom_statement}
             FROM
             (SELECT

--- a/flowmachine/flowmachine/features/subscriber/displacement.py
+++ b/flowmachine/flowmachine/features/subscriber/displacement.py
@@ -106,16 +106,13 @@ class Displacement(SubscriberFeature):
         subscriber_subset: Optional[Query] = None,
     ):
 
-        # need to subtract one day from hl end in order to be
-        # comparing over same period...
-        self.stop_sl = stop
-        self.stop_hl = str(parse_datestring(stop) - relativedelta(days=1))
         self.return_subscribers_not_seen = return_subscribers_not_seen
         self.start = start
+        self.stop = stop
         self.spatial_unit = reference_location.spatial_unit
         subscriber_locations = SubscriberLocations(
             self.start,
-            self.stop_sl,
+            self.stop,
             spatial_unit=self.spatial_unit,
             hours=hours,
             table=table,

--- a/flowmachine/flowmachine/features/subscriber/displacement.py
+++ b/flowmachine/flowmachine/features/subscriber/displacement.py
@@ -47,20 +47,11 @@ class Displacement(SubscriberFeature):
     unit : {'km', 'm'}, default 'km'
         Unit with which to express the answers, currently the choices
         are kilometres ('km') or metres ('m')
-    
-    Other parameters
-    ----------------
     hours : tuple of ints, default 'all'
         Subset the result within certain hours, e.g. (4,17)
         This will subset the query only with these hours, but
         across all specified days. Or set to 'all' to include
         all hours.
-    method : str, default 'last'
-        The method by which to calculate the location of the subscriber.
-        This can be either 'most-common' or last. 'most-common' is
-        simply the modal location of the subscribers, whereas 'lsat' is
-        the location of the subscriber at the time of the final call in
-        the data.
     table : str, default 'all'
         schema qualified name of the table which the analysis is
         based upon. If 'all' it will use all tables that contain

--- a/flowmachine/flowmachine/features/subscriber/displacement.py
+++ b/flowmachine/flowmachine/features/subscriber/displacement.py
@@ -11,10 +11,8 @@ from typing import List, Union, Tuple, Optional
 from flowmachine.features.spatial import DistanceMatrix
 from .metaclasses import SubscriberFeature
 from ..utilities.subscriber_locations import SubscriberLocations, BaseLocation
-from flowmachine.utils import parse_datestring, get_dist_query_string, list_of_dates
-from flowmachine.core import make_spatial_unit, Table, Query
+from flowmachine.core import Query
 
-from dateutil.relativedelta import relativedelta
 
 valid_stats = {"sum", "avg", "max", "min", "median", "stddev", "variance"}
 
@@ -161,7 +159,7 @@ class Displacement(SubscriberFeature):
         sql = f"""
         SELECT 
             subscriber,
-            {self.statistic}(COALESCE(distance_dist, 0) * {multiplier}) as value
+            {self.statistic}(COALESCE(value_dist, 0) * {multiplier}) as value
         FROM 
             ({self.joined.get_query()}) _
         GROUP BY 

--- a/flowmachine/flowmachine/features/subscriber/displacement.py
+++ b/flowmachine/flowmachine/features/subscriber/displacement.py
@@ -61,7 +61,7 @@ class Displacement(SubscriberFeature):
         results to; or, a query or table which has a column with a name matching
         subscriber_identifier (typically, msisdn), to limit results to.
     return_subscribers_not_seen : bool, default False
-        By default, subscribers who are not seen in the time period are dropped. Set to Truw
+        By default, subscribers who are not seen in the time period are dropped. Set to True
         to return them as NULL.
     ignore_nulls : bool, default True
         ignores those values that are null. Sometime data appears for which

--- a/flowmachine/flowmachine/features/subscriber/distance_counterparts.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_counterparts.py
@@ -121,7 +121,7 @@ class DistanceCounterparts(SubscriberFeature):
 
     @property
     def column_names(self) -> List[str]:
-        return ["subscriber", f"distance_{self.statistic}"]
+        return ["subscriber", "value"]
 
     def _make_query(self):
 
@@ -137,7 +137,7 @@ class DistanceCounterparts(SubscriberFeature):
         sql = f"""
         SELECT
             U.subscriber AS subscriber,
-            {self.statistic}(D.distance) AS distance_{self.statistic}
+            {self.statistic}(D.value) AS value
         FROM
             (
                 SELECT A.subscriber, A.location_id AS location_id_from, B.location_id AS location_id_to FROM

--- a/flowmachine/flowmachine/features/subscriber/distance_counterparts.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_counterparts.py
@@ -147,7 +147,7 @@ class DistanceCounterparts(SubscriberFeature):
             ) U
         JOIN
             ({self.distance_matrix.get_query()}) D
-        ON U.location_id_from = D.location_id_from AND U.location_id_to = D.location_id_to
+        USING (location_id_from, location_id_to)
         GROUP BY U.subscriber
         """
 

--- a/flowmachine/flowmachine/models/pwo.py
+++ b/flowmachine/flowmachine/models/pwo.py
@@ -84,7 +84,7 @@ class _populationBuffer(Query):
                 A.value AS distance,
                 A.geom_origin AS geom_origin,
                 A.geom_destination AS geom_destination,
-                ST_Buffer(A.geom_destination::geography, A.distance * 1000) AS geom_buffer
+                ST_Buffer(A.geom_destination::geography, A.value * 1000) AS geom_buffer
             FROM ({distance_matrix_table}) AS A
 
         """.format(

--- a/flowmachine/flowmachine/models/pwo.py
+++ b/flowmachine/flowmachine/models/pwo.py
@@ -81,7 +81,7 @@ class _populationBuffer(Query):
             SELECT
                 {froms},
                 {tos},
-                A.distance AS distance,
+                A.value AS distance,
                 A.geom_origin AS geom_origin,
                 A.geom_destination AS geom_destination,
                 ST_Buffer(A.geom_destination::geography, A.distance * 1000) AS geom_buffer

--- a/flowmachine/tests/test_displacement.py
+++ b/flowmachine/tests/test_displacement.py
@@ -19,7 +19,7 @@ from unittest.mock import Mock
         ("stddev", 182.885304966881, 218.698764480622),
         ("avg", 370.301009034846, 389.155343931983),
         ("sum", 11109.0302710454, 11285.5049740275),
-        ("variance", 33447034.7728291, 47829149.5853505),
+        ("variance", 3344.70347728291, 47829.1495853505),
     ],
 )
 def test_returns_expected_values(stat, sub_a_expected, sub_b_expected, get_dataframe):

--- a/flowmachine/tests/test_displacement.py
+++ b/flowmachine/tests/test_displacement.py
@@ -132,7 +132,6 @@ def test_subscriber_with_home_loc_but_no_calls_is_nan(get_dataframe):
     but has a home location returns a nan value
     """
 
-    p1 = ("2016-01-02 10:00:00", "2016-01-02 12:00:00")
     p2 = ("2016-01-01 12:01:00", "2016-01-01 15:20:00")
     subscriber = "OdM7np8LYEp1mkvP"
 
@@ -144,3 +143,20 @@ def test_subscriber_with_home_loc_but_no_calls_is_nan(get_dataframe):
     df = get_dataframe(d).set_index("subscriber")
 
     assert isnan(df.loc[subscriber].value)
+
+
+def test_subscriber_with_home_loc_but_no_calls_is_ommitted(get_dataframe):
+    """
+    Test that a subscriber who has no activity between start and stop
+    but has a home location is omitted by default.
+    """
+
+    p2 = ("2016-01-01 12:01:00", "2016-01-01 15:20:00")
+    subscriber = "OdM7np8LYEp1mkvP"
+
+    rl = daily_location("2016-01-01", spatial_unit=make_spatial_unit("lon-lat"))
+    d = Displacement(*p2, reference_location=rl)
+
+    df = get_dataframe(d).set_index("subscriber")
+
+    assert subscriber not in df

--- a/flowmachine/tests/test_displacement.py
+++ b/flowmachine/tests/test_displacement.py
@@ -19,7 +19,7 @@ from unittest.mock import Mock
         ("stddev", 182.885304966881, 218.698764480622),
         ("avg", 370.301009034846, 389.155343931983),
         ("sum", 11109.0302710454, 11285.5049740275),
-        ("variance", 3344.70347728291, 47829.1495853505),
+        ("variance", 33447.0347728291, 47829.1495853505),
     ],
 )
 def test_returns_expected_values(stat, sub_a_expected, sub_b_expected, get_dataframe):
@@ -127,7 +127,9 @@ def test_get_all_users_in_reference_location(get_dataframe):
     p2 = ("2016-01-01 12:01:00", "2016-01-01 15:20:00")
 
     rl = daily_location("2016-01-01", spatial_unit=make_spatial_unit("lon-lat"))
-    d = Displacement(p2[0], p2[1], reference_location=rl)
+    d = Displacement(
+        p2[0], p2[1], reference_location=rl, return_subscribers_not_seen=True
+    )
 
     ml_subscribers = set(get_dataframe(rl).subscriber)
     d_subscribers = set(get_dataframe(d).subscriber)
@@ -146,7 +148,9 @@ def test_subscriber_with_home_loc_but_no_calls_is_nan(get_dataframe):
     subscriber = "OdM7np8LYEp1mkvP"
 
     rl = daily_location("2016-01-01", spatial_unit=make_spatial_unit("lon-lat"))
-    d = Displacement(p2[0], p2[1], reference_location=rl)
+    d = Displacement(
+        p2[0], p2[1], reference_location=rl, return_subscribers_not_seen=True
+    )
 
     df = get_dataframe(d).set_index("subscriber")
 

--- a/flowmachine/tests/test_displacement.py
+++ b/flowmachine/tests/test_displacement.py
@@ -3,51 +3,41 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from flowmachine.features import Displacement, ModalLocation, daily_location
+from flowmachine.features import Displacement, daily_location
 from numpy import isnan
 
-from flowmachine.utils import list_of_dates
 from flowmachine.core import make_spatial_unit
 from unittest.mock import Mock
 
 
 @pytest.mark.parametrize(
-    "stat, sub_a_expected, sub_b_expected",
+    "stat, unit, sub_a_expected, sub_b_expected",
     [
-        ("max", 622.28125098963, 677.14603390011),
-        ("median", 398.64699488375, 442.22387282014),
-        ("stddev", 182.885304966881, 218.698764480622),
-        ("avg", 370.301009034846, 389.155343931983),
-        ("sum", 11109.0302710454, 11285.5049740275),
-        ("variance", 33447.0347728291, 47829.1495853505),
+        ("max", "km", 622.28125098963, 677.14603390011),
+        ("median", "km", 398.64699488375, 442.22387282014),
+        ("stddev", "km", 182.885304966881, 218.698764480622),
+        ("avg", "km", 370.301009034846, 389.155343931983),
+        ("sum", "km", 11109.0302710454, 11285.5049740275),
+        ("variance", "km", 33447.0347728291, 47829.1495853505),
+        ("max", "m", 622281.25098963, 677146.03390011),
+        ("variance", "m", 33447034772.8291, 47829149585.3505),
     ],
 )
-def test_returns_expected_values(stat, sub_a_expected, sub_b_expected, get_dataframe):
+def test_returns_expected_values(
+    stat, unit, sub_a_expected, sub_b_expected, get_dataframe
+):
     """
     Test that we get expected return values for the various statistics
     """
     sub_a_id, sub_b_id = "j6QYNbMJgAwlVORP", "NG1km5NzBg5JD8nj"
     rl = daily_location("2016-01-01", spatial_unit=make_spatial_unit("lon-lat"))
     df = get_dataframe(
-        Displacement("2016-01-01", "2016-01-07", reference_location=rl, statistic=stat)
+        Displacement(
+            "2016-01-01", "2016-01-07", reference_location=rl, statistic=stat, unit=unit
+        )
     ).set_index("subscriber")
     assert df.loc[sub_a_id].value == pytest.approx(sub_a_expected)
     assert df.loc[sub_b_id].value == pytest.approx(sub_b_expected)
-
-
-def test_returns_expected_result_for_unit_m(get_dataframe):
-    """
-    Test that we get expected results when unit='m'.
-    """
-    sub_a_id, sub_b_id = "j6QYNbMJgAwlVORP", "NG1km5NzBg5JD8nj"
-    rl = daily_location("2016-01-01", spatial_unit=make_spatial_unit("lon-lat"))
-    df = get_dataframe(
-        Displacement(
-            "2016-01-01", "2016-01-07", reference_location=rl, statistic="max", unit="m"
-        )
-    ).set_index("subscriber")
-    assert df.loc[sub_a_id].value == pytest.approx(622281.25098963)
-    assert df.loc[sub_b_id].value == pytest.approx(677146.03390011)
 
 
 def test_min_displacement_zero(get_dataframe):
@@ -123,7 +113,6 @@ def test_get_all_users_in_reference_location(get_dataframe):
     in the home location object.
     """
 
-    p1 = ("2016-01-02 10:00:00", "2016-01-02 12:00:00")
     p2 = ("2016-01-01 12:01:00", "2016-01-01 15:20:00")
 
     rl = daily_location("2016-01-01", spatial_unit=make_spatial_unit("lon-lat"))

--- a/flowmachine/tests/test_models_pwo.py
+++ b/flowmachine/tests/test_models_pwo.py
@@ -8,6 +8,7 @@ Tests for the PopulationWeightedOpportunities() class.
 
 import pytest
 
+from flowmachine.core.errors import UnstorableQueryError
 from flowmachine.models import PopulationWeightedOpportunities
 
 
@@ -25,23 +26,23 @@ def test_returns_correct_results(get_dataframe):
     assert set_df.loc["0xqNDj"]["site_id_to"].values[7] == "DonxkP"
 
     assert set_df.loc["0xqNDj"]["prediction"].values[1] == pytest.approx(
-        0.00425979428316989
+        0.00428076166366159
     )
     assert set_df.loc["0xqNDj"]["prediction"].values[3] == pytest.approx(
-        0.0159849136646041
+        0.0160635939352117
     )
     assert set_df.loc["0xqNDj"]["prediction"].values[7] == pytest.approx(
-        0.00687498444435647
+        0.0069088242040108
     )
 
     assert set_df.loc["0xqNDj"]["probability"].values[1] == pytest.approx(
-        0.00193627012871359
+        0.00194580075620981
     )
     assert set_df.loc["0xqNDj"]["probability"].values[3] == pytest.approx(
-        0.00726586984754731
+        0.00730163360691442
     )
     assert set_df.loc["0xqNDj"]["probability"].values[7] == pytest.approx(
-        0.00312499292925294
+        0.00314037463818673
     )
 
 
@@ -60,23 +61,23 @@ def test_run_with_location_vector(get_dataframe):
     assert set_df.loc["0xqNDj"]["site_id_to"].values[7] == "DonxkP"
 
     assert set_df.loc["0xqNDj"]["prediction"].values[1] == pytest.approx(
-        0.038338148548529
+        0.0385268549729543
     )
     assert set_df.loc["0xqNDj"]["prediction"].values[3] == pytest.approx(
-        0.143864222981437
+        0.144572345416906
     )
     assert set_df.loc["0xqNDj"]["prediction"].values[7] == pytest.approx(
-        0.0618748599992082
+        0.0621794178360972
     )
 
     assert set_df.loc["0xqNDj"]["probability"].values[1] == pytest.approx(
-        0.00193627012871359
+        0.00194580075620981
     )
     assert set_df.loc["0xqNDj"]["probability"].values[3] == pytest.approx(
-        0.00726586984754731
+        0.00730163360691442
     )
     assert set_df.loc["0xqNDj"]["probability"].values[7] == pytest.approx(
-        0.00312499292925294
+        0.00314037463818673
     )
 
 
@@ -162,7 +163,7 @@ def test_get_stored():
 
 def test_model_result_store_dependencies():
     """
-    Test that storing a ModelResult with store_dependencies=True stores the model's dependencies.
+    Test that storing a ModelResult with store_dependencies=True stores the model's (storable) dependencies.
     """
     p = PopulationWeightedOpportunities("2016-01-01", "2016-01-02")
     mr = p.run(departure_rate_vector={"0xqNDj": 0.9}, ignore_missing=True)
@@ -170,7 +171,12 @@ def test_model_result_store_dependencies():
     # Check that the dependencies aren't all already stored
     assert not all([dep.is_stored for dep in deps])
     mr.store(store_dependencies=True).result()
-    assert all([dep.is_stored for dep in deps])
+    for dep in deps:
+        try:
+            dep.table_name
+            assert dep.is_stored
+        except NotImplementedError:
+            assert not dep.is_stored
 
 
 def test_model_result_string_rep():

--- a/flowmachine/tests/test_spatial_distancematrix.py
+++ b/flowmachine/tests/test_spatial_distancematrix.py
@@ -40,3 +40,8 @@ def test_result_has_correct_length(spatial_unit_type, length, get_length):
     """
     c = DistanceMatrix(spatial_unit=make_spatial_unit(spatial_unit_type))
     assert get_length(c) == length
+
+
+def test_not_storeable():
+    with pytest.raises(ValueError):
+        DistanceMatrix(spatial_unit=make_spatial_unit("versioned-site")).store()

--- a/flowmachine/tests/test_spatial_distancematrix.py
+++ b/flowmachine/tests/test_spatial_distancematrix.py
@@ -32,7 +32,7 @@ def test_some_results(get_dataframe):
 
 @pytest.mark.parametrize(
     "spatial_unit_type, length",
-    [("versioned-cell", 3844), ("versioned-site", 1225), ("lon-lat", 2638)],
+    [("versioned-cell", 3844), ("versioned-site", 1225), ("lon-lat", 1089)],
 )
 def test_result_has_correct_length(spatial_unit_type, length, get_length):
     """

--- a/flowmachine/tests/test_spatial_distancematrix.py
+++ b/flowmachine/tests/test_spatial_distancematrix.py
@@ -18,10 +18,16 @@ def test_some_results(get_dataframe):
     """
     c = DistanceMatrix(spatial_unit=make_spatial_unit("versioned-site"))
     df = get_dataframe(c)
-    set_df = df.set_index("site_id_from")
-    assert set_df.loc["8wPojr"]["distance"].values[0] == pytest.approx(789)
-    assert set_df.loc["8wPojr"]["distance"].values[2] == pytest.approx(769)
-    assert set_df.loc["8wPojr"]["distance"].values[4] == pytest.approx(758)
+    set_df = df.set_index(["site_id_from", "version_from", "site_id_to", "version_to"])
+    assert set_df.loc[("8wPojr", 1, "GN2k0G", 0)]["distance"] == pytest.approx(
+        789.23239740488
+    )
+    assert set_df.loc[("8wPojr", 0, "GN2k0G", 0)]["distance"] == pytest.approx(
+        769.20155628077
+    )
+    assert set_df.loc[("8wPojr", 1, "DbWg4K", 0)]["distance"] == pytest.approx(
+        757.97771793683
+    )
 
 
 @pytest.mark.parametrize(

--- a/flowmachine/tests/test_spatial_distancematrix.py
+++ b/flowmachine/tests/test_spatial_distancematrix.py
@@ -19,13 +19,13 @@ def test_some_results(get_dataframe):
     c = DistanceMatrix(spatial_unit=make_spatial_unit("versioned-site"))
     df = get_dataframe(c)
     set_df = df.set_index(["site_id_from", "version_from", "site_id_to", "version_to"])
-    assert set_df.loc[("8wPojr", 1, "GN2k0G", 0)]["distance"] == pytest.approx(
+    assert set_df.loc[("8wPojr", 1, "GN2k0G", 0)]["value"] == pytest.approx(
         789.23239740488
     )
-    assert set_df.loc[("8wPojr", 0, "GN2k0G", 0)]["distance"] == pytest.approx(
+    assert set_df.loc[("8wPojr", 0, "GN2k0G", 0)]["value"] == pytest.approx(
         769.20155628077
     )
-    assert set_df.loc[("8wPojr", 1, "DbWg4K", 0)]["distance"] == pytest.approx(
+    assert set_df.loc[("8wPojr", 1, "DbWg4K", 0)]["value"] == pytest.approx(
         757.97771793683
     )
 

--- a/flowmachine/tests/test_spatial_distancematrix.py
+++ b/flowmachine/tests/test_spatial_distancematrix.py
@@ -26,11 +26,11 @@ def test_some_results(get_dataframe):
 
 @pytest.mark.parametrize(
     "spatial_unit_type, length",
-    [("versioned-cell", 62), ("versioned-site", 35), ("lon-lat", 62)],
+    [("versioned-cell", 2638), ("versioned-site", 1225), ("lon-lat", 2638)],
 )
 def test_result_has_correct_length(spatial_unit_type, length, get_length):
     """
-    DistanceMatrix() has the correct length.
+    DistanceMatrix has the correct length.
     """
     c = DistanceMatrix(spatial_unit=make_spatial_unit(spatial_unit_type))
-    assert get_length(c) == length ** 2
+    assert get_length(c) == length

--- a/flowmachine/tests/test_spatial_distancematrix.py
+++ b/flowmachine/tests/test_spatial_distancematrix.py
@@ -8,6 +8,7 @@ Tests for the DistanceMatrix() class.
 
 import pytest
 
+from flowmachine.core.errors import UnstorableQueryError
 from flowmachine.features.spatial import DistanceMatrix
 from flowmachine.core import make_spatial_unit
 
@@ -43,5 +44,5 @@ def test_result_has_correct_length(spatial_unit_type, length, get_length):
 
 
 def test_not_storeable():
-    with pytest.raises(ValueError):
+    with pytest.raises(UnstorableQueryError):
         DistanceMatrix(spatial_unit=make_spatial_unit("versioned-site")).store()

--- a/flowmachine/tests/test_spatial_distancematrix.py
+++ b/flowmachine/tests/test_spatial_distancematrix.py
@@ -19,14 +19,14 @@ def test_some_results(get_dataframe):
     c = DistanceMatrix(spatial_unit=make_spatial_unit("versioned-site"))
     df = get_dataframe(c)
     set_df = df.set_index("site_id_from")
-    assert round(set_df.loc["8wPojr"]["distance"].values[0]) == 789
-    assert round(set_df.loc["8wPojr"]["distance"].values[2]) == 769
-    assert round(set_df.loc["8wPojr"]["distance"].values[4]) == 758
+    assert set_df.loc["8wPojr"]["distance"].values[0] == pytest.approx(789)
+    assert set_df.loc["8wPojr"]["distance"].values[2] == pytest.approx(769)
+    assert set_df.loc["8wPojr"]["distance"].values[4] == pytest.approx(758)
 
 
 @pytest.mark.parametrize(
     "spatial_unit_type, length",
-    [("versioned-cell", 2638), ("versioned-site", 1225), ("lon-lat", 2638)],
+    [("versioned-cell", 3844), ("versioned-site", 1225), ("lon-lat", 2638)],
 )
 def test_result_has_correct_length(spatial_unit_type, length, get_length):
     """

--- a/flowmachine/tests/test_subscriber_distance_counterparts.py
+++ b/flowmachine/tests/test_subscriber_distance_counterparts.py
@@ -60,7 +60,7 @@ def distance_counterparts_wanted(get_dataframe, distance_matrix):
             right_on=("location_id_from", "location_id_to"),
         )
 
-        return events.loc[:, ["subscriber", "distance"]].groupby("subscriber")
+        return events.loc[:, ["subscriber", "value"]].groupby("subscriber")
 
     return _distance_counterparts_wanted
 
@@ -73,19 +73,19 @@ def test_distance_counterparts(get_dataframe, distance_counterparts_wanted):
     df = get_dataframe(query).set_index("subscriber")
     got = df.head(n=5)
     want = distance_counterparts_wanted("2016-01-01", "2016-01-07", "both", got).mean()
-    assert got.distance_avg.to_dict() == pytest.approx(want.distance.to_dict())
+    assert got.value.to_dict() == pytest.approx(want.value.to_dict())
 
     query = DistanceCounterparts("2016-01-01", "2016-01-07", direction="out")
     df = get_dataframe(query).set_index("subscriber")
     got = df.head(n=5)
     want = distance_counterparts_wanted("2016-01-01", "2016-01-07", "out", got).mean()
-    assert got.distance_avg.to_dict() == pytest.approx(want.distance.to_dict())
+    assert got.value.to_dict() == pytest.approx(want.value.to_dict())
 
     query = DistanceCounterparts("2016-01-03", "2016-01-05", direction="in")
     df = get_dataframe(query).set_index("subscriber")
     got = df.head(n=5)
     want = distance_counterparts_wanted("2016-01-03", "2016-01-05", "in", got).mean()
-    assert got.distance_avg.to_dict() == pytest.approx(want.distance.to_dict())
+    assert got.value.to_dict() == pytest.approx(want.value.to_dict())
 
     query = DistanceCounterparts(
         "2016-01-03", "2016-01-05", direction="in", subscriber_subset=got.index.values
@@ -93,10 +93,10 @@ def test_distance_counterparts(get_dataframe, distance_counterparts_wanted):
     df = get_dataframe(query).set_index("subscriber")
     got = df.head(n=5)
     want = distance_counterparts_wanted("2016-01-03", "2016-01-05", "in", got).mean()
-    assert got.distance_avg.to_dict() == pytest.approx(want.distance.to_dict())
+    assert got.value.to_dict() == pytest.approx(want.value.to_dict())
 
     query = DistanceCounterparts("2016-01-01", "2016-01-05", statistic="stddev")
     df = get_dataframe(query).set_index("subscriber")
     got = df.head(n=5)
     want = distance_counterparts_wanted("2016-01-01", "2016-01-05", "both", got).std()
-    assert got.distance_stddev.to_dict() == pytest.approx(want.distance.to_dict())
+    assert got.value.to_dict() == pytest.approx(want.value.to_dict())


### PR DESCRIPTION
Closes #1271

Distance matrix is, for even moderate numbers of cells, _crazy_ slow. Storing a full distance matrix is basically untenable because they're massive. This compromises, by allowing us to store the most compact possible distance matrix - the distinct geoms.

There are also some minor changes to classes using it, to ensure they use it effectively (i.e. a whole n x n distance matrix never gets calculated), and some corrections to previously erroneous tests.