### PR TITLE
Fix diff reporters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .env
 
+# Approval tests diff reporters overrides
+reporters.json
+approvaltests_diff_reporters.json
+
 # Notebook output
 docs/test.csv
 docs/tower_metrics.csv

--- a/approvaltests_diff_reporters.json
+++ b/approvaltests_diff_reporters.json
@@ -1,6 +1,0 @@
-[
-    [
-        "OpenDiff",
-        "opendiff"
-    ]
-]

--- a/docs/source/developer/dev_environment_setup.md
+++ b/docs/source/developer/dev_environment_setup.md
@@ -56,14 +56,11 @@ black...................................................Passed
 Some of the tests use [ApprovalTests](https://github.com/approvals/ApprovalTests.Python) to verify large output against
 a known "approved" version (stored in files called `*approved.txt`). For example, the API specification is
 verified in this way. If you make code changes that alter the results of these tests, the content of the
-relevant `*.approved.txt` file needs to be updated. ApprovalTests will do this automatically for you, but you need to have a
+relevant `*.approved.txt` file needs to be updated. ApprovalTests will do this automatically for you, but it may be useful to have a
 diff tool installed. (See here for some recommendations for diff tools on [Mac](`https://www.git-tower.com/blog/diff-tools-mac`)
-and [Windows](https://www.git-tower.com/blog/diff-tools-windows).)
+and [Windows](https://www.git-tower.com/blog/diff-tools-windows).) The reporters supported out of the box by ApprovalTests can be found [here](https://github.com/approvals/ApprovalTests.Python/blob/master/approvaltests/reporters/reporters.json).
 
-There is a toplevel config file called `approvaltests_diff_reporters.json` which lists the diff tools that ApprovalTests
-will try to find. Currently only `opendiff` is listed there (but we may add additional ones in the future). If you are using a different tool you should
-manually add it to this file. See the ApprovalTests [README](https://github.com/approvals/ApprovalTests.Python) for
-examples (illustrative particularly for file paths on Windows).
+To use a specific diff reporter, you should create a file named `reporters.json` following the format shown in the ApprovalTests [README](https://github.com/approvals/ApprovalTests.Python).
 
 !!! warning
     The project root contains an env file (`development_environment`), in which are default values for _all_ of the environment variables used to control and configure the FlowDB, FlowAPI, FlowMachine and FlowAuth. You will need to source this file (`set -a && . ./development_environment && set +a`), or otherwise set the environment variables before running _any other command_.

--- a/docs/source/developer/dev_environment_setup.md
+++ b/docs/source/developer/dev_environment_setup.md
@@ -60,7 +60,7 @@ relevant `*.approved.txt` file needs to be updated. ApprovalTests will do this a
 diff tool installed. (See here for some recommendations for diff tools on [Mac](`https://www.git-tower.com/blog/diff-tools-mac`)
 and [Windows](https://www.git-tower.com/blog/diff-tools-windows).) The reporters supported out of the box by ApprovalTests can be found [here](https://github.com/approvals/ApprovalTests.Python/blob/master/approvaltests/reporters/reporters.json).
 
-To use a specific diff reporter, you should create a file named `reporters.json` following the format shown in the ApprovalTests [README](https://github.com/approvals/ApprovalTests.Python).
+To use a specific diff reporter, you should create files named `reporters.json` in `flowmachine/tests` and `integration_tests` following the format shown in the ApprovalTests [README](https://github.com/approvals/ApprovalTests.Python).
 
 !!! warning
     The project root contains an env file (`development_environment`), in which are default values for _all_ of the environment variables used to control and configure the FlowDB, FlowAPI, FlowMachine and FlowAuth. You will need to source this file (`set -a && . ./development_environment && set +a`), or otherwise set the environment variables before running _any other command_.

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -243,7 +243,5 @@ def dummy_redis(monkeypatch):
 @pytest.fixture(scope="session")
 def diff_reporter():
     diff_reporter_factory = GenericDiffReporterFactory()
-    diff_reporter_factory.load(
-        os.path.join(flowkit_toplevel_dir, "approvaltests_diff_reporters.json")
-    )
+
     return diff_reporter_factory.get_first_working()

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -10,6 +10,7 @@ import json
 import os
 from functools import partial
 from json import JSONDecodeError
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -246,7 +247,7 @@ def dummy_redis(monkeypatch):
 def diff_reporter():
     diff_reporter_factory = GenericDiffReporterFactory()
     try:
-        with open("reporters.json") as fin:
+        with open(Path(__file__).parent / "reporters.json") as fin:
             for config in json.load(fin):
                 diff_reporter_factory.add_default_reporter_config(config)
     except FileNotFoundError:

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -8,6 +8,7 @@ Commonly used testing fixtures for flowmachine.
 """
 import json
 import os
+from functools import partial
 from json import JSONDecodeError
 
 import pandas as pd
@@ -17,6 +18,7 @@ import logging
 from unittest.mock import Mock
 
 from _pytest.capture import CaptureResult
+from approvaltests import verify
 from approvaltests.reporters.generic_diff_reporter_factory import (
     GenericDiffReporterFactory,
 )
@@ -243,5 +245,11 @@ def dummy_redis(monkeypatch):
 @pytest.fixture(scope="session")
 def diff_reporter():
     diff_reporter_factory = GenericDiffReporterFactory()
-
-    return diff_reporter_factory.get_first_working()
+    try:
+        with open("reporters.json") as fin:
+            for config in json.load(fin):
+                diff_reporter_factory.add_default_reporter_config(config)
+    except FileNotFoundError:
+        pass
+    differ = diff_reporter_factory.get_first_working()
+    return partial(verify, reporter=differ)

--- a/flowmachine/tests/functional_tests/test_sql_strings_and_results.py
+++ b/flowmachine/tests/functional_tests/test_sql_strings_and_results.py
@@ -4,7 +4,6 @@
 
 from flowmachine.utils import pretty_sql
 
-from approvaltests.approvals import verify
 from flowmachine.core import CustomQuery, make_spatial_unit
 from flowmachine.features import daily_location
 
@@ -15,7 +14,7 @@ def test_daily_location_1_sql(diff_reporter):
     """
     dl = daily_location("2016-01-01", "2016-01-02")
     sql = pretty_sql(dl.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_daily_location_1_df(get_dataframe, diff_reporter):
@@ -24,7 +23,7 @@ def test_daily_location_1_df(get_dataframe, diff_reporter):
     """
     dl = daily_location("2016-01-01", "2016-01-02")
     df = get_dataframe(dl)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())
 
 
 def test_daily_location_2_sql(diff_reporter):
@@ -48,7 +47,7 @@ def test_daily_location_2_sql(diff_reporter):
         ],
     )
     sql = pretty_sql(dl.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_daily_location_2_df(get_dataframe, diff_reporter):
@@ -70,7 +69,7 @@ def test_daily_location_2_df(get_dataframe, diff_reporter):
         ],
     )
     df = get_dataframe(dl)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())
 
 
 def test_daily_location_3_sql(diff_reporter):
@@ -91,7 +90,7 @@ def test_daily_location_3_sql(diff_reporter):
         subscriber_subset=subset_query,
     )
     sql = pretty_sql(dl.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_daily_location_3_df(get_dataframe, diff_reporter):
@@ -112,7 +111,7 @@ def test_daily_location_3_df(get_dataframe, diff_reporter):
         subscriber_subset=subset_query,
     )
     df = get_dataframe(dl)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())
 
 
 def test_daily_location_4_sql(diff_reporter):
@@ -130,7 +129,7 @@ def test_daily_location_4_sql(diff_reporter):
         subscriber_subset=subset_query,
     )
     sql = pretty_sql(dl.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_daily_location_4_df(get_dataframe, diff_reporter):
@@ -148,7 +147,7 @@ def test_daily_location_4_df(get_dataframe, diff_reporter):
         subscriber_subset=subset_query,
     )
     df = get_dataframe(dl)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())
 
 
 def test_daily_location_5_sql(diff_reporter):
@@ -169,7 +168,7 @@ def test_daily_location_5_sql(diff_reporter):
         subscriber_subset=subset_query,
     )
     sql = pretty_sql(dl.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_daily_location_5_df(get_dataframe, diff_reporter):
@@ -196,7 +195,7 @@ def test_daily_location_5_df(get_dataframe, diff_reporter):
         subscriber_subset=subset_query,
     )
     df = get_dataframe(dl)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())
 
 
 def test_daily_location_6_sql(diff_reporter):
@@ -215,7 +214,7 @@ def test_daily_location_6_sql(diff_reporter):
         "2016-01-03", table="events.calls", subscriber_subset=subset_query
     )
     sql = pretty_sql(dl.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_daily_location_6_df(get_dataframe, diff_reporter):
@@ -234,7 +233,7 @@ def test_daily_location_6_df(get_dataframe, diff_reporter):
         "2016-01-03", table="events.calls", subscriber_subset=subset_query
     )
     df = get_dataframe(dl)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())
 
 
 def test_versioned_site_sql(diff_reporter):
@@ -243,4 +242,4 @@ def test_versioned_site_sql(diff_reporter):
     """
     su = make_spatial_unit("versioned-site")
     sql = pretty_sql(su.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)

--- a/flowmachine/tests/test_query_object_construction.py
+++ b/flowmachine/tests/test_query_object_construction.py
@@ -4,7 +4,6 @@
 
 import json
 import pytest
-from approvaltests.approvals import verify
 from marshmallow import ValidationError
 
 from flowmachine.core.server.query_schemas import FlowmachineQuerySchema
@@ -277,7 +276,7 @@ def test_construct_query(diff_reporter):
         indent=2,
     )
 
-    verify(query_ids_and_specs_as_json_string, diff_reporter)
+    diff_reporter(query_ids_and_specs_as_json_string)
 
 
 # TODO: we should re-think how we want to test invalid values, now that these are validated using marshmallow

--- a/integration_tests/tests/conftest.py
+++ b/integration_tests/tests/conftest.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import json
 from functools import partial
+from pathlib import Path
 
 from approvaltests import verify
 from approvaltests.reporters.generic_diff_reporter_factory import (
@@ -263,7 +264,7 @@ def get_dataframe(fm_conn):
 def diff_reporter():
     diff_reporter_factory = GenericDiffReporterFactory()
     try:
-        with open("reporters.json") as fin:
+        with open(Path(__file__).parent / "reporters.json") as fin:
             for config in json.load(fin):
                 diff_reporter_factory.add_default_reporter_config(config)
     except FileNotFoundError:

--- a/integration_tests/tests/conftest.py
+++ b/integration_tests/tests/conftest.py
@@ -260,7 +260,5 @@ def get_dataframe(fm_conn):
 @pytest.fixture(scope="session")
 def diff_reporter():
     diff_reporter_factory = GenericDiffReporterFactory()
-    diff_reporter_factory.load(
-        os.path.join(flowkit_toplevel_dir, "approvaltests_diff_reporters.json")
-    )
+
     return diff_reporter_factory.get_first_working()

--- a/integration_tests/tests/flowapi_tests/test_api_spec.py
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.py
@@ -3,7 +3,6 @@ import flowapi
 import yaml
 from flowmachine.utils import sort_recursively
 import requests
-from approvaltests import verify
 
 
 def test_generated_openapi_json_spec(flowapi_url, diff_reporter):
@@ -14,7 +13,7 @@ def test_generated_openapi_json_spec(flowapi_url, diff_reporter):
     spec_version = spec["info"].pop("version")
     assert spec_version == flowapi.__version__
     spec_as_json_string = json.dumps(sort_recursively(spec), indent=2, sort_keys=True)
-    verify(spec_as_json_string, diff_reporter)
+    diff_reporter(spec_as_json_string)
 
 
 def test_generated_openapi_yaml_spec(flowapi_url, diff_reporter):
@@ -25,4 +24,4 @@ def test_generated_openapi_yaml_spec(flowapi_url, diff_reporter):
     spec_version = spec["info"].pop("version")
     assert spec_version == flowapi.__version__
     spec_as_json_string = json.dumps(sort_recursively(spec), indent=2, sort_keys=True)
-    verify(spec_as_json_string, diff_reporter)
+    diff_reporter(spec_as_json_string)

--- a/integration_tests/tests/flowmachine_server_tests/test_server.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.py
@@ -10,7 +10,6 @@ from flowmachine.features.utilities.spatial_aggregates import SpatialAggregate
 from flowmachine.features.dfs.total_amount_for_metric import DFSTotalMetricAmount
 from flowmachine.features import daily_location, ModalLocation
 from flowmachine.utils import sort_recursively
-from approvaltests.approvals import verify
 from .helpers import poll_until_done
 
 
@@ -84,7 +83,7 @@ def test_api_spec_of_flowmachine_query_schemas(zmq_host, zmq_port, diff_reporter
     spec_as_json_string = json.dumps(
         sort_recursively(reply["payload"]["query_schemas"]), indent=2
     )
-    verify(spec_as_json_string, diff_reporter)
+    diff_reporter(spec_as_json_string)
 
 
 def test_run_daily_location_query(zmq_host, zmq_port):

--- a/integration_tests/tests/flowmachine_tests/test_daily_location_results.py
+++ b/integration_tests/tests/flowmachine_tests/test_daily_location_results.py
@@ -4,7 +4,6 @@
 
 from flowmachine.utils import pretty_sql
 
-from approvaltests.approvals import verify
 from flowmachine.core import CustomQuery, make_spatial_unit
 from flowmachine.features import daily_location
 
@@ -25,7 +24,7 @@ def test_daily_location_1_sql(diff_reporter):
         subscriber_subset=subset_query,
     )
     sql = pretty_sql(dl.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_daily_location_1_df(get_dataframe, diff_reporter):
@@ -46,4 +45,4 @@ def test_daily_location_1_df(get_dataframe, diff_reporter):
         subscriber_subset=subset_query,
     )
     df = get_dataframe(dl)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())

--- a/integration_tests/tests/flowmachine_tests/test_event_count_results.py
+++ b/integration_tests/tests/flowmachine_tests/test_event_count_results.py
@@ -4,7 +4,6 @@
 
 from flowmachine.utils import pretty_sql
 
-from approvaltests.approvals import verify
 from flowmachine.core import CustomQuery
 from flowmachine.features import EventCount
 
@@ -15,7 +14,7 @@ def test_event_count_1_sql(diff_reporter):
     """
     ec = EventCount(start="2016-01-02", stop="2016-01-04")
     sql = pretty_sql(ec.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_event_count_1_df(get_dataframe, diff_reporter):
@@ -24,7 +23,7 @@ def test_event_count_1_df(get_dataframe, diff_reporter):
     """
     ec = EventCount(start="2016-01-02", stop="2016-01-04")
     df = get_dataframe(ec)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())
 
 
 def test_event_count_2_sql(diff_reporter):
@@ -33,7 +32,7 @@ def test_event_count_2_sql(diff_reporter):
     """
     ec = EventCount(start="2016-01-05", stop=None)
     sql = pretty_sql(ec.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_event_count_2_df(get_dataframe, diff_reporter):
@@ -42,7 +41,7 @@ def test_event_count_2_df(get_dataframe, diff_reporter):
     """
     ec = EventCount(start="2016-01-05", stop=None)
     df = get_dataframe(ec)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())
 
 
 def test_event_count_3_sql(diff_reporter):
@@ -51,7 +50,7 @@ def test_event_count_3_sql(diff_reporter):
     """
     ec = EventCount(start=None, stop="2016-01-02")
     sql = pretty_sql(ec.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_event_count_3_df(get_dataframe, diff_reporter):
@@ -60,7 +59,7 @@ def test_event_count_3_df(get_dataframe, diff_reporter):
     """
     ec = EventCount(start=None, stop="2016-01-02")
     df = get_dataframe(ec)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())
 
 
 def test_event_count_4_sql(diff_reporter):
@@ -69,7 +68,7 @@ def test_event_count_4_sql(diff_reporter):
     """
     ec = EventCount(start="2016-01-02", stop="2016-01-04", hours=(12, 18))
     sql = pretty_sql(ec.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_event_count_4_df(get_dataframe, diff_reporter):
@@ -78,7 +77,7 @@ def test_event_count_4_df(get_dataframe, diff_reporter):
     """
     ec = EventCount(start="2016-01-02", stop="2016-01-04", hours=(12, 18))
     df = get_dataframe(ec)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())
 
 
 def test_event_count_5_sql(diff_reporter):
@@ -87,7 +86,7 @@ def test_event_count_5_sql(diff_reporter):
     """
     ec = EventCount(start="2016-01-03", stop="2016-01-06", hours=(22, 4))
     sql = pretty_sql(ec.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_event_count_5_df(get_dataframe, diff_reporter):

--- a/integration_tests/tests/flowmachine_tests/test_event_count_results.py
+++ b/integration_tests/tests/flowmachine_tests/test_event_count_results.py
@@ -95,4 +95,4 @@ def test_event_count_5_df(get_dataframe, diff_reporter):
     """
     ec = EventCount(start="2016-01-03", stop="2016-01-06", hours=(22, 4))
     df = get_dataframe(ec)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())

--- a/integration_tests/tests/flowmachine_tests/test_events_tables_union.py
+++ b/integration_tests/tests/flowmachine_tests/test_events_tables_union.py
@@ -4,7 +4,6 @@
 
 from flowmachine.utils import pretty_sql
 
-from approvaltests.approvals import verify
 from flowmachine.core import CustomQuery
 from flowmachine.features import EventsTablesUnion
 
@@ -29,7 +28,7 @@ def test_events_tables_union_1_sql(diff_reporter):
         ],
     )
     sql = pretty_sql(etu.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_events_tables_union_1_df(diff_reporter, get_dataframe):
@@ -52,7 +51,7 @@ def test_events_tables_union_1_df(diff_reporter, get_dataframe):
         ],
     )
     df = get_dataframe(etu)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())
 
 
 def test_events_tables_union_2_sql(diff_reporter):
@@ -76,7 +75,7 @@ def test_events_tables_union_2_sql(diff_reporter):
         ],
     )
     sql = pretty_sql(etu.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_events_tables_union_2_df(diff_reporter, get_dataframe):
@@ -100,7 +99,7 @@ def test_events_tables_union_2_df(diff_reporter, get_dataframe):
         ],
     )
     df = get_dataframe(etu)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())
 
 
 def test_events_tables_union_3_sql(diff_reporter):
@@ -124,7 +123,7 @@ def test_events_tables_union_3_sql(diff_reporter):
         ],
     )
     sql = pretty_sql(etu.get_query())
-    verify(sql, diff_reporter)
+    diff_reporter(sql)
 
 
 def test_events_tables_union_3_df(diff_reporter, get_dataframe):
@@ -148,4 +147,4 @@ def test_events_tables_union_3_df(diff_reporter, get_dataframe):
         ],
     )
     df = get_dataframe(etu)
-    verify(df.to_csv(), diff_reporter)
+    diff_reporter(df.to_csv())


### PR DESCRIPTION
Closes #1615 

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Tweaks the diff reporters so that the default reporters aren't trashed, and removes our imposed default of opendiff (the approval tests folks found this to create problems on non-mac systems, or where Xcode wasn't installed.)

Fyi, as a PyCharm user I'm quite happy with the following:

1. Find PyCharm path (`ps -ef | grep PyCharm`)
2. Stick this in /usr/local/bin/
```bash
#!/bin/bash
eval "<pycharm_path>" $@ $3
```

(The `$3` is required because pycharm's merge command wants an output file - this sets it to the approved file)

3. Create `reporters.json`:
```json
[[
    "PyCharm",
    "<whatever_you_called_the_script>",
    ["merge"]
  ]]
```

