### PR TITLE
Fix adding servers to users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - FlowETL now only creates DAGs for CDR types which are present in the config, leading to a better user experience in the Airflow UI. [#1376](https://github.com/Flowminder/FlowKit/issues/1376)
 - The `concurrency` settings in the FlowETL config are no longer ignored. [#1378](https://github.com/Flowminder/FlowKit/issues/1378)
 - The FlowETL deployment example has been updated so that it no longer fails due to a missing foreign data wrapper for the available CDR dates. [#1379](https://github.com/Flowminder/FlowKit/issues/1379)
+- Fixed error when editing a user in FlowAuth who did not have two factor enabled. [#1374](https://github.com/Flowminder/FlowKit/issues/1374)
 
 ### Removed
 

--- a/flowauth/backend/flowauth/admin.py
+++ b/flowauth/backend/flowauth/admin.py
@@ -732,7 +732,11 @@ def edit_user(user_id):
             user.is_admin = edits["is_admin"]
     if "require_two_factor" in edits:
         user.require_two_factor = edits["require_two_factor"]
-    if "has_two_factor" in edits and not edits["has_two_factor"] and user.two_factor_auth is not None:
+    if (
+        "has_two_factor" in edits
+        and not edits["has_two_factor"]
+        and user.two_factor_auth is not None
+    ):
         db.session.delete(user.two_factor_auth)
     db.session.add(user)
     db.session.commit()

--- a/flowauth/backend/flowauth/admin.py
+++ b/flowauth/backend/flowauth/admin.py
@@ -732,7 +732,7 @@ def edit_user(user_id):
             user.is_admin = edits["is_admin"]
     if "require_two_factor" in edits:
         user.require_two_factor = edits["require_two_factor"]
-    if "has_two_factor" in edits and not edits["has_two_factor"]:
+    if "has_two_factor" in edits and not edits["has_two_factor"] and user.two_factor_auth is not None:
         db.session.delete(user.two_factor_auth)
     db.session.add(user)
     db.session.commit()


### PR DESCRIPTION
Closes #1374

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Fixes an error (and being bounced to login) in FlowAuth when trying to add a newly created server to a user. Actual issue was 'any edit to a user except turning on has two factor if they didn't have two factor on raises an error'.