### PR TITLE
Fix adding api routes to servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - FlowETL now only creates DAGs for CDR types which are present in the config, leading to a better user experience in the Airflow UI. [#1376](https://github.com/Flowminder/FlowKit/issues/1376)
 - The `concurrency` settings in the FlowETL config are no longer ignored. [#1378](https://github.com/Flowminder/FlowKit/issues/1378)
 - The FlowETL deployment example has been updated so that it no longer fails due to a missing foreign data wrapper for the available CDR dates. [#1379](https://github.com/Flowminder/FlowKit/issues/1379)
-- Fixed not being able to enable a newly added api route on existing servers. [#1373](https://github.com/Flowminder/FlowKit/issues/1373)
+- Fixed not being able to enable a newly added api route on existing servers in FlowAuth. [#1373](https://github.com/Flowminder/FlowKit/issues/1373)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - FlowETL now only creates DAGs for CDR types which are present in the config, leading to a better user experience in the Airflow UI. [#1376](https://github.com/Flowminder/FlowKit/issues/1376)
 - The `concurrency` settings in the FlowETL config are no longer ignored. [#1378](https://github.com/Flowminder/FlowKit/issues/1378)
 - The FlowETL deployment example has been updated so that it no longer fails due to a missing foreign data wrapper for the available CDR dates. [#1379](https://github.com/Flowminder/FlowKit/issues/1379)
+- Fixed not being able to enable a newly added api route on existing servers. [#1373](https://github.com/Flowminder/FlowKit/issues/1373)
 
 ### Removed
 

--- a/flowauth/frontend/cypress/integration/add_new_route.js
+++ b/flowauth/frontend/cypress/integration/add_new_route.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+describe("Server management", function() {
+  Cypress.Cookies.debug(true);
+
+  beforeEach(function() {
+    // Log in and navigate to user details screen
+    cy.login_admin()
+      .goto("/")
+      .get("#api_routes")
+      .click();
+  });
+  it("Add a new route", function() {
+    // adding username with space
+    const route_name = Math.random()
+      .toString(36)
+      .substring(2, 15);
+    cy.get("#name").type(route_name, {
+      force: true
+    });
+    cy.get("#new").click();
+    cy.get("#name").should("be.empty");
+    cy.contains(route_name).should("exist");
+    cy.get("#server_list")
+      .click()
+      .get("#edit_1")
+      .click()
+      .get("#api-exp")
+      .click();
+    cy.get("#permissions").should("have.attr", "data-indeterminate", "true");
+    cy.get("[data-permission-id='" + route_name + "_get_result']")
+      .children(".MuiIconButton-label")
+      .children("#permission")
+      .should("not.be.checked")
+      .should("not.be.disabled");
+    cy.get("[data-permission-id='" + route_name + "_poll']")
+      .children(".MuiIconButton-label")
+      .children("#permission")
+      .should("not.be.checked")
+      .should("not.be.disabled");
+    cy.get("[data-permission-id='" + route_name + "_run']")
+      .children(".MuiIconButton-label")
+      .children("#permission")
+      .should("not.be.checked")
+      .should("not.be.disabled");
+    cy.get("#unit-exp").click();
+    cy.get('[data-aggregation-id="' + route_name + '_admin0"]')
+      .children(".MuiIconButton-label")
+      .children("#unit")
+      .should("not.be.disabled");
+    cy.get("#api_routes").click();
+    cy.contains(route_name)
+      .parent()
+      .parent()
+      .children()
+      .last()
+      .click({
+        force: true
+      });
+    cy.contains(route_name).should("not.exist");
+  });
+});

--- a/flowauth/frontend/cypress/integration/add_new_route.js
+++ b/flowauth/frontend/cypress/integration/add_new_route.js
@@ -54,8 +54,7 @@ describe("Server management", function() {
     cy.contains(route_name)
       .parent()
       .parent()
-      .children()
-      .last()
+      .find("button")
       .click({
         force: true
       });

--- a/flowauth/frontend/src/AdminMenu.jsx
+++ b/flowauth/frontend/src/AdminMenu.jsx
@@ -33,7 +33,11 @@ class AdminMenu extends React.Component {
           >
             <ListItemText primary="Groups" />
           </ListItem>
-          <ListItem button onClick={() => onClick("capability_admin")}>
+          <ListItem
+            button
+            onClick={() => onClick("capability_admin")}
+            id="api_routes"
+          >
             <ListItemText primary="API Routes" />
           </ListItem>
           <ListItem button onClick={() => onClick("aggregation_unit_admin")}>

--- a/flowauth/frontend/src/AggregationUnitList.jsx
+++ b/flowauth/frontend/src/AggregationUnitList.jsx
@@ -119,6 +119,7 @@ class AggregationUnitList extends React.Component {
                 <IconButton
                   color="inherit"
                   aria-label="New"
+                  id="new"
                   onClick={this.addCap}
                 >
                   <AddIcon />

--- a/flowauth/frontend/src/AggregationUnitSetting.jsx
+++ b/flowauth/frontend/src/AggregationUnitSetting.jsx
@@ -46,6 +46,7 @@ class AggregationUnitSetting extends React.Component {
                 control={
                   <Checkbox
                     checked={permissions[key]}
+                    data-aggregation-id={claim + "_" + key}
                     onChange={checkedHandler(claim_id, claim, key)}
                     value={claim + ":" + key}
                     color="primary"

--- a/flowauth/frontend/src/CapabilityList.jsx
+++ b/flowauth/frontend/src/CapabilityList.jsx
@@ -104,7 +104,7 @@ class CapabilityList extends React.Component {
           {this.renderCapabilities()}
           <Grid item xs={6}>
             <TextField
-              id="standard-name"
+              id="name"
               label="New Route"
               className={classes.textField}
               value={new_cap}
@@ -119,6 +119,7 @@ class CapabilityList extends React.Component {
                 color="inherit"
                 aria-label="New"
                 onClick={this.addCap}
+                id="new"
               >
                 <AddIcon />
               </IconButton>

--- a/flowauth/frontend/src/PermissionDetails.jsx
+++ b/flowauth/frontend/src/PermissionDetails.jsx
@@ -127,15 +127,24 @@ class PermissionDetails extends React.Component {
   };
 
   static getDerivedStateFromProps(props, state) {
-    const { permitted } = props;
+    const { permitted, rights } = props;
+
     if (permitted) {
       const totalAggUnits = Object.keys(permitted).reduce(
         (acc, k) => acc + permitted[k].spatial_aggregation.length,
         0
       );
+      const permissionSet = new Set();
+      for (const keys in rights) {
+        for (const key in rights[keys].permissions) {
+          if (permitted[keys].permissions[key]) {
+            permissionSet.add(rights[keys].permissions[key]);
+          }
+        }
+      }
       return {
         totalAggregateUnits: totalAggUnits,
-        ...state
+        permissionIndeterminate: permissionSet.size > 1
       };
     } else {
       return state;
@@ -171,8 +180,7 @@ class PermissionDetails extends React.Component {
 
   renderAggUnits = () => {
     var perms = [];
-    const { rights, permitted } = this.props;
-    const { isAggregationChecked } = this.state;
+    const { rights } = this.props;
     for (const key in rights) {
       perms.push([
         <ServerAggregationUnits
@@ -206,7 +214,7 @@ class PermissionDetails extends React.Component {
       isPermissionChecked,
       permissionIndeterminate
     } = this.state;
-    const { classes, onClick, permitted } = this.props;
+    const { classes, permitted } = this.props;
 
     if (permitted) {
       return (

--- a/flowauth/frontend/src/ServerAdminDetails.jsx
+++ b/flowauth/frontend/src/ServerAdminDetails.jsx
@@ -163,12 +163,13 @@ class ServerAdminDetails extends React.Component {
           this.setState({
             name: name,
             rights: rights,
-            permitted: JSON.parse(JSON.stringify(rights || {})),
             latest_expiry: json.latest_token_expiry,
             max_life: json.longest_token_life,
             edit_mode: true
           });
+          return getAllCapabilities();
         })
+        .then(json => this.setState({ permitted: json }))
         .catch(err => {
           this.setState({ hasError: true, error: err });
         });

--- a/flowauth/frontend/src/ServerAggregationUnits.jsx
+++ b/flowauth/frontend/src/ServerAggregationUnits.jsx
@@ -57,6 +57,7 @@ class ServerAggregationUnits extends React.Component {
                 control={
                   <Checkbox
                     id="unit"
+                    data-aggregation-id={claim + "_" + unit.name}
                     checked={units.indexOf(unit.name) !== -1}
                     onChange={checkedHandler(claim_id, claim, unit.name)}
                     value={claim + ":" + unit.name}

--- a/flowauth/frontend/src/TokenPermission.jsx
+++ b/flowauth/frontend/src/TokenPermission.jsx
@@ -45,6 +45,7 @@ class TokenPermission extends React.Component {
                 control={
                   <Checkbox
                     data-cy="permission-nested"
+                    data-permission-id={claim + "_" + key}
                     id="permission"
                     checked={permissions[key]}
                     onChange={checkedHandler(claim, key)}


### PR DESCRIPTION
Closes #1373

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [x] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Fixes not being able to turn on a newly added api route for an existing server by correctly setting the permitted options on servers to all options, and adds a test to cover this case.