### PR TITLE
Remove redoc specific api spec

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -45,7 +45,7 @@ if [ "$CI" != "true" ]; then
 fi
 
 echo "Retrieving API spec"
-curl http://localhost:9090/api/0/spec/openapi-redoc.json -o source/_static/openapi-redoc.json
+curl http://localhost:9090/api/0/spec/openapi.json -o source/_static/openapi.json
 echo "Starting build."
 
 # Note: the DOCS_BRANCH variable is used by `mkdocs.yml` to pick up the correct git repositories for building API docs

--- a/docs/source/api-spec.html
+++ b/docs/source/api-spec.html
@@ -1,2 +1,2 @@
-<redoc spec-url='_static/openapi-redoc.json'></redoc>
+<redoc spec-url='_static/openapi.json'></redoc>
 <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>

--- a/flowapi/flowapi/api_spec.py
+++ b/flowapi/flowapi/api_spec.py
@@ -11,28 +11,6 @@ from flowapi import __version__
 blueprint = Blueprint("spec", __name__)
 
 
-def remove_discriminators(spec: dict) -> dict:
-    """
-    Remove any discriminator keys from an openapi spec dict, because
-    they are not supported properly by redoc.
-
-    Parameters
-    ----------
-    spec : dict
-        Dict version of an openapi spec
-
-    Returns
-    -------
-    dict
-        The same spec, but with all discriminator keys removed.
-    """
-    newdict = {}
-    for k, v in spec.items():
-        if k != "discriminator":
-            newdict[k] = remove_discriminators(v) if isinstance(v, dict) else v
-    return newdict
-
-
 async def get_spec(socket: Socket, request_id: str) -> APISpec:
     """
     Construct open api spec by interrogating FlowMachine.
@@ -108,14 +86,3 @@ async def get_api_spec():
 async def get_yaml_api_spec():
     spec = await get_spec(request.socket, request.request_id)
     return current_app.response_class(spec.to_yaml(), content_type="application/x-yaml")
-
-
-@blueprint.route("/openapi-redoc.json")
-async def get_redoc_api_spec():
-    spec = await get_spec(request.socket, request.request_id)
-    return jsonify(remove_discriminators(spec.to_dict()))
-
-
-@blueprint.route("/redoc")
-async def redoc_api_spec():
-    return await render_template("spec.html", api_version=__version__)

--- a/flowapi/flowapi/templates/spec.html
+++ b/flowapi/flowapi/templates/spec.html
@@ -18,7 +18,7 @@
     </style>
   </head>
   <body>
-    <redoc spec-url='{{ url_for('spec.get_redoc_api_spec') }}'></redoc>
+    <redoc spec-url='{{ url_for('spec.get_api_spec') }}'></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
   </body>
 </html>

--- a/integration_tests/tests/flowapi_tests/test_api_spec.py
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.py
@@ -6,17 +6,6 @@ import requests
 from approvaltests import verify
 
 
-def test_generated_openapi_redoc_spec(flowapi_url, diff_reporter):
-    """
-    Verify the OpenAPI spec for FlowAPI (as formatted for redoc).
-    """
-    spec = requests.get(f"{flowapi_url}/api/0/spec/openapi-redoc.json").json()
-    spec_version = spec["info"].pop("version")
-    assert spec_version == flowapi.__version__
-    spec_as_json_string = json.dumps(sort_recursively(spec), indent=2, sort_keys=True)
-    verify(spec_as_json_string, diff_reporter)
-
-
 def test_generated_openapi_json_spec(flowapi_url, diff_reporter):
     """
     Verify the OpenAPI spec for FlowAPI.


### PR DESCRIPTION
Discriminators now work, so we don't need a redoc specific version of the spec

Currently (with spec edited to remove discriminator keys):
<img width="650" alt="Screenshot 2019-10-15 at 09 26 01" src="https://user-images.githubusercontent.com/472828/66815150-ac9d4480-ef2f-11e9-8023-329f15183dc2.png">

With this PR:
<img width="673" alt="Screenshot 2019-10-15 at 09 24 16" src="https://user-images.githubusercontent.com/472828/66815212-c2ab0500-ef2f-11e9-8d9a-a9a43547993d.png">
