### PR TITLE
Distance series query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- Added new `DistanceSeries` query to Flowmachine, which produces per-subscriber time series of distance from a reference point. [#1313](https://github.com/Flowminder/FlowKit/issues/1313)
 
 ### Changed
 

--- a/flowmachine/flowmachine/features/subscriber/__init__.py
+++ b/flowmachine/flowmachine/features/subscriber/__init__.py
@@ -72,3 +72,4 @@ from .per_contact_event_stats import PerContactEventStats
 from .per_location_event_stats import PerLocationEventStats
 from .handset_stats import HandsetStats
 from .interevent_interval import IntereventInterval
+from .distance_series import DistanceSeries

--- a/flowmachine/flowmachine/features/subscriber/distance_series.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_series.py
@@ -14,7 +14,17 @@ from ..utilities.subscriber_locations import SubscriberLocations, BaseLocation
 
 
 valid_stats = {"sum", "avg", "max", "min", "median", "stddev", "variance"}
-valid_time_buckets = ["second", "minute", "hour", "day", "week", "month", "quarter", "year", "century"]
+valid_time_buckets = [
+    "second",
+    "minute",
+    "hour",
+    "day",
+    "week",
+    "month",
+    "quarter",
+    "year",
+    "century",
+]
 
 
 class DistanceSeries(SubscriberFeature):
@@ -70,7 +80,6 @@ class DistanceSeries(SubscriberFeature):
             raise ValueError(
                 f"'{time_bucket}' is not a valid value for time_bucket. Use one of {valid_time_buckets}"
             )
-
 
         if statistic not in valid_stats:
             raise ValueError(

--- a/flowmachine/flowmachine/features/subscriber/distance_series.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_series.py
@@ -130,7 +130,7 @@ class DistanceSeries(SubscriberFeature):
         SELECT 
             subscriber,
             date_trunc('{self.aggregate_by}', time_to){date_cast} as datetime,
-            {self.statistic}(COALESCE(value_dist, 0) as value
+            {self.statistic}(COALESCE(value_dist, 0)) as value
         FROM 
             ({joined}) _
         GROUP BY 

--- a/flowmachine/flowmachine/features/subscriber/distance_series.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_series.py
@@ -14,7 +14,7 @@ from ..utilities.subscriber_locations import SubscriberLocations, BaseLocation
 
 
 valid_stats = {"sum", "avg", "max", "min", "median", "stddev", "variance"}
-valid_time_buckets = ["second", "minute", "hour", "day", "month", "year", "century"]
+valid_time_buckets = ["second", "minute", "hour", "day", "week", "month", "quarter", "year", "century"]
 
 
 class DistanceSeries(SubscriberFeature):
@@ -38,7 +38,7 @@ class DistanceSeries(SubscriberFeature):
     statistic : str
         the statistic to calculate one of 'sum', 'avg', 'max', 'min', 
         'median', 'stddev' or 'variance'
-    time_bucket : {"second", "minute", "hour", "day", "month", "year", "century"}, default "day"
+    time_bucket : {"second", "minute", "hour", "day", "week", "month", "quarter", "year", "century"}, default "day"
         Time bucket to calculate the statistic over.
 
     Examples

--- a/flowmachine/flowmachine/features/subscriber/distance_series.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_series.py
@@ -71,11 +71,12 @@ class DistanceSeries(SubscriberFeature):
                 f"'{time_bucket}' is not a valid value for time_bucket. Use one of {valid_time_buckets}"
             )
 
-        self.statistic = statistic.lower()
-        if self.statistic not in valid_stats:
+
+        if statistic not in valid_stats:
             raise ValueError(
-                f"{self.statistic} is not a valid statistic. Use one of {valid_stats}"
+                f"'{statistic}' is not a valid statistic. Use one of {valid_stats}"
             )
+        self.statistic = statistic.lower()
         self.start = subscriber_locations.start
         self.stop = subscriber_locations.stop
         if isinstance(reference_location, tuple):
@@ -105,7 +106,7 @@ class DistanceSeries(SubscriberFeature):
         else:
             raise ValueError(
                 "Argument 'reference_location' should be an instance of BaseLocation class or a tuple of two floats. "
-                f"Got: {type(reference_location)}"
+                f"Got: {type(reference_location).__name__}"
             )
 
         super().__init__()

--- a/flowmachine/flowmachine/features/subscriber/distance_series.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_series.py
@@ -67,9 +67,7 @@ class DistanceSeries(SubscriberFeature):
         self.statistic = statistic.lower()
         if self.statistic not in valid_stats:
             raise ValueError(
-                "{} is not a valid statistic. Use one of {}".format(
-                    self.statistic, valid_stats
-                )
+                f"{self.statistic} is not a valid statistic. Use one of {valid_stats}"
             )
         self.start = subscriber_locations.start
         self.stop = subscriber_locations.stop

--- a/flowmachine/flowmachine/features/subscriber/distance_series.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_series.py
@@ -81,7 +81,7 @@ class DistanceSeries(SubscriberFeature):
                 f"'{time_bucket}' is not a valid value for time_bucket. Use one of {valid_time_buckets}"
             )
 
-        if statistic not in valid_stats:
+        if statistic.lower() not in valid_stats:
             raise ValueError(
                 f"'{statistic}' is not a valid statistic. Use one of {valid_stats}"
             )

--- a/flowmachine/flowmachine/features/subscriber/distance_series.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_series.py
@@ -1,0 +1,147 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# -*- coding: utf-8 -*-
+"""
+Per subscriber time series of distances from some reference location.
+"""
+from typing import List, Optional
+
+from flowmachine.features.spatial import DistanceMatrix
+from .metaclasses import SubscriberFeature
+from ..utilities.subscriber_locations import SubscriberLocations, BaseLocation
+
+
+valid_stats = {"sum", "avg", "max", "min", "median", "stddev", "variance"}
+valid_time_buckets = ["second", "minute", "hour", "day", "month", "year", "century"]
+
+
+class DistanceSeries(SubscriberFeature):
+    """
+    Per subscriber time series of distances from some reference location.
+
+    Parameters
+    ----------
+    subscriber_locations : SubscriberLocations
+        A subscriber locations query with a lon-lat spatial unit to build the distance series against.
+    reference_location : BaseLocation or None, default None
+        The set of home locations from which to calculate distance at each sighting.
+        If not given then distances will be from (0, 0).
+    statistic : str
+        the statistic to calculate one of 'sum', 'avg', 'max', 'min', 
+        'median', 'stddev' or 'variance'
+    unit : {'km', 'm'}, default 'km'
+        Unit with which to express the answers, currently the choices
+        are kilometres ('km') or metres ('m')
+    time_bucket : {"second", "minute", "hour", "day", "month", "year", "century"}, default "day"
+        Time bucket to calculate the statistic over.
+
+    Examples
+    --------
+    >>> d = DistanceSeries(subscriber_locations=SubscriberLocations("2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")))
+    >>> d.head()
+             subscriber    datetime         value
+    0  038OVABN11Ak4W5P  2016-01-01  9.384215e+06
+    1  038OVABN11Ak4W5P  2016-01-02  9.233302e+06
+    2  038OVABN11Ak4W5P  2016-01-03  9.376996e+06
+    3  038OVABN11Ak4W5P  2016-01-04  9.401404e+06
+    4  038OVABN11Ak4W5P  2016-01-05  9.357210e+06
+    """
+
+    def __init__(
+        self,
+        *,
+        subscriber_locations: SubscriberLocations,
+        reference_location: Optional[BaseLocation] = None,
+        statistic: str = "avg",
+        unit: str = "km",
+        time_bucket: str = "day",
+    ):
+        subscriber_locations.spatial_unit.verify_criterion("has_geography")
+        subscriber_locations.spatial_unit.verify_criterion("has_lon_lat_columns")
+        self.spatial_unit = subscriber_locations.spatial_unit
+        if time_bucket.lower() in valid_time_buckets:
+            self.aggregate_by = time_bucket.lower()
+        else:
+            raise ValueError(
+                f"'{time_bucket}' is not a valid value for time_bucket. Use one of {valid_time_buckets}"
+            )
+
+        self.statistic = statistic.lower()
+        if self.statistic not in valid_stats:
+            raise ValueError(
+                "{} is not a valid statistic. Use one of {}".format(
+                    self.statistic, valid_stats
+                )
+            )
+        self.start = subscriber_locations.start
+        self.stop = subscriber_locations.stop
+        if reference_location is None:
+            # Using 0, 0
+            self.reference_location = None
+            self.joined = subscriber_locations
+        elif isinstance(reference_location, BaseLocation):
+            self.reference_location = reference_location
+            self.joined = reference_location.join(
+                other=subscriber_locations,
+                on_left=["subscriber"],
+                left_append="_from",
+                right_append="_to",
+            ).join(
+                DistanceMatrix(spatial_unit=self.spatial_unit),
+                on_left=[
+                    f"{col}_{direction}"
+                    for direction in ("from", "to")
+                    for col in self.spatial_unit.location_id_columns
+                ],
+                right_append="_dist",
+                how="left outer",
+            )
+        else:
+            raise ValueError(
+                "Argument 'reference_location' should be an instance of BaseLocation class or None. "
+                f"Got: {type(reference_location)}"
+            )
+
+        self.unit = unit
+
+        super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "datetime", "value"]
+
+    def _make_query(self):
+        if self.reference_location is None:
+            joined = f"""
+            SELECT subscriber, time as time_to, ST_Distance(ST_Point(0, 0)::geography, ST_Point(lon, lat)::geography) as value_dist
+            FROM ({self.joined.get_query()}) _
+            """
+        else:
+            joined = self.joined.get_query()
+
+        if self.unit == "m":
+            multiplier = 1000
+        elif self.unit == "km":
+            multiplier = 1
+
+        if valid_time_buckets.index(self.aggregate_by) > valid_time_buckets.index(
+            "hour"
+        ):  # Slightly nicer to cast things which aren't timestamps to a date
+            date_cast = "::date"
+        else:
+            date_cast = ""
+
+        sql = f"""
+        SELECT 
+            subscriber,
+            date_trunc('{self.aggregate_by}', time_to){date_cast} as datetime,
+            {self.statistic}(COALESCE(value_dist, 0) * {multiplier}) as value
+        FROM 
+            ({joined}) _
+        GROUP BY 
+            subscriber, date_trunc('{self.aggregate_by}', time_to)
+        """
+
+        return sql

--- a/flowmachine/flowmachine/features/subscriber/distance_series.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_series.py
@@ -82,6 +82,10 @@ class DistanceSeries(SubscriberFeature):
             self.reference_location = None
             self.joined = subscriber_locations
         elif isinstance(reference_location, BaseLocation):
+            if reference_location.spatial_unit != subscriber_locations.spatial_unit:
+                raise ValueError(
+                    "reference_location must have the same spatial unit as subscriber_locations."
+                )
             self.reference_location = reference_location
             self.joined = reference_location.join(
                 other=subscriber_locations,
@@ -104,7 +108,12 @@ class DistanceSeries(SubscriberFeature):
                 f"Got: {type(reference_location)}"
             )
 
-        self.unit = unit
+        if unit.lower() in {"m", "km"}:
+            self.unit = unit.lower()
+        else:
+            raise ValueError(
+                f"'{unit}' is not a valid value for unit. Use one of 'm' or 'km'"
+            )
 
         super().__init__()
 

--- a/flowmachine/tests/test_subscriber_distance_series.py
+++ b/flowmachine/tests/test_subscriber_distance_series.py
@@ -92,7 +92,9 @@ def test_error_when_subs_locations_not_point_geom():
     with pytest.raises(ValueError, match="does not have longitude/latitude columns"):
         DistanceSeries(
             subscriber_locations=SubscriberLocations(
-                "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("admin", level=3)
+                "2016-01-01",
+                "2016-01-07",
+                spatial_unit=make_spatial_unit("admin", level=3),
             )
         )
 
@@ -104,7 +106,10 @@ def test_error_on_spatial_unit_mismatch():
 
     rl = daily_location("2016-01-01", spatial_unit=make_spatial_unit("admin", level=3))
 
-    with pytest.raises(ValueError, match="reference_location must have the same spatial unit as subscriber_locations."):
+    with pytest.raises(
+        ValueError,
+        match="reference_location must have the same spatial unit as subscriber_locations.",
+    ):
         DistanceSeries(
             subscriber_locations=SubscriberLocations(
                 "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")
@@ -130,7 +135,9 @@ def test_invalid_time_bucket_raises_error():
     """
     Test that passing an invalid time bucket raises an error.
     """
-    with pytest.raises(ValueError, match="'NOT_A_BUCKET' is not a valid value for time_bucket"):
+    with pytest.raises(
+        ValueError, match="'NOT_A_BUCKET' is not a valid value for time_bucket"
+    ):
         DistanceSeries(
             subscriber_locations=SubscriberLocations(
                 "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")
@@ -143,7 +150,10 @@ def test_invalid_reference_raises_error():
     """
     Test that passing an invalid reference location raises an error.
     """
-    with pytest.raises(ValueError, match="Argument 'reference_location' should be an instance of BaseLocation class or a tuple of two floats. Got: str"):
+    with pytest.raises(
+        ValueError,
+        match="Argument 'reference_location' should be an instance of BaseLocation class or a tuple of two floats. Got: str",
+    ):
         DistanceSeries(
             subscriber_locations=SubscriberLocations(
                 "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")

--- a/flowmachine/tests/test_subscriber_distance_series.py
+++ b/flowmachine/tests/test_subscriber_distance_series.py
@@ -1,0 +1,113 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from datetime import date
+
+import pytest
+from flowmachine.features import DistanceSeries, daily_location, SubscriberLocations
+from numpy import isnan
+
+from flowmachine.core import make_spatial_unit
+from unittest.mock import Mock
+
+
+@pytest.mark.parametrize(
+    "stat, sub_a_expected, sub_b_expected",
+    [
+        ("min", 0, 0),
+        ("median", 426.73295117925, 407.89567243203),
+        ("stddev", 259.637731932506, 193.169444586714),
+        ("avg", 298.78017265186, 375.960833781832),
+        ("sum", 896.34051795558, 4511.53000538199),
+        ("variance", 67411.7518430558, 37314.4343219396),
+    ],
+)
+def test_returns_expected_values(stat, sub_a_expected, sub_b_expected, get_dataframe):
+    """
+    Test that we get expected return values for the various statistics
+    """
+    sub_a_id, sub_b_id = "j6QYNbMJgAwlVORP", "NG1km5NzBg5JD8nj"
+    rl = daily_location("2016-01-01", spatial_unit=make_spatial_unit("lon-lat"))
+    df = get_dataframe(
+        DistanceSeries(
+            subscriber_locations=SubscriberLocations(
+                "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")
+            ),
+            reference_location=rl,
+            statistic=stat,
+        )
+    ).set_index(["subscriber", "datetime"])
+    assert df.loc[(sub_a_id, date(2016, 1, 1))].value == pytest.approx(sub_a_expected)
+    assert df.loc[(sub_b_id, date(2016, 1, 6))].value == pytest.approx(sub_b_expected)
+
+
+@pytest.mark.parametrize(
+    "stat, sub_a_expected, sub_b_expected",
+    [
+        ("min", 9284030.27181416, 9123237.1676943),
+        ("median", 9327090.49789517, 9348965.25483016),
+        ("stddev", 213651.966918163, 180809.405030127),
+        ("avg", 9428284.48898054, 9390833.62618702),
+        ("sum", 28284853.4669416, 112690003.514244),
+        ("variance", 45647162968.0, 32692040947.3485),
+    ],
+)
+def test_returns_expected_values(stat, sub_a_expected, sub_b_expected, get_dataframe):
+    """
+    Test that we get expected return values for the various statistics with 0, 0 reference
+    """
+    sub_a_id, sub_b_id = "j6QYNbMJgAwlVORP", "NG1km5NzBg5JD8nj"
+    df = get_dataframe(
+        DistanceSeries(
+            subscriber_locations=SubscriberLocations(
+                "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")
+            ),
+            statistic=stat,
+        )
+    ).set_index(["subscriber", "datetime"])
+    assert df.loc[(sub_a_id, date(2016, 1, 1))].value == pytest.approx(sub_a_expected)
+    assert df.loc[(sub_b_id, date(2016, 1, 6))].value == pytest.approx(sub_b_expected)
+
+
+def test_error_when_subs_locations_not_point_geom():
+    """
+    Test that error is raised if the spatial unit of the subscriber locations isn't point.
+    """
+
+    rl = daily_location("2016-01-01")
+
+    with pytest.raises(ValueError):
+        DistanceSeries(
+            subscriber_locations=SubscriberLocations(
+                "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("admin3")
+            )
+        )
+
+
+def test_error_on_spatial_unit_mismatch():
+    """
+    Test that error is raised if the spatial unit of the subscriber locations isn't point.
+    """
+
+    rl = daily_location("2016-01-01")
+
+    with pytest.raises(ValueError):
+        DistanceSeries(
+            subscriber_locations=SubscriberLocations(
+                "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")
+            ),
+            reference_location=rl,
+        )
+
+
+def test_invalid_statistic_raises_error():
+    """
+    Test that passing an invalid statistic raises an error.
+    """
+    with pytest.raises(ValueError):
+        DistanceSeries(
+            subscriber_locations=SubscriberLocations(
+                "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")
+            ),
+            statistic="NOT_A_STATISTIC",
+        )

--- a/flowmachine/tests/test_subscriber_distance_series.py
+++ b/flowmachine/tests/test_subscriber_distance_series.py
@@ -139,19 +139,6 @@ def test_invalid_time_bucket_raises_error():
         )
 
 
-def test_invalid_unit_raises_error():
-    """
-    Test that passing an invalid unit raises an error.
-    """
-    with pytest.raises(ValueError):
-        DistanceSeries(
-            subscriber_locations=SubscriberLocations(
-                "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")
-            ),
-            unit="NOT_A_UNIT",
-        )
-
-
 def test_reference_raises_error():
     """
     Test that passing an invalid reference location raises an error.

--- a/flowmachine/tests/test_subscriber_distance_series.py
+++ b/flowmachine/tests/test_subscriber_distance_series.py
@@ -89,10 +89,10 @@ def test_error_when_subs_locations_not_point_geom():
     Test that error is raised if the spatial unit of the subscriber locations isn't point.
     """
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="does not have longitude/latitude columns"):
         DistanceSeries(
             subscriber_locations=SubscriberLocations(
-                "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("admin3")
+                "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("admin", level=3)
             )
         )
 
@@ -102,9 +102,9 @@ def test_error_on_spatial_unit_mismatch():
     Test that error is raised if the spatial unit of the subscriber locations isn't point.
     """
 
-    rl = daily_location("2016-01-01")
+    rl = daily_location("2016-01-01", spatial_unit=make_spatial_unit("admin", level=3))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="reference_location must have the same spatial unit as subscriber_locations."):
         DistanceSeries(
             subscriber_locations=SubscriberLocations(
                 "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")
@@ -117,7 +117,7 @@ def test_invalid_statistic_raises_error():
     """
     Test that passing an invalid statistic raises an error.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'NOT_A_STATISTIC' is not a valid statistic"):
         DistanceSeries(
             subscriber_locations=SubscriberLocations(
                 "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")
@@ -130,7 +130,7 @@ def test_invalid_time_bucket_raises_error():
     """
     Test that passing an invalid time bucket raises an error.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'NOT_A_BUCKET' is not a valid value for time_bucket"):
         DistanceSeries(
             subscriber_locations=SubscriberLocations(
                 "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")
@@ -143,7 +143,7 @@ def test_invalid_reference_raises_error():
     """
     Test that passing an invalid reference location raises an error.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Argument 'reference_location' should be an instance of BaseLocation class or a tuple of two floats. Got: str"):
         DistanceSeries(
             subscriber_locations=SubscriberLocations(
                 "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")

--- a/flowmachine/tests/test_subscriber_distance_series.py
+++ b/flowmachine/tests/test_subscriber_distance_series.py
@@ -1,14 +1,12 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from datetime import date
+from datetime import date, datetime
 
 import pytest
 from flowmachine.features import DistanceSeries, daily_location, SubscriberLocations
-from numpy import isnan
 
 from flowmachine.core import make_spatial_unit
-from unittest.mock import Mock
 
 
 @pytest.mark.parametrize(
@@ -69,6 +67,21 @@ def test_returns_expected_values_fixed_point(
     ).set_index(["subscriber", "datetime"])
     assert df.loc[(sub_a_id, date(2016, 1, 1))].value == pytest.approx(sub_a_expected)
     assert df.loc[(sub_b_id, date(2016, 1, 6))].value == pytest.approx(sub_b_expected)
+
+
+def test_no_cast_for_below_day(get_dataframe):
+    """
+    Test that results aren't cast to date for smaller time buckets.
+    """
+    df = get_dataframe(
+        DistanceSeries(
+            subscriber_locations=SubscriberLocations(
+                "2016-01-01", "2016-01-02", spatial_unit=make_spatial_unit("lon-lat")
+            ),
+            time_bucket="hour",
+        )
+    )
+    assert isinstance(df.datetime[0], datetime)
 
 
 def test_error_when_subs_locations_not_point_geom():

--- a/flowmachine/tests/test_subscriber_distance_series.py
+++ b/flowmachine/tests/test_subscriber_distance_series.py
@@ -52,7 +52,9 @@ def test_returns_expected_values(stat, sub_a_expected, sub_b_expected, get_dataf
         ("variance", 45647162968.0, 32692040947.3485),
     ],
 )
-def test_returns_expected_values(stat, sub_a_expected, sub_b_expected, get_dataframe):
+def test_returns_expected_values_fixed_point(
+    stat, sub_a_expected, sub_b_expected, get_dataframe
+):
     """
     Test that we get expected return values for the various statistics with 0, 0 reference
     """
@@ -73,8 +75,6 @@ def test_error_when_subs_locations_not_point_geom():
     """
     Test that error is raised if the spatial unit of the subscriber locations isn't point.
     """
-
-    rl = daily_location("2016-01-01")
 
     with pytest.raises(ValueError):
         DistanceSeries(
@@ -110,4 +110,43 @@ def test_invalid_statistic_raises_error():
                 "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")
             ),
             statistic="NOT_A_STATISTIC",
+        )
+
+
+def test_invalid_time_bucket_raises_error():
+    """
+    Test that passing an invalid time bucket raises an error.
+    """
+    with pytest.raises(ValueError):
+        DistanceSeries(
+            subscriber_locations=SubscriberLocations(
+                "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")
+            ),
+            time_bucket="NOT_A_BUCKET",
+        )
+
+
+def test_invalid_unit_raises_error():
+    """
+    Test that passing an invalid unit raises an error.
+    """
+    with pytest.raises(ValueError):
+        DistanceSeries(
+            subscriber_locations=SubscriberLocations(
+                "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")
+            ),
+            unit="NOT_A_UNIT",
+        )
+
+
+def test_reference_raises_error():
+    """
+    Test that passing an invalid reference location raises an error.
+    """
+    with pytest.raises(ValueError):
+        DistanceSeries(
+            subscriber_locations=SubscriberLocations(
+                "2016-01-01", "2016-01-07", spatial_unit=make_spatial_unit("lon-lat")
+            ),
+            reference_location="NOT_A_LOCATION",
         )

--- a/flowmachine/tests/test_subscriber_distance_series.py
+++ b/flowmachine/tests/test_subscriber_distance_series.py
@@ -139,7 +139,7 @@ def test_invalid_time_bucket_raises_error():
         )
 
 
-def test_reference_raises_error():
+def test_invalid_reference_raises_error():
     """
     Test that passing an invalid reference location raises an error.
     """


### PR DESCRIPTION
Closes #1313

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [x] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Adds a `DistanceSeries` query to flowmachine. 

This outputs, per subscriber, a time series of some stat over the distances there were observed to be from a reference location, or arbitary reference point. E.g. minimum distance from 0,0 per day, or  median distance from home per week.