### PR TITLE
Flowetl refactoring & bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The FlowETL config file is now always validated, avoiding runtime errors if a config setting is wrong or missing. [#1375](https://github.com/Flowminder/FlowKit/issues/1375)
+- FlowETL now only creates DAGs for CDR types which are present in the config, leading to a better user experience in the Airflow UI. [#1376](https://github.com/Flowminder/FlowKit/issues/1376)
+- The `concurrency` settings in the FlowETL config are no longer ignored. [#1378](https://github.com/Flowminder/FlowKit/issues/1378)
+- The FlowETL deployment example has been updated so that it no longer fails due to a missing foreign data wrapper for the available CDR dates. [#1379](https://github.com/Flowminder/FlowKit/issues/1379)
+
 ### Removed
+
+- The `default_args` section in the FlowETL config file has been removed. [#1377](https://github.com/Flowminder/FlowKit/issues/1377)
 
 
 ## [0.9.0]
@@ -45,10 +52,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Quickstart will no longer fail if it has been run previously with a different FlowDB data size and not explicitly shut down. [#900](https://github.com/Flowminder/FlowKit/issues/900)
 
-
 ### Removed
 - Flowmachine's `subscriber_locations_cluster` function has been removed - use `HartiganCluster` or `MeaningfulLocations` directly.
 - FlowAPI no longer supports the non-reproducible random sampling method `system_rows`. [#1263](https://github.com/Flowminder/FlowKit/issues/1263)
+
 
 ## [0.8.0]
 

--- a/flowetl/dags/etl.py
+++ b/flowetl/dags/etl.py
@@ -34,7 +34,9 @@ if flowetl_runtime_config == "testing":
     task_callable_mapping = TEST_ETL_TASK_CALLABLES
     logger.info("Running in testing environment")
 
-    dag = construct_etl_dag(**task_callable_mapping, cdr_type="testing")
+    dag = construct_etl_dag(
+        **task_callable_mapping, cdr_type="testing", max_active_runs_per_dag=1
+    )
 elif flowetl_runtime_config == "production":
     task_callable_mapping = PRODUCTION_ETL_TASK_CALLABLES
     logger.info("Running in production environment")

--- a/flowetl/dags/etl.py
+++ b/flowetl/dags/etl.py
@@ -14,7 +14,6 @@ from pathlib import Path
 # need to import and not use so that airflow looks here for a DAG
 from airflow import DAG  # pylint: disable=unused-import
 
-from pendulum import parse
 from etl.dag_task_callable_mappings import (
     TEST_ETL_TASK_CALLABLES,
     PRODUCTION_ETL_TASK_CALLABLES,
@@ -27,7 +26,6 @@ from etl.config_parser import (
 )
 
 logger = structlog.get_logger("flowetl")
-default_args = {"owner": "flowminder", "start_date": parse("1900-01-01")}
 
 ETL_TASK_CALLABLES = {
     "testing": TEST_ETL_TASK_CALLABLES,
@@ -39,14 +37,12 @@ flowetl_runtime_config = os.environ.get("FLOWETL_RUNTIME_CONFIG", "production")
 # Determine if we are in a testing environment - use dummy callables if so
 if flowetl_runtime_config == "testing":
     task_callable_mapping = TEST_ETL_TASK_CALLABLES
-    logger.info("running in testing environment")
+    logger.info("Running in testing environment")
 
-    dag = construct_etl_dag(
-        **task_callable_mapping, default_args=default_args, cdr_type="testing"
-    )
+    dag = construct_etl_dag(**task_callable_mapping, cdr_type="testing")
 elif flowetl_runtime_config == "production":
     task_callable_mapping = PRODUCTION_ETL_TASK_CALLABLES
-    logger.info("running in production environment")
+    logger.info("Running in production environment")
 
     # read and validate the config file before creating the DAGs
     global_config_dict = get_config_from_file(
@@ -55,8 +51,6 @@ elif flowetl_runtime_config == "production":
     validate_config(global_config_dict)
     global_config_dict = fill_config_default_values(global_config_dict)
 
-    default_args = global_config_dict["default_args"]
-
     # create DAG for each cdr_type
     for cdr_type in CDRType:
         # Ensure `cdr_type` is a string (e.g. "sms", instead of the raw value `CDRType.SMS`)
@@ -64,7 +58,7 @@ elif flowetl_runtime_config == "production":
         cdr_type = cdr_type.value
 
         globals()[f"etl_{cdr_type}"] = construct_etl_dag(
-            **task_callable_mapping, default_args=default_args, cdr_type=cdr_type
+            **task_callable_mapping, cdr_type=cdr_type
         )
 else:
     raise ValueError(

--- a/flowetl/dags/etl.py
+++ b/flowetl/dags/etl.py
@@ -49,8 +49,6 @@ elif flowetl_runtime_config == "production":
     global_config_dict = get_config_from_file(
         config_filepath=Path("/mounts/config/config.yml")
     )
-    validate_config(global_config_dict)
-    global_config_dict = fill_config_default_values(global_config_dict)
 
     # create DAG for each cdr_type
     for cdr_type in CDRType:

--- a/flowetl/dags/etl.py
+++ b/flowetl/dags/etl.py
@@ -9,8 +9,6 @@ Skeleton specification for ETL DAG
 import os
 import structlog
 
-from pathlib import Path
-
 # Need to import the DAG class (even if it is not directly
 # used in this file) so that Airflow looks here for a DAG.
 from airflow import DAG  # pylint: disable=unused-import
@@ -20,11 +18,7 @@ from etl.dag_task_callable_mappings import (
     PRODUCTION_ETL_TASK_CALLABLES,
 )
 from etl.etl_utils import construct_etl_dag, CDRType
-from etl.config_parser import (
-    get_config_from_file,
-    validate_config,
-    fill_config_default_values,
-)
+from etl.config_parser import get_config_from_file
 
 logger = structlog.get_logger("flowetl")
 
@@ -47,7 +41,7 @@ elif flowetl_runtime_config == "production":
 
     # read and validate the config file before creating the DAGs
     global_config_dict = get_config_from_file(
-        config_filepath=Path("/mounts/config/config.yml")
+        config_filepath="/mounts/config/config.yml"
     )
     print(f"[FFF] global_config_dict={global_config_dict}")
 

--- a/flowetl/dags/etl.py
+++ b/flowetl/dags/etl.py
@@ -49,6 +49,7 @@ elif flowetl_runtime_config == "production":
     global_config_dict = get_config_from_file(
         config_filepath=Path("/mounts/config/config.yml")
     )
+    print(f"[FFF] global_config_dict={global_config_dict}")
 
     # create DAG for each cdr_type
     for cdr_type in CDRType:

--- a/flowetl/dags/etl.py
+++ b/flowetl/dags/etl.py
@@ -11,7 +11,8 @@ import structlog
 
 from pathlib import Path
 
-# need to import and not use so that airflow looks here for a DAG
+# Need to import the DAG class (even if it is not directly
+# used in this file) so that Airflow looks here for a DAG.
 from airflow import DAG  # pylint: disable=unused-import
 
 from etl.dag_task_callable_mappings import (

--- a/flowetl/dags/etl_sensor.py
+++ b/flowetl/dags/etl_sensor.py
@@ -6,7 +6,8 @@
 import os
 import structlog
 
-# need to import and not use so that airflow looks here for a DAG
+# Need to import the DAG class (even if it is not directly
+# used in this file) so that Airflow looks here for a DAG.
 from airflow import DAG  # pylint: disable=unused-import
 
 from etl.etl_utils import construct_etl_sensor_dag

--- a/flowetl/dags/etl_sensor.py
+++ b/flowetl/dags/etl_sensor.py
@@ -16,8 +16,6 @@ from etl.dag_task_callable_mappings import (
     PRODUCTION_ETL_SENSOR_TASK_CALLABLE,
 )
 
-logger = structlog.get_logger("flowetl")
-
 ETL_SENSOR_TASK_CALLABLES = {
     "testing": TEST_ETL_SENSOR_TASK_CALLABLE,
     "production": PRODUCTION_ETL_SENSOR_TASK_CALLABLE,
@@ -33,5 +31,6 @@ except KeyError:
         f"Valid config names are: {list(ETL_SENSOR_TASK_CALLABLES.keys())}"
     )
 
+logger = structlog.get_logger("flowetl")
 logger.info(f"Running in {flowetl_runtime_config} environment")
 dag = construct_etl_sensor_dag(callable=etl_sensor_task_callable)

--- a/flowetl/dags/etl_sensor.py
+++ b/flowetl/dags/etl_sensor.py
@@ -9,8 +9,6 @@ import structlog
 # need to import and not use so that airflow looks here for a DAG
 from airflow import DAG  # pylint: disable=unused-import
 
-from pendulum import parse
-
 from etl.etl_utils import construct_etl_sensor_dag
 from etl.dag_task_callable_mappings import (
     TEST_ETL_SENSOR_TASK_CALLABLE,
@@ -18,8 +16,6 @@ from etl.dag_task_callable_mappings import (
 )
 
 logger = structlog.get_logger("flowetl")
-
-default_args = {"owner": "flowminder", "start_date": parse("1900-01-01")}
 
 ETL_SENSOR_TASK_CALLABLES = {
     "testing": TEST_ETL_SENSOR_TASK_CALLABLE,
@@ -37,6 +33,4 @@ except KeyError:
     )
 
 logger.info(f"Running in {flowetl_runtime_config} environment")
-dag = construct_etl_sensor_dag(
-    callable=etl_sensor_task_callable, default_args=default_args
-)
+dag = construct_etl_sensor_dag(callable=etl_sensor_task_callable)

--- a/flowetl/deployment_example/mounts/config/config.yml
+++ b/flowetl/deployment_example/mounts/config/config.yml
@@ -1,6 +1,3 @@
-default_args:
-  owner: flowminder
-  start_date: '1900-01-01'
 etl:
   calls:
     concurrency: 4

--- a/flowetl/etl/etl/config_parser.py
+++ b/flowetl/etl/etl/config_parser.py
@@ -10,6 +10,7 @@ import yaml
 
 from copy import deepcopy
 from pathlib import Path
+from typing import Union
 
 from etl.etl_utils import CDRType
 
@@ -107,7 +108,7 @@ def fill_config_default_values(global_config_dict: dict) -> dict:
     return global_config_dict
 
 
-def get_config_from_file(config_filepath: Path) -> dict:
+def get_config_from_file(config_filepath: Union[Path, str]) -> dict:
     """
     Function used to load configuration from YAML file.
     This also validates the structure of the config and
@@ -115,7 +116,7 @@ def get_config_from_file(config_filepath: Path) -> dict:
 
     Parameters
     ----------
-    config_filepath : Path
+    config_filepath : Path or str
         Location of the file config.yml
 
     Returns

--- a/flowetl/etl/etl/config_parser.py
+++ b/flowetl/etl/etl/config_parser.py
@@ -32,11 +32,6 @@ def validate_config(global_config_dict: dict) -> None:
     if "etl" not in keys:
         exceptions.append(ValueError("etl must be a toplevel key in the config file"))
 
-    if "default_args" not in keys:
-        exceptions.append(
-            ValueError("default_args must be a toplevel key in the config file")
-        )
-
     etl_keys = global_config_dict.get("etl", {}).keys()
     if not set(etl_keys).issubset(CDRType):
         unexpected_keys = list(set(etl_keys).difference(CDRType))

--- a/flowetl/etl/etl/config_parser.py
+++ b/flowetl/etl/etl/config_parser.py
@@ -127,4 +127,6 @@ def get_config_from_file(*, config_filepath: Path) -> dict:
         Yaml config loaded into a python dict
     """
     content = config_filepath.open("r").read()
-    return yaml.load(content, Loader=yaml.SafeLoader)
+    config_dict = yaml.load(content, Loader=yaml.SafeLoader)
+    validate_config(config_dict)
+    return fill_config_default_values(config_dict)

--- a/flowetl/etl/etl/config_parser.py
+++ b/flowetl/etl/etl/config_parser.py
@@ -107,7 +107,7 @@ def fill_config_default_values(global_config_dict: dict) -> dict:
     return global_config_dict
 
 
-def get_config_from_file(*, config_filepath: Path) -> dict:
+def get_config_from_file(config_filepath: Path) -> dict:
     """
     Function used to load configuration from YAML file.
     This also validates the structure of the config and
@@ -123,6 +123,9 @@ def get_config_from_file(*, config_filepath: Path) -> dict:
     dict
         Yaml config loaded into a python dict
     """
+    # Ensure config_filepath is actually a Path object (e.g. in case a string is passed)
+    config_filepath = Path(config_filepath)
+
     content = config_filepath.open("r").read()
     config_dict = yaml.load(content, Loader=yaml.SafeLoader)
     validate_config(config_dict)

--- a/flowetl/etl/etl/config_parser.py
+++ b/flowetl/etl/etl/config_parser.py
@@ -110,6 +110,8 @@ def fill_config_default_values(global_config_dict: dict) -> dict:
 def get_config_from_file(*, config_filepath: Path) -> dict:
     """
     Function used to load configuration from YAML file.
+    This also validates the structure of the config and
+    fills any optional settings with default values.
 
     Parameters
     ----------

--- a/flowetl/etl/etl/etl_utils.py
+++ b/flowetl/etl/etl/etl_utils.py
@@ -40,6 +40,8 @@ def construct_etl_sensor_dag(*, callable: Callable) -> DAG:
     """
     default_args = {"owner": "flowminder"}
 
+    # Note: in order for Airflow to actually run the DAG when it is triggered
+    # we need to set the start_date parameter to a date in the past.
     with DAG(
         dag_id=f"etl_sensor",
         start_date=pendulum.parse("1900-01-01"),

--- a/flowetl/etl/etl/etl_utils.py
+++ b/flowetl/etl/etl/etl_utils.py
@@ -9,7 +9,6 @@ Contains utility functions for use in the ETL dag and it's callables
 import os
 import pendulum
 import re
-import sqlalchemy
 
 from typing import List, Callable
 from enum import Enum
@@ -23,7 +22,7 @@ from airflow.hooks.postgres_hook import PostgresHook
 from airflow.operators.python_operator import PythonOperator
 
 
-def construct_etl_sensor_dag(*, callable: Callable, default_args: dict) -> DAG:
+def construct_etl_sensor_dag(*, callable: Callable) -> DAG:
     """
     This function constructs the sensor single task DAG that triggers ETL
     DAGS with correct config based on filename.
@@ -33,14 +32,16 @@ def construct_etl_sensor_dag(*, callable: Callable, default_args: dict) -> DAG:
     callable : Callable
         The sense callable that deals with finding files and triggering
         ETL DAGs
-    default_args : dict
-        Default arguments for DAG
 
     Returns
     -------
     DAG
         Airflow DAG
     """
+    # Note: we set `start_date` to a date in the past so that Airflow
+    # definitely executes it when it is triggered.
+    default_args = {"owner": "flowminder", "start_date": pendulum.parse("1900-01-01")}
+
     with DAG(
         dag_id=f"etl_sensor", schedule_interval=None, default_args=default_args
     ) as dag:

--- a/flowetl/etl/etl/etl_utils.py
+++ b/flowetl/etl/etl/etl_utils.py
@@ -38,12 +38,13 @@ def construct_etl_sensor_dag(*, callable: Callable) -> DAG:
     DAG
         Airflow DAG
     """
-    # Note: we set `start_date` to a date in the past so that Airflow
-    # definitely executes it when it is triggered.
-    default_args = {"owner": "flowminder", "start_date": pendulum.parse("1900-01-01")}
+    default_args = {"owner": "flowminder"}
 
     with DAG(
-        dag_id=f"etl_sensor", schedule_interval=None, default_args=default_args
+        dag_id=f"etl_sensor",
+        start_date=pendulum.parse("1900-01-01"),
+        schedule_interval=None,
+        default_args=default_args,
     ) as dag:
         sense = PythonOperator(
             task_id="sense", python_callable=callable, provide_context=True

--- a/flowetl/etl/etl/etl_utils.py
+++ b/flowetl/etl/etl/etl_utils.py
@@ -68,6 +68,7 @@ def construct_etl_dag(
     clean: Callable,
     fail: Callable,
     cdr_type: str,
+    max_active_runs_per_dag: int,
     config_path: str = "/mounts/config",
 ) -> DAG:
     """
@@ -99,6 +100,8 @@ def construct_etl_dag(
         The fail task callable.
     cdr_type : str
         The type of CDR that this ETL DAG will process.
+    max_active_runs_per_dag : int
+        The maximum number of active DAG runs per DAG.
     config_path : str
         The config path used to look for the sql templates.
 
@@ -116,6 +119,7 @@ def construct_etl_dag(
         dag_id=f"etl_{cdr_type}",
         start_date=pendulum.parse("1900-01-01"),
         schedule_interval=None,
+        max_active_runs=max_active_runs_per_dag,
         default_args=default_args,
         template_searchpath=config_path,  # template paths will be relative to this
         user_defined_macros={

--- a/flowetl/etl/etl/etl_utils.py
+++ b/flowetl/etl/etl/etl_utils.py
@@ -40,8 +40,8 @@ def construct_etl_sensor_dag(*, callable: Callable) -> DAG:
     """
     default_args = {"owner": "flowminder"}
 
-    # Note: in order for Airflow to actually run the DAG when it is triggered
-    # we need to set the start_date parameter to a date in the past.
+    # Note: the `start_date` parameter needs to be set to a date in the past,
+    # otherwise Airflow won't run the DAG when it is triggered.
     with DAG(
         dag_id=f"etl_sensor",
         start_date=pendulum.parse("1900-01-01"),
@@ -67,7 +67,6 @@ def construct_etl_dag(
     quarantine: Callable,
     clean: Callable,
     fail: Callable,
-    default_args: dict,
     cdr_type: str,
     config_path: str = "/mounts/config",
 ) -> DAG:
@@ -98,10 +97,6 @@ def construct_etl_dag(
         The clean task callable.
     fail : Callable
         The fail task callable.
-    default_args : dict
-        A set of default args to pass to all callables.
-        Must containt at least "owner" key and "start" key (which must be a
-        pendulum date object)
     cdr_type : str
         The type of CDR that this ETL DAG will process.
     config_path : str
@@ -113,8 +108,13 @@ def construct_etl_dag(
         Specification of Airflow DAG for ETL
     """
 
+    default_args = {"owner": "flowminder"}
+
+    # Note: the `start_date` parameter needs to be set to a date in the past,
+    # otherwise Airflow won't run the DAG when it is triggered.
     with DAG(
         dag_id=f"etl_{cdr_type}",
+        start_date=pendulum.parse("1900-01-01"),
         schedule_interval=None,
         default_args=default_args,
         template_searchpath=config_path,  # template paths will be relative to this

--- a/flowetl/etl/tests/test_config.py
+++ b/flowetl/etl/tests/test_config.py
@@ -193,7 +193,7 @@ def test_get_config_from_file(tmpdir):
     config_file = config_dir.join("config.yml")
     config_file.write(yaml.dump(sample_dict))
 
-    config = get_config_from_file(config_filepath=Path(config_file))
+    config = get_config_from_file(config_filepath=config_file)
     assert config == sample_dict
 
 

--- a/flowetl/etl/tests/test_config.py
+++ b/flowetl/etl/tests/test_config.py
@@ -197,6 +197,28 @@ def test_get_config_from_file(tmpdir):
     assert config == sample_dict
 
 
+def test_loading_invalid_config_file_raises_error(tmpdir):
+    """
+    Test that the config is validated when loading from a file and errors are raised.
+    """
+    invalid_config = textwrap.dedent(
+        """
+        etl:
+          calls:
+            source:
+              source_type: sql
+              table_name: "sample_data_fdw"
+        """
+    )
+
+    config_file = tmpdir.join("config.yml")
+    config_file.write(invalid_config)
+
+    error_msg = "Each etl subsection must contain a 'source' and 'concurrency' subsection - not present for 'calls'."
+    with pytest.raises(ValueError, match=error_msg):
+        get_config_from_file(config_filepath=config_file)
+
+
 def test_extract_date_from_filename():
     filename = "CALLS_20160101.csv.gz"
     filename_pattern = r"CALLS_(\d{8}).csv.gz"

--- a/flowetl/etl/tests/test_config.py
+++ b/flowetl/etl/tests/test_config.py
@@ -200,7 +200,10 @@ def test_get_config_from_file(tmpdir):
     """
     Test that we can load yaml to dict from file
     """
-    sample_dict = {"A": 23, "B": [1, 2, 34], "C": {"A": "bob"}}
+    sample_dict = {
+        "etl": {"calls": {"concurrency": 3, "source": {"source_type": "csv"}}},
+        "default_args": {},
+    }
     config_dir = tmpdir.mkdir("config")
     config_file = config_dir.join("config.yml")
     config_file.write(yaml.dump(sample_dict))

--- a/flowetl/etl/tests/test_config.py
+++ b/flowetl/etl/tests/test_config.py
@@ -60,20 +60,6 @@ def test_config_validation_fails_for_invalid_etl_section(sample_config_dict):
         validate_config(bad_config)
 
 
-def test_config_validation_fails_no_default_args_section(sample_config_dict):
-    """
-    Check that we get an exception raised if default args
-    subsection missing.
-    """
-    bad_config = deepcopy(sample_config_dict)
-    bad_config.pop("default_args")
-
-    with pytest.raises(ValueError) as raised_exception:
-        validate_config(bad_config)
-
-    assert len(raised_exception.value.args[0]) == 1
-
-
 def test_config_validation_fails_bad_etl_subsection(sample_config_dict):
     """
     Check that we get an exception raised if an etl subsection
@@ -201,8 +187,7 @@ def test_get_config_from_file(tmpdir):
     Test that we can load yaml to dict from file
     """
     sample_dict = {
-        "etl": {"calls": {"concurrency": 3, "source": {"source_type": "csv"}}},
-        "default_args": {},
+        "etl": {"calls": {"concurrency": 3, "source": {"source_type": "csv"}}}
     }
     config_dir = tmpdir.mkdir("config")
     config_file = config_dir.join("config.yml")
@@ -241,9 +226,6 @@ def test_sql_find_available_dates(sample_config_dict):
 
     config_without_explicit_sql = textwrap.dedent(
         """
-        default_args:
-          owner: flowminder
-          start_date: '1900-01-01'
         etl:
           calls:
             concurrency: 4

--- a/flowetl/etl/tests/test_construct_etl_dag.py
+++ b/flowetl/etl/tests/test_construct_etl_dag.py
@@ -8,10 +8,8 @@ Tests for the construction of the ETL DAG
 """
 import pytest
 from pendulum import parse
-from pendulum.parsing.exceptions import ParserError
 from unittest.mock import Mock
 
-from airflow.exceptions import AirflowException
 from airflow.operators.python_operator import PythonOperator
 
 from etl.etl_utils import construct_etl_dag
@@ -27,15 +25,12 @@ def test_construct_etl_dag_with_test_callables():
     specified in the task_callable_mapping argument. Use TEST_ETL_TASK_CALLABLES
     mapping.
     """
-    default_args = {"owner": "bob", "start_date": parse("1900-01-01")}
     task_callable_mapping = {
         t: Mock(wraps=v) for (t, v) in TEST_ETL_TASK_CALLABLES.items()
     }
     cdr_type = "spaghetti"
 
-    dag = construct_etl_dag(
-        **task_callable_mapping, default_args=default_args, cdr_type=cdr_type
-    )
+    dag = construct_etl_dag(**task_callable_mapping, cdr_type=cdr_type)
 
     assert dag.dag_id == f"etl_{cdr_type}"
 
@@ -57,15 +52,12 @@ def test_construct_etl_dag_with_production_callables():
     specified in the task_callable_mapping argument. Use PRODUCTION_ETL_TASK_CALLABLES
     mapping.
     """
-    default_args = {"owner": "bob", "start_date": parse("1900-01-01")}
     task_callable_mapping = {
         t: Mock(wraps=v) for (t, v) in PRODUCTION_ETL_TASK_CALLABLES.items()
     }
     cdr_type = "spaghetti"
 
-    dag = construct_etl_dag(
-        **task_callable_mapping, default_args=default_args, cdr_type=cdr_type
-    )
+    dag = construct_etl_dag(**task_callable_mapping, cdr_type=cdr_type)
 
     assert dag.dag_id == f"etl_{cdr_type}"
 
@@ -83,50 +75,28 @@ def test_construct_etl_dag_with_production_callables():
     [t.assert_called_once() for _, t in task_callable_mapping.items()]
 
 
-def test_construct_etl_dag_fails_with_no_start_date():
+def test_construct_etl_dag_sets_owner_to_airflow():
     """
-    Make sure we get an exception if default_args does not contain a start_date
+    Make sure that the DAG owner of the constructed DAG is Flowminder.
     """
-    default_args = {"owner": "bob"}
     task_callable_mapping = TEST_ETL_TASK_CALLABLES
     cdr_type = "spaghetti"
 
-    # pylint: disable=unused-variable
-    with pytest.raises(AirflowException):
-        dag = construct_etl_dag(
-            **task_callable_mapping, default_args=default_args, cdr_type=cdr_type
-        )
+    dag = construct_etl_dag(**task_callable_mapping, cdr_type=cdr_type)
+
+    assert dag.owner == "flowminder"
 
 
-def test_construct_etl_dag_with_no_owner_defaults_to_airflow():
+def test_construct_etl_dag_sets_start_date_correctly():
     """
-    Make sure that if we pass no owner in default_args the owner is
-    Airflow.
+    Make sure that the start_date of the DAG is the expected date in the past.
     """
-    default_args = {"start_date": parse("1900-01-01")}
     task_callable_mapping = TEST_ETL_TASK_CALLABLES
     cdr_type = "spaghetti"
 
-    dag = construct_etl_dag(
-        **task_callable_mapping, default_args=default_args, cdr_type=cdr_type
-    )
+    dag = construct_etl_dag(**task_callable_mapping, cdr_type=cdr_type)
 
-    assert dag.owner == "airflow"
-
-
-def test_construct_etl_dag_fails_with_bad_start_date():
-    """
-    If the start_date is not a valid date we get an error
-    """
-    default_args = {"owner": "bob", "start_date": "bob_time"}
-    task_callable_mapping = TEST_ETL_TASK_CALLABLES
-    cdr_type = "spaghetti"
-
-    # pylint: disable=unused-variable
-    with pytest.raises(ParserError):
-        dag = construct_etl_dag(
-            **task_callable_mapping, default_args=default_args, cdr_type=cdr_type
-        )
+    assert dag.start_date == parse("1900-01-01")
 
 
 def test_construct_etl_dag_fails_with_incorrect_mapping_keys():
@@ -134,12 +104,9 @@ def test_construct_etl_dag_fails_with_incorrect_mapping_keys():
     If the dictionary we pass to task_callable_mapping does not have
     correct keys we get a TypeError.
     """
-    default_args = {"owner": "bob", "start_date": "bob_time"}
     task_callable_mapping = {}
     cdr_type = "spaghetti"
 
     # pylint: disable=unused-variable
     with pytest.raises(TypeError):
-        dag = construct_etl_dag(
-            **task_callable_mapping, default_args=default_args, cdr_type=cdr_type
-        )
+        dag = construct_etl_dag(**task_callable_mapping, cdr_type=cdr_type)

--- a/flowetl/etl/tests/test_construct_etl_dag.py
+++ b/flowetl/etl/tests/test_construct_etl_dag.py
@@ -30,7 +30,9 @@ def test_construct_etl_dag_with_test_callables():
     }
     cdr_type = "spaghetti"
 
-    dag = construct_etl_dag(**task_callable_mapping, cdr_type=cdr_type)
+    dag = construct_etl_dag(
+        **task_callable_mapping, cdr_type=cdr_type, max_active_runs_per_dag=1
+    )
 
     assert dag.dag_id == f"etl_{cdr_type}"
 
@@ -57,7 +59,9 @@ def test_construct_etl_dag_with_production_callables():
     }
     cdr_type = "spaghetti"
 
-    dag = construct_etl_dag(**task_callable_mapping, cdr_type=cdr_type)
+    dag = construct_etl_dag(
+        **task_callable_mapping, cdr_type=cdr_type, max_active_runs_per_dag=1
+    )
 
     assert dag.dag_id == f"etl_{cdr_type}"
 
@@ -82,7 +86,9 @@ def test_construct_etl_dag_sets_owner_to_airflow():
     task_callable_mapping = TEST_ETL_TASK_CALLABLES
     cdr_type = "spaghetti"
 
-    dag = construct_etl_dag(**task_callable_mapping, cdr_type=cdr_type)
+    dag = construct_etl_dag(
+        **task_callable_mapping, cdr_type=cdr_type, max_active_runs_per_dag=1
+    )
 
     assert dag.owner == "flowminder"
 
@@ -94,9 +100,25 @@ def test_construct_etl_dag_sets_start_date_correctly():
     task_callable_mapping = TEST_ETL_TASK_CALLABLES
     cdr_type = "spaghetti"
 
-    dag = construct_etl_dag(**task_callable_mapping, cdr_type=cdr_type)
+    dag = construct_etl_dag(
+        **task_callable_mapping, cdr_type=cdr_type, max_active_runs_per_dag=1
+    )
 
     assert dag.start_date == parse("1900-01-01")
+
+
+def test_construct_etl_dag_concurrency_setting():
+    """
+    Make sure that the DAG's `max_active_runs` is set correctly.
+    """
+    task_callable_mapping = TEST_ETL_TASK_CALLABLES
+    cdr_type = "spaghetti"
+
+    dag = construct_etl_dag(
+        **task_callable_mapping, cdr_type=cdr_type, max_active_runs_per_dag=42
+    )
+
+    assert dag.max_active_runs == 42
 
 
 def test_construct_etl_dag_fails_with_incorrect_mapping_keys():
@@ -109,4 +131,6 @@ def test_construct_etl_dag_fails_with_incorrect_mapping_keys():
 
     # pylint: disable=unused-variable
     with pytest.raises(TypeError):
-        dag = construct_etl_dag(**task_callable_mapping, cdr_type=cdr_type)
+        dag = construct_etl_dag(
+            **task_callable_mapping, cdr_type=cdr_type, max_active_runs_per_dag=1
+        )

--- a/flowetl/etl/tests/test_construct_etl_sensor_dag.py
+++ b/flowetl/etl/tests/test_construct_etl_sensor_dag.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # -*- coding: utf-8 -*-
-from pendulum import parse
 from etl.etl_utils import construct_etl_sensor_dag
 from etl.dag_task_callable_mappings import (
     TEST_ETL_SENSOR_TASK_CALLABLE,
@@ -16,15 +15,11 @@ def test_construct_etl_sensor_dag_with_test_callable():
     Make sure we get the python callables we expect when using
     construct_etl_sensor_dag with testing callables.
     """
-    default_args = {"owner": "bob", "start_date": parse("1900-01-01")}
     task_callable = TEST_ETL_SENSOR_TASK_CALLABLE
-
-    dag = construct_etl_sensor_dag(callable=task_callable, default_args=default_args)
+    dag = construct_etl_sensor_dag(callable=task_callable)
 
     assert dag.dag_id == f"etl_sensor"
-
     assert len(dag.tasks) == 1
-
     assert dag.tasks[0].python_callable is task_callable
 
 
@@ -33,13 +28,9 @@ def test_construct_etl_sensor_dag_with_production_callable():
     Make sure we get the python callables we expect when using
     construct_etl_sensor_dag with production callables.
     """
-    default_args = {"owner": "bob", "start_date": parse("1900-01-01")}
     task_callable = PRODUCTION_ETL_SENSOR_TASK_CALLABLE
-
-    dag = construct_etl_sensor_dag(callable=task_callable, default_args=default_args)
+    dag = construct_etl_sensor_dag(callable=task_callable)
 
     assert dag.dag_id == f"etl_sensor"
-
     assert len(dag.tasks) == 1
-
     assert dag.tasks[0].python_callable is task_callable

--- a/flowetl/mounts/config/config.yml
+++ b/flowetl/mounts/config/config.yml
@@ -1,8 +1,5 @@
 # This is an example flowetl config file which
 # is also used in the flowetl unit tests.
-default_args:
-  owner: flowminder
-  start_date: '1900-01-01'
 etl:
   calls:
     concurrency: 4


### PR DESCRIPTION
Closes #1375, closes #1376, closes #1377, closes #1378, closes #1379.

### I have:

- [X] Formatted any Python files with [black](https://github.com/ambv/black)
- [X] Brought the branch up to date with master
- [X] Added any relevant Github labels
- [X] Added tests for any new additions
- [X] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [X] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

- The `default_args` section has been removed from the FlowETL `config.yml`. Similarly, we don't pass in a `default_args` dict to `construct_etl_dag()` any more - instead, the values for `owner` and `start_date` are now hard-coded inside that function because they don't need to change.

- We now create DAGs only for those CDR types that are present in `config.yml`.

- The config is now always validated and default values filled in when reading the `config.yml` file.

- The `concurrency` setting from `config.yml` is now passed on to the DAG during creation, using the `max_active_runs_per_dag` parameter. Note that Airflow has a plethora of concurrency/parallelism settings, which can be a bit confusing (see discussions [here](https://stackoverflow.com/questions/38200666/airflow-parallelism), [here](https://cwiki.apache.org/confluence/display/AIRFLOW/Common+Pitfalls), [here](https://issues.apache.org/jira/browse/AIRFLOW-57) and [here](https://www.astronomer.io/guides/airflow-executors-explained/#Related_Definitions), among other places), but `max_active_runs_per_dag` seems to be the right setting for this purpose.

- The FlowETL deployment example has been updated so that it works when simply following the instructions.

