### PR TITLE
Fix FlowAuth bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Quickstart should no longer fail on systems which do not include the `netstat` tool. [#1472](https://github.com/Flowminder/FlowKit/issues/1472)
+- Fixed an error that prevented FlowAuth admin users from resetting users' passwords using the FlowAuth UI. [#1635](https://github.com/Flowminder/FlowKit/issues/1635)
+- The 'Cancel' button on the FlowAuth 'New User' form no longer submits the form. [#1636](https://github.com/Flowminder/FlowKit/issues/1636)
+- FlowAuth backend now sends a meaningful 400 response when trying to create a user with an empty password. [#1637](https://github.com/Flowminder/FlowKit/issues/1637)
+- Usernames of deleted users can now be re-used as usernames for new users. [#1638](https://github.com/Flowminder/FlowKit/issues/1638)
 
 ### Removed
 - Removed pg_cron.

--- a/flowauth/backend/flowauth/admin.py
+++ b/flowauth/backend/flowauth/admin.py
@@ -636,11 +636,16 @@ def add_user():
     Returns the new user's id and group_id.
     """
     json = request.get_json()
-    if zxcvbn(json["password"])["score"] > 3:
-        user = User(**json)
+    if len(json["password"]) > 0:
+        if zxcvbn(json["password"])["score"] > 3:
+            user = User(**json)
+        else:
+            raise InvalidUsage(
+                "Password not complex enough.", payload={"bad_field": "password"}
+            )
     else:
         raise InvalidUsage(
-            "Password not complex enough.", payload={"bad_field": "password"}
+            "Password must be provided.", payload={"bad_field": "password"}
         )
     if User.query.filter(User.username == json["username"]).first() is not None:
         raise InvalidUsage(

--- a/flowauth/backend/flowauth/admin.py
+++ b/flowauth/backend/flowauth/admin.py
@@ -677,9 +677,11 @@ def rm_user(user_id):
 
     """
     user = User.query.filter(User.id == user_id).first_or_404()
+    user_group = [g for g in user.groups if g.user_group][0]
     if user.is_admin and len(User.query.filter(User.is_admin).all()) == 1:
         raise InvalidUsage("Removing this user would leave no admins.")
     db.session.delete(user)
+    db.session.delete(user_group)
     db.session.commit()
     return jsonify({"poll": "OK"})
 

--- a/flowauth/backend/tests/test_user_and_groups_admin.py
+++ b/flowauth/backend/tests/test_user_and_groups_admin.py
@@ -276,7 +276,9 @@ def test_delete_user(client, auth, test_admin):
         "group_id": 2,
     } == response.get_json()
     # Check user group members
-    response = client.get("/admin/groups/2/members", headers={"X-CSRF-Token": csrf_cookie})
+    response = client.get(
+        "/admin/groups/2/members", headers={"X-CSRF-Token": csrf_cookie}
+    )
     assert [{"id": 2, "name": "TEST_USER"}] == response.get_json()
 
     # Delete user

--- a/flowauth/frontend/cypress/integration/add_new_user.js
+++ b/flowauth/frontend/cypress/integration/add_new_user.js
@@ -91,6 +91,18 @@ describe("User management", function() {
     cy.contains("Save").click();
     cy.contains(user_name).should("be.visible");
   });
+  it("Cancel adding User", function() {
+    cy.get("#new").click();
+    //Add new user with password
+    const user_name = Math.random()
+      .toString(36)
+      .substring(2, 15);
+    cy.get("#username").type(user_name);
+    cy.get("#password").type("C>K,7|~44]44:ibK");
+    cy.contains("Cancel").click();
+    cy.get("[data-action=edit]").should("be.visible");
+    cy.contains(user_name).should("not.exist");
+  });
   it("Unauthorised access", function() {
     cy.get("#new").click();
     //Add new user with password

--- a/flowauth/frontend/cypress/integration/admin_edit_user.js
+++ b/flowauth/frontend/cypress/integration/admin_edit_user.js
@@ -12,17 +12,20 @@ describe("User management", function() {
     cy.get("#user_list").click();
   });
   it("Edit existing user password", function() {
+    const user_name = Math.random()
+      .toString(36)
+      .substring(2, 15);
     cy.get("#new").click();
     //Add new user with password
-    cy.get("#username").type("USER_TEST");
+    cy.get("#username").type(user_name);
     cy.get("#password").type("DUMMY_ORIGINAL_PASSWORD");
     cy.contains("Save").click();
-    cy.get("#edit_3").click();
+    cy.get("[data-action=edit][data-item-name=" + user_name + "]").click();
     cy.get("#password").type("DUMMY_UPDATED_PASSWORD");
     cy.contains("Save").click();
     cy.request("/signout");
     cy.request("POST", "/signin", {
-      username: "USER_TEST",
+      username: user_name,
       password: "DUMMY_UPDATED_PASSWORD"
     });
   });

--- a/flowauth/frontend/cypress/integration/admin_edit_user.js
+++ b/flowauth/frontend/cypress/integration/admin_edit_user.js
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+describe("User management", function() {
+  Cypress.Cookies.debug(true);
+
+  beforeEach(function() {
+    // Log in and navigate to user details screen
+    cy.login_admin();
+    cy.goto("/");
+    cy.get("#user_list").click();
+  });
+  it("Edit existing user password", function() {
+    cy.get("#new").click();
+    //Add new user with password
+    cy.get("#username").type("USER_TEST");
+    cy.get("#password").type("DUMMY_ORIGINAL_PASSWORD");
+    cy.contains("Save").click();
+    cy.get("#edit_3").click();
+    cy.get("#password").type("DUMMY_UPDATED_PASSWORD");
+    cy.contains("Save").click();
+    cy.request("/signout");
+    cy.request("POST", "/signin", {
+      username: "USER_TEST",
+      password: "DUMMY_UPDATED_PASSWORD"
+    });
+  });
+});

--- a/flowauth/frontend/src/AdminListItem.jsx
+++ b/flowauth/frontend/src/AdminListItem.jsx
@@ -29,6 +29,8 @@ function AdminListItem(props) {
               color="inherit"
               onClick={() => editAction(id)}
               id={"edit_" + id}
+              data-item-name={name}
+              data-action={"edit"}
             >
               <EditIcon />
             </IconButton>
@@ -39,6 +41,8 @@ function AdminListItem(props) {
             color="inherit"
             onClick={() => deleteAction(id)}
             id={"rm_" + id}
+            data-item-name={name}
+            data-action={"rm"}
           >
             <DeleteIcon />
           </IconButton>

--- a/flowauth/frontend/src/UserAdminDetails.jsx
+++ b/flowauth/frontend/src/UserAdminDetails.jsx
@@ -143,7 +143,7 @@ class UserAdminDetails extends React.Component {
         task = editUser(
           item_id,
           name,
-          password ? password.length > 0 : undefined,
+          password.length > 0 ? password : undefined,
           is_admin,
           require_two_factor,
           has_two_factor

--- a/flowauth/frontend/src/UserAdminDetails.jsx
+++ b/flowauth/frontend/src/UserAdminDetails.jsx
@@ -315,10 +315,7 @@ class UserAdminDetails extends React.Component {
           message={this.state.errors.message}
         />
         <Grid item xs={12} />
-        <SubmitButtons
-          handleSubmit={this.handleSubmit}
-          onClick={this.handleSubmit}
-        />
+        <SubmitButtons handleSubmit={this.handleSubmit} onClick={onClick} />
       </React.Fragment>
     );
   }

--- a/flowclient/flowclient/client.py
+++ b/flowclient/flowclient/client.py
@@ -218,6 +218,9 @@ def connect(
         JSON Web Token for this API server
     api_version : int, default 0
         Version of the API to connect to
+    ssl_certificate: str or None
+        Provide a path to an ssl certificate to use, or None to use
+        default root certificates.
 
     Returns
     -------


### PR DESCRIPTION
Closes #1635, closes #1636, closes #1637, closes #1638 

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [x] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Fixes 4 bugs in FlowAuth:
- Frontend was sending the bool `password.len > 0` instead of the string `password` when editing user details.
- `this.handleSubmit` was assigned to both submit buttons ('Save' and 'Cancel') in the `UserAdminDetails` form, when the 'Cancel' button should have used `onClick`.
- `zxcvbn` raises an `IndexError` if called with an empty string (which happens if a user submits the 'add user' form without filling in the password box), so I've added an extra if/else to check `len(json["password"]) > 0` before calling `zxcvbn`.
- When adding a new user, a new group unique to that user is also added, but this group was not removed when deleting the user. Attempting to re-add a user with the name of a deleted user would then try to create a new user group with the same name as the still-existing user group for the now-deleted user, violating the `UNIQUE` constraint on the `groups` table.