### PR TITLE
Iterative median filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added new `DistanceSeries` query to Flowmachine, which produces per-subscriber time series of distance from a reference point. [#1313](https://github.com/Flowminder/FlowKit/issues/1313)
 - Added new `ImputedDistanceSeries` query to Flowmachine, which produces contiguous per-subscriber time series of distance from a reference point by filling in gaps using the rolling median. [#1337](https://github.com/Flowminder/FlowKit/issues/1337)
+- Added new `IterativeMedianFilter` query to Flowmachine, which applies an iterative median filter to the output of another query. [#1339](https://github.com/Flowminder/FlowKit/issues/1339)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - FlowMachine now periodically prunes the cache to below the permitted cache size. [#1307](https://github.com/Flowminder/FlowKit/issues/1307)
-  
   The frequency of this pruning is configurable using the `FLOWMACHINE_CACHE_PRUNING_FREQUENCY` environment variable to Flowmachine, and queries are excluded from being removed by the automatic shrinker based on the `cache_protected_period` config key within FlowDB.
 - FlowDB now includes Paul Ramsey's [OGR foreign data wrapper](https://github.com/pramsey/pgsql-ogr-fdw), for easy loading of GIS data. [#1512](https://github.com/Flowminder/FlowKit/issues/1512)
 - FlowETL now allows all configuration options to be set using docker secrets. [#1515](https://github.com/Flowminder/FlowKit/issues/1515)
 - Added a new component, AutoFlow, to automate running Jupyter notebooks when new data is added to FlowDB. [#1570](https://github.com/Flowminder/FlowKit/issues/1570)
 - `FLOWETL_INTEGRATION_TESTS_SAVE_AIRFLOW_LOGS` environment variable added to allow copying the Airflow logs in FlowETL integration tests into the /mounts/logs directory for debugging. [#1019](https://github.com/Flowminder/FlowKit/issues/1019)
+- Added new `IterativeMedianFilter` query to Flowmachine, which applies an iterative median filter to the output of another query. [#1339](https://github.com/Flowminder/FlowKit/issues/1339)
 
 ### Changed
 - FlowDB is now built on PostgreSQL 12 [#1396](https://github.com/Flowminder/FlowKit/issues/1313) and PostGIS 3.
@@ -38,7 +38,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added new `DistanceSeries` query to Flowmachine, which produces per-subscriber time series of distance from a reference point. [#1313](https://github.com/Flowminder/FlowKit/issues/1313)
 - Added new `ImputedDistanceSeries` query to Flowmachine, which produces contiguous per-subscriber time series of distance from a reference point by filling in gaps using the rolling median. [#1337](https://github.com/Flowminder/FlowKit/issues/1337)
-- Added new `IterativeMedianFilter` query to Flowmachine, which applies an iterative median filter to the output of another query. [#1339](https://github.com/Flowminder/FlowKit/issues/1339)
 
 ### Changed
 

--- a/flowmachine/flowmachine/features/subscriber/__init__.py
+++ b/flowmachine/flowmachine/features/subscriber/__init__.py
@@ -70,3 +70,4 @@ from .handset_stats import HandsetStats
 from .interevent_interval import IntereventInterval
 from .distance_series import DistanceSeries
 from .imputed_distance_series import ImputedDistanceSeries
+from .iterative_median_filter import IterativeMedianFilter

--- a/flowmachine/flowmachine/features/subscriber/imputed_distance_series.py
+++ b/flowmachine/flowmachine/features/subscriber/imputed_distance_series.py
@@ -23,7 +23,7 @@ class ImputedDistanceSeries(Query):
     distance_series : DistanceSeries
         A subscriber distance series which may contain gaps.
     window_size : int, default 3
-        Number of observations to use for imputation. Must be odd and positive.
+        Number of observations to use for imputation. Must be odd, positive and greater than 1.
 
 
     References

--- a/flowmachine/flowmachine/features/subscriber/imputed_distance_series.py
+++ b/flowmachine/flowmachine/features/subscriber/imputed_distance_series.py
@@ -11,6 +11,7 @@ from typing import List
 from flowmachine.core import Query
 from flowmachine.features.subscriber.distance_series import DistanceSeries
 from flowmachine.features.subscriber.distance_series import valid_time_buckets
+from flowmachine.features.utilities.validators import valid_median_window
 
 
 class ImputedDistanceSeries(Query):
@@ -33,11 +34,7 @@ class ImputedDistanceSeries(Query):
 
     def __init__(self, *, distance_series: DistanceSeries, window_size: int = 3):
         self.distance_series = distance_series
-        self.window_size = window_size
-        if self.window_size <= 1:
-            raise ValueError("Window size should be positive and greater than 1.")
-        if self.window_size % 2 == 0:
-            raise ValueError("Window size must be odd.")
+        self.window_size = valid_median_window("window_size", window_size)
 
         super().__init__()
 

--- a/flowmachine/flowmachine/features/subscriber/iterative_median_filter.py
+++ b/flowmachine/flowmachine/features/subscriber/iterative_median_filter.py
@@ -36,10 +36,10 @@ class IterativeMedianFilter(Query):
 
         self.query_to_filter = query_to_filter
         self.filter_window_size = filter_window_size
-        if (filter_window_size % 2) == 0:
-            raise ValueError("filter_window_size must be odd.")
         if not (filter_window_size > 1):
             raise ValueError("filter_window_size must be positive and more than 1.")
+        if (filter_window_size % 2) == 0:
+            raise ValueError("filter_window_size must be odd.")
         self.column_to_filter = column_to_filter
         if column_to_filter not in query_to_filter.column_names:
             raise ValueError(

--- a/flowmachine/flowmachine/features/subscriber/iterative_median_filter.py
+++ b/flowmachine/flowmachine/features/subscriber/iterative_median_filter.py
@@ -4,6 +4,10 @@
 from typing import List
 
 from flowmachine.core import Query
+from flowmachine.features.utilities.validators import (
+    valid_median_window,
+    validate_column_present,
+)
 
 
 class IterativeMedianFilter(Query):
@@ -35,32 +39,20 @@ class IterativeMedianFilter(Query):
     ):
 
         self.query_to_filter = query_to_filter
-        self.filter_window_size = filter_window_size
-        if not (filter_window_size > 1):
-            raise ValueError("filter_window_size must be positive and more than 1.")
-        if (filter_window_size % 2) == 0:
-            raise ValueError("filter_window_size must be odd.")
-        self.column_to_filter = column_to_filter
-        if column_to_filter not in query_to_filter.column_names:
-            raise ValueError(
-                f"Invalid column_to_filter: '{column_to_filter}' not in query's columns. Must be one of {query_to_filter.column_names}"
-            )
-        self.partition_column = partition_column
-        if (
-            partition_column is not None
-            and partition_column not in query_to_filter.column_names
-        ):
-            raise ValueError(
-                f"Invalid partition_column: '{partition_column}' not in query's columns. Must be one of {query_to_filter.column_names}"
-            )
-        self.order_column = order_column
-        if (
-            order_column is not None
-            and order_column not in query_to_filter.column_names
-        ):
-            raise ValueError(
-                f"Invalid order_column: '{order_column}' not in query's columns. Must be one of {query_to_filter.column_names}"
-            )
+        self.filter_window_size = valid_median_window(
+            "filter_window_size", filter_window_size
+        )
+        self.column_to_filter = validate_column_present(
+            "column_to_filter", column_to_filter, query_to_filter
+        )
+        self.partition_column = validate_column_present(
+            "partition_column", partition_column, query_to_filter
+        )
+
+        self.order_column = validate_column_present(
+            "order_column", order_column, query_to_filter
+        )
+
         super().__init__()
 
     @property

--- a/flowmachine/flowmachine/features/subscriber/iterative_median_filter.py
+++ b/flowmachine/flowmachine/features/subscriber/iterative_median_filter.py
@@ -15,7 +15,7 @@ class IterativeMedianFilter(Query):
     query_to_filter : Query
         Query to apply iterated median filter to.
     filter_window_size : int
-        Size of filter window - must be odd.
+        Size of filter window - must be odd, positive and more than 1.
     column_to_filter : str, default 'value'
         Column to apply the filter to.
     partition_column : str, default 'subscriber'
@@ -38,6 +38,8 @@ class IterativeMedianFilter(Query):
         self.filter_window_size = filter_window_size
         if (filter_window_size % 2) == 0:
             raise ValueError("filter_window_size must be odd.")
+        if not (filter_window_size > 1):
+            raise ValueError("filter_window_size must be positive and more than 1.")
         self.column_to_filter = column_to_filter
         if column_to_filter not in query_to_filter.column_names:
             raise ValueError(

--- a/flowmachine/flowmachine/features/subscriber/iterative_median_filter.py
+++ b/flowmachine/flowmachine/features/subscriber/iterative_median_filter.py
@@ -1,0 +1,90 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from typing import List
+
+from flowmachine.core import Query
+
+
+class IterativeMedianFilter(Query):
+    """
+    Applies an iterative median filter
+
+    Parameters
+    ----------
+    query_to_filter : Query
+        Query to apply iterated median filter to.
+    filter_window_size : int
+        Size of filter window - must be odd.
+    column_to_filter : str, default 'value'
+        Column to apply the filter to.
+    partition_column : str, default 'subscriber'
+        Column to use for partitioning. May be none, in which case no partitioning is applied.
+    order_column : str, default datetime
+        Column to use for ordering within partitions. May be none, in which case no ordering is applied.
+    """
+
+    def __init__(
+        self,
+        *,
+        query_to_filter: Query,
+        filter_window_size: int,
+        column_to_filter: str = "value",
+        partition_column: str = "subscriber",
+        order_column: str = "datetime",
+    ):
+
+        self.query_to_filter = query_to_filter
+        self.filter_window_size = filter_window_size
+        if (filter_window_size % 2) == 0:
+            raise ValueError("filter_window_size must be odd.")
+        self.column_to_filter = column_to_filter
+        if column_to_filter not in query_to_filter.column_names:
+            raise ValueError(
+                f"Invalid column_to_filter: '{column_to_filter}' not in query's columns. Must be one of {query_to_filter.column_names}"
+            )
+        self.partition_column = partition_column
+        if (
+            partition_column is not None
+            and partition_column not in query_to_filter.column_names
+        ):
+            raise ValueError(
+                f"Invalid partition_column: '{partition_column}' not in query's columns. Must be one of {query_to_filter.column_names}"
+            )
+        self.order_column = order_column
+        if (
+            order_column is not None
+            and order_column not in query_to_filter.column_names
+        ):
+            raise ValueError(
+                f"Invalid order_column: '{order_column}' not in query's columns. Must be one of {query_to_filter.column_names}"
+            )
+        super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return [
+            name
+            for name in self.query_to_filter.column_names
+            if name != self.column_to_filter
+        ] + [self.column_to_filter]
+
+    def _make_query(self):
+        column_names = [
+            name for name in self.column_names if name != self.column_to_filter
+        ]
+        partition_statement = (
+            f"partition by {self.partition_column}"
+            if self.partition_column is not None
+            else ""
+        )
+        cols = f"{', '.join(column_names)}," if len(column_names) > 0 else ""
+        order_statement = (
+            f"order by {self.order_column}" if self.order_column is not None else ""
+        )
+        return f"""
+        SELECT {cols} iterated_median_filter({self.column_to_filter}, 
+        {self.filter_window_size}) over({partition_statement} {order_statement}) as {self.column_to_filter}
+        FROM
+        ({self.query_to_filter.get_query()}) as to_filter
+        """

--- a/flowmachine/flowmachine/features/utilities/validators.py
+++ b/flowmachine/flowmachine/features/utilities/validators.py
@@ -1,0 +1,69 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from flowmachine.core import Query
+
+
+def valid_median_window(arg_name: str, value: int):
+    """
+    Raise a value error if the value provided is not an odd positive integer bigger than 1.
+    Parameters
+    ----------
+    arg_name : str
+        Argument name for error message
+    value : int
+        Value to check
+
+    Returns
+    -------
+    int
+        The validated value
+
+    Raises
+    ------
+    ValueError
+        If the value is even, negative, or less than 3
+
+    """
+    if value < 3:
+        raise ValueError(f"{arg_name} must be positive and greater than 1.")
+    if (value % 2) == 0:
+        raise ValueError(f"{arg_name} must be odd.")
+    return value
+
+
+def validate_column_present(arg_name: str, column: str, query: Query, allow_none=True):
+    """
+    Raises a value error if the column is not in the columns of the query.
+
+    Parameters
+    ----------
+    arg_name : str
+        Argument being validated
+    column : str
+        Name of the column
+    query : Query
+        The query to check the column against the columns of
+    allow_none : bool, default True
+        Set to False to error when the column is None.
+
+    Returns
+    -------
+    str
+        The column name
+
+    Raises
+    ------
+    ValueError
+        If the column is not one of those returned by the query
+    """
+    if column is None and not allow_none:
+        raise ValueError(
+            f"Invalid {arg_name}: Cannot be None. Must be one of {query.column_names}"
+        )
+    elif column is not None and column not in query.column_names:
+        raise ValueError(
+            f"Invalid {arg_name}: '{column}' not in query's columns. Must be one of {query.column_names}"
+        )
+    return column

--- a/flowmachine/flowmachine/features/utilities/validators.py
+++ b/flowmachine/flowmachine/features/utilities/validators.py
@@ -27,7 +27,7 @@ def valid_median_window(arg_name: str, value: int):
 
     """
     if value < 3:
-        raise ValueError(f"{arg_name} must be positive and greater than 1.")
+        raise ValueError(f"{arg_name} must be odd and greater than 1.")
     if (value % 2) == 0:
         raise ValueError(f"{arg_name} must be odd.")
     return value

--- a/flowmachine/tests/test_subscriber_imputed_distance_series.py
+++ b/flowmachine/tests/test_subscriber_imputed_distance_series.py
@@ -81,10 +81,10 @@ def test_impute(get_dataframe):
 @pytest.mark.parametrize(
     "size, match",
     [
-        (1, "Window size should be positive and greater than 1"),
-        (0, "Window size should be positive and greater than 1"),
-        (-1, "Window size should be positive and greater than 1"),
-        (4, "Window size must be odd"),
+        (1, "window_size must be positive and greater than 1"),
+        (0, "window_size must be positive and greater than 1"),
+        (-1, "window_size must be positive and greater than 1"),
+        (4, "window_size must be odd"),
     ],
 )
 def test_bad_window(size, match):

--- a/flowmachine/tests/test_subscriber_imputed_distance_series.py
+++ b/flowmachine/tests/test_subscriber_imputed_distance_series.py
@@ -81,9 +81,9 @@ def test_impute(get_dataframe):
 @pytest.mark.parametrize(
     "size, match",
     [
-        (1, "window_size must be positive and greater than 1"),
-        (0, "window_size must be positive and greater than 1"),
-        (-1, "window_size must be positive and greater than 1"),
+        (1, "window_size must be odd and greater than 1"),
+        (0, "window_size must be odd and greater than 1"),
+        (-1, "window_size must be odd and greater than 1"),
         (4, "window_size must be odd"),
     ],
 )

--- a/flowmachine/tests/test_subscriber_iterative_median_filter.py
+++ b/flowmachine/tests/test_subscriber_iterative_median_filter.py
@@ -3,16 +3,14 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from flowmachine.features import DistanceSeries, SubscriberLocations
-
-from flowmachine.core import make_spatial_unit, CustomQuery
-
-from flowmachine.features.subscriber.imputed_distance_series import (
+from flowmachine.features import (
+    DistanceSeries,
+    SubscriberLocations,
     ImputedDistanceSeries,
-)
-from flowmachine.features.subscriber.iterative_median_filter import (
     IterativeMedianFilter,
 )
+
+from flowmachine.core import make_spatial_unit, CustomQuery
 
 
 def test_partition_and_order_can_be_ommitted(get_dataframe):
@@ -70,11 +68,14 @@ def test_column_must_exist(column_arg):
         )
 
 
-def test_window_must_be_odd():
+@pytest.mark.parametrize(
+    "size, match", [(1, "positive"), (0, "positive"), (-1, "positive"), (4, "odd")]
+)
+def test_bad_window(size, match):
     """
-    Check window size must be odd.
+    Test some median unfriendly window sizes raise errors.
     """
-    with pytest.raises(ValueError, match="odd"):
+    with pytest.raises(ValueError, match=match):
         sl = SubscriberLocations(
             "2016-01-01",
             "2016-01-07",
@@ -84,7 +85,7 @@ def test_window_must_be_odd():
         ds = DistanceSeries(subscriber_locations=sl, statistic="min")
         IterativeMedianFilter(
             query_to_filter=ImputedDistanceSeries(distance_series=ds),
-            filter_window_size=2,
+            filter_window_size=size,
         )
 
 

--- a/flowmachine/tests/test_subscriber_iterative_median_filter.py
+++ b/flowmachine/tests/test_subscriber_iterative_median_filter.py
@@ -69,7 +69,13 @@ def test_column_must_exist(column_arg):
 
 
 @pytest.mark.parametrize(
-    "size, match", [(1, "positive"), (0, "positive"), (-1, "positive"), (4, "odd")]
+    "size, match",
+    [
+        (1, "filter_window_size must be positive and greater than 1"),
+        (0, "filter_window_size must be positive and greater than 1"),
+        (-1, "filter_window_size must be positive and greater than 1"),
+        (4, "filter_window_size must be odd"),
+    ],
 )
 def test_bad_window(size, match):
     """

--- a/flowmachine/tests/test_subscriber_iterative_median_filter.py
+++ b/flowmachine/tests/test_subscriber_iterative_median_filter.py
@@ -72,9 +72,9 @@ def test_column_must_exist(column_arg):
 @pytest.mark.parametrize(
     "size, match",
     [
-        (1, "filter_window_size must be positive and greater than 1"),
-        (0, "filter_window_size must be positive and greater than 1"),
-        (-1, "filter_window_size must be positive and greater than 1"),
+        (1, "filter_window_size must be odd and greater than 1"),
+        (0, "filter_window_size must be odd and greater than 1"),
+        (-1, "filter_window_size must be odd and greater than 1"),
         (4, "filter_window_size must be odd"),
     ],
 )

--- a/flowmachine/tests/test_subscriber_iterative_median_filter.py
+++ b/flowmachine/tests/test_subscriber_iterative_median_filter.py
@@ -1,0 +1,119 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+from flowmachine.features import DistanceSeries, SubscriberLocations
+
+from flowmachine.core import make_spatial_unit, CustomQuery
+
+from flowmachine.features.subscriber.imputed_distance_series import (
+    ImputedDistanceSeries,
+)
+from flowmachine.features.subscriber.iterative_median_filter import (
+    IterativeMedianFilter,
+)
+
+
+def test_partition_and_order_can_be_ommitted(get_dataframe):
+    """
+    Test that the filter can be applied without partitioning or ordering.
+    """
+    test_query = CustomQuery(
+        "SELECT v as value FROM (VALUES (1), (1.1), (0.9), (1.1), (0.95), (2.1), (1.95), (2.0), (2.05), (3.11), (2.99), (3.05), (3.0)) as t(v);",
+        column_names=["value"],
+    )
+    smoothed = get_dataframe(
+        IterativeMedianFilter(
+            query_to_filter=test_query,
+            filter_window_size=3,
+            partition_column=None,
+            order_column=None,
+        )
+    )
+    assert smoothed.value.tolist() == [
+        1,
+        1,
+        1,
+        1.1,
+        1.1,
+        1.95,
+        2,
+        2,
+        2.05,
+        2.99,
+        3,
+        3,
+        3,
+    ]
+
+
+@pytest.mark.parametrize(
+    "column_arg", ["column_to_filter", "partition_column", "order_column"]
+)
+def test_column_must_exist(column_arg):
+    """
+    Check errors for required columns.
+    """
+    with pytest.raises(ValueError, match=column_arg):
+        sl = SubscriberLocations(
+            "2016-01-01",
+            "2016-01-07",
+            spatial_unit=make_spatial_unit("lon-lat"),
+            hours=(20, 0),
+        )
+        ds = DistanceSeries(subscriber_locations=sl, statistic="min")
+        IterativeMedianFilter(
+            query_to_filter=ImputedDistanceSeries(distance_series=ds),
+            filter_window_size=3,
+            **{column_arg: "NOT_A_VALID_COLUMN"},
+        )
+
+
+def test_window_must_be_odd():
+    """
+    Check window size must be odd.
+    """
+    with pytest.raises(ValueError, match="odd"):
+        sl = SubscriberLocations(
+            "2016-01-01",
+            "2016-01-07",
+            spatial_unit=make_spatial_unit("lon-lat"),
+            hours=(20, 0),
+        )
+        ds = DistanceSeries(subscriber_locations=sl, statistic="min")
+        IterativeMedianFilter(
+            query_to_filter=ImputedDistanceSeries(distance_series=ds),
+            filter_window_size=2,
+        )
+
+
+def test_smooth(get_dataframe):
+    """
+    Test that iterated median filter matches an independently calculated result.
+    """
+    sl = SubscriberLocations(
+        "2016-01-01",
+        "2016-01-07",
+        spatial_unit=make_spatial_unit("lon-lat"),
+        hours=(20, 0),
+    )
+    ds = DistanceSeries(subscriber_locations=sl, statistic="min")
+    smoothed_df = get_dataframe(
+        IterativeMedianFilter(
+            query_to_filter=ImputedDistanceSeries(distance_series=ds),
+            filter_window_size=3,
+        )
+    )
+    assert smoothed_df.set_index("subscriber").loc[
+        "038OVABN11Ak4W5P"
+    ].value.tolist() == pytest.approx(
+        [
+            9343367.56611,
+            9343367.56611,
+            9343367.56611,
+            9343367.56611,
+            9343367.56611,
+            9221492.17419,
+        ]
+    )


### PR DESCRIPTION
Closes #1339

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [x] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Adds a new query type which applies an iterative median filter to another query'd output - primary immediate use case is in combination with #1338, but can be used for other purposes.