### PR TITLE
Fix redacted joined spatial aggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The 'Cancel' button on the FlowAuth 'New User' form no longer submits the form. [#1636](https://github.com/Flowminder/FlowKit/issues/1636)
 - FlowAuth backend now sends a meaningful 400 response when trying to create a user with an empty password. [#1637](https://github.com/Flowminder/FlowKit/issues/1637)
 - Usernames of deleted users can now be re-used as usernames for new users. [#1638](https://github.com/Flowminder/FlowKit/issues/1638)
+- RedactedJoinedSpatialAggregate now only redacts rows with too few subscribers. [#1747](https://github.com/Flowminder/FlowKit/issues/1747)
 
 ### Removed
 - Removed pg_cron.

--- a/flowmachine/flowmachine/features/location/redacted_joined_spatial_aggregate.py
+++ b/flowmachine/flowmachine/features/location/redacted_joined_spatial_aggregate.py
@@ -70,8 +70,9 @@ class RedactedJoinedSpatialAggregate(GeoDataMixin, Query):
         return f"""
         SELECT jsa.* FROM
         ({self.joined_spatial_aggregate.get_query()}) as jsa
-        NATURAL JOIN
+        INNER JOIN
         ({self.redacted_spatial_agg.get_query()}) as redact
+        USING ({','.join(self.spatial_unit.location_id_columns)})
         """
 
     @property

--- a/flowmachine/tests/test_redacted_joined_spatial_aggregate.py
+++ b/flowmachine/tests/test_redacted_joined_spatial_aggregate.py
@@ -22,6 +22,7 @@ def test_all_above_threshold(get_dataframe):
             )
         )
     ).pcod
+    assert len(in_agg) > 0
     under_15 = get_dataframe(
         daily_location("2016-01-01")
         .aggregate()


### PR DESCRIPTION
Closes #1747 

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Fixes `RedactedJoinedSpatialAggregate`, by explicitly using only the location ID columns to join to the `RedactedSpatialAggregate` query.