### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ ifneq ($(NUM_SPECIFIED_FLOWDB_SERVICES),0)
   endif
 endif
 
+up : DOCKER_COMPOSE += -f $(DOCKER_COMPOSE_FILE_BUILD)
 
 ifeq ($(FLOWDB_SERVICE), flowdb_testdata)
  up up-no_build : DOCKER_COMPOSE += -f $(DOCKER_COMPOSE_TESTDATA_FILE)
@@ -51,14 +52,14 @@ ifeq ($(FLOWDB_SERVICE), flowdb_synthetic_data)
 endif
 
 # Only build flowdb if a flowdb service is requested
-ifeq ($(words, $FLOWDB_SERVICE), 1)
+ifeq ($(words $(FLOWDB_SERVICE)), 1)
     FLOWDB_BUILD = flowdb-build
 endif
 
 all:
 
 up: $(FLOWDB_BUILD)
-	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE_BUILD) up --build -d $(DOCKER_SERVICES_TO_START)
+	$(DOCKER_COMPOSE) up --build -d $(DOCKER_SERVICES_TO_START)
 
 up-no_build:
 	$(DOCKER_COMPOSE) up -d $(DOCKER_SERVICES_TO_START)


### PR DESCRIPTION
Closes #1617 

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Changes the order of docker compose files in the Makefile, so that the correct image is used when starting `flowdb-testdata` or `flowdb-synthetic-data`.