### PR TITLE
Use Bundler to manage AutoFlow Ruby dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -599,12 +599,14 @@ jobs:
           name: Install non-python autoflow dependencies
           command: |
             sudo apt-get update && sudo apt-get install -y postgresql pandoc ruby
-            sudo gem install asciidoctor
-            sudo gem install asciidoctor-pdf --pre
+            sudo gem install bundler
       - run:
           name: Install python dependencies
           command: |
             pipenv install --deploy --dev
+      - run:
+          name: Install Ruby gems
+          command: bundle install --deployment
       - save_cache:
           key: autoflow-deps-1-{{ checksum "Pipfile.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,7 +606,7 @@ jobs:
             pipenv install --deploy --dev
       - run:
           name: Install Ruby gems
-          command: bundle install --deployment
+          command: bundle install
       - save_cache:
           key: autoflow-deps-1-{{ checksum "Pipfile.lock" }}
           paths:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - FlowETL now defaults to disabling Airflow's REST API, and enables RBAC for the webui. [#1516](https://github.com/Flowminder/FlowKit/issues/1516)
 - FlowETL now requires that the `FLOWETL_AIRFLOW_ADMIN_USERNAME` and `FLOWETL_AIRFLOW_ADMIN_PASSWORD` environment variables be set, which specify the default web ui account. [#1516](https://github.com/Flowminder/FlowKit/issues/1516)
 - FlowAPI will no longer return a result for rows in spatial aggregate, joined spatial aggregate, flows, total events, meaningful locations aggregate, meaningful locations od, or unique subscriber count where the aggregate would contain less than 16 sims. [#1026](https://github.com/Flowminder/FlowKit/issues/1026)
+- AutoFlow now uses [Bundler](https://bundler.io/) to manage Ruby dependencies.
 
 ### Fixed
 - Quickstart should no longer fail on systems which do not include the `netstat` tool. [#1472](https://github.com/Flowminder/FlowKit/issues/1472)

--- a/autoflow/.dockerignore
+++ b/autoflow/.dockerignore
@@ -16,3 +16,5 @@
 !setup.py
 !versioneer.py
 !README.md
+!Gemfile
+!Gemfile.lock

--- a/autoflow/Dockerfile
+++ b/autoflow/Dockerfile
@@ -11,12 +11,14 @@ ENV AUTOFLOW_OUTPUTS_DIR=/mounts/outputs
 ENV PREFECT__USER_CONFIG_PATH=/${SOURCE_TREE}/autoflow/config/config.toml
 ENV PREFECT__ASCIIDOC_TEMPLATE_PATH=/${SOURCE_TREE}/autoflow/config/asciidoc_extended.tpl
 
+WORKDIR /${SOURCE_TREE}/autoflow
+
 RUN apt-get update -yqq \
     && apt-get upgrade -yqq \
     && apt-get upgrade -yqq git \
-    && apt-get install -yqq pandoc ruby  gcc \
-    && gem install asciidoctor \
-    && gem install asciidoctor-pdf --pre \
+    && apt-get install -yqq pandoc ruby gcc \
+    && gem install bundler \
+    && bundle install \
     && apt-get clean \
     && rm -rf \
     /var/lib/apt/lists/* \
@@ -26,7 +28,6 @@ RUN apt-get update -yqq \
     /usr/share/doc \
     /usr/share/doc-base
 
-WORKDIR /${SOURCE_TREE}/autoflow
 RUN pip install -U pip && pip install .[postgres,examples]
 
 CMD ["python", "-m", "autoflow"]

--- a/autoflow/Gemfile
+++ b/autoflow/Gemfile
@@ -2,7 +2,5 @@
 
 source "https://rubygems.org"
 
-ruby ">= 2.5"
-
 gem "asciidoctor"
 gem "asciidoctor-pdf", "~> 1.5.0.rc.1"

--- a/autoflow/Gemfile
+++ b/autoflow/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+ruby ">= 2.5"
+
+gem "asciidoctor"
+gem "asciidoctor-pdf", "~> 1.5.0.rc.1"

--- a/autoflow/Gemfile.lock
+++ b/autoflow/Gemfile.lock
@@ -1,0 +1,65 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    Ascii85 (1.0.3)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    afm (0.2.2)
+    asciidoctor (2.0.10)
+    asciidoctor-pdf (1.5.0.rc.1)
+      asciidoctor (>= 1.5.3, < 3.0.0)
+      concurrent-ruby (~> 1.1.0)
+      prawn (~> 2.2.0)
+      prawn-icon (~> 2.5.0)
+      prawn-svg (~> 0.30.0)
+      prawn-table (~> 0.2.0)
+      prawn-templates (~> 0.1.0)
+      safe_yaml (~> 1.0.0)
+      thread_safe (~> 0.3.0)
+      treetop (~> 1.5.0)
+      ttfunk (~> 1.5.0, >= 1.5.1)
+    concurrent-ruby (1.1.5)
+    css_parser (1.7.1)
+      addressable
+    hashery (2.1.2)
+    pdf-core (0.7.0)
+    pdf-reader (2.4.0)
+      Ascii85 (~> 1.0.0)
+      afm (~> 0.2.1)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
+    polyglot (0.3.5)
+    prawn (2.2.2)
+      pdf-core (~> 0.7.0)
+      ttfunk (~> 1.5)
+    prawn-icon (2.5.0)
+      prawn (>= 1.1.0, < 3.0.0)
+    prawn-svg (0.30.0)
+      css_parser (~> 1.6)
+      prawn (>= 0.11.1, < 3)
+    prawn-table (0.2.2)
+      prawn (>= 1.3.0, < 3.0.0)
+    prawn-templates (0.1.2)
+      pdf-reader (~> 2.0)
+      prawn (~> 2.2)
+    public_suffix (4.0.3)
+    ruby-rc4 (0.1.5)
+    safe_yaml (1.0.5)
+    thread_safe (0.3.6)
+    treetop (1.5.3)
+      polyglot (~> 0.3)
+    ttfunk (1.5.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  asciidoctor
+  asciidoctor-pdf (~> 1.5.0.rc.1)
+
+RUBY VERSION
+   ruby 2.7.0p0
+
+BUNDLED WITH
+   2.1.2

--- a/docs/source/developer/dev_environment_setup.md
+++ b/docs/source/developer/dev_environment_setup.md
@@ -146,7 +146,7 @@ successfully and are wired up correctly so that they can talk to each other.
 
 You can run the integration tests as follows. If these pass, this is a good indication that everything is set up correctly.
 ```bash
-$ cd integretion_tests
+$ cd integration_tests
 $ pipenv install  # only needed once to install dependencies
 $ pipenv run pytest
 ```

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -109,7 +109,7 @@ During development, you will typically also want to run FlowMachine, FlowAPI, Fl
 - [Pipenv](https://pipenv.readthedocs.io/en/latest/) (to manage separate pipenv environment for each FlowKit component)
 - FlowMachine server: `Python >= 3.7`
 - FlowAuth: `npm` (we recommend installing it via [nvm](https://github.com/nvm-sh/nvm)); [Cypress](https://www.cypress.io/) for testing
-- AutoFlow: [pandoc](https://pandoc.org/installing.html), [ruby](https://www.ruby-lang.org/en/downloads/), and the [asciidoctor](https://asciidoctor.org/) and [asciidoctor-pdf](https://asciidoctor.org/docs/asciidoctor-pdf/#install-the-published-gem) ruby gems.
+- AutoFlow: [pandoc](https://pandoc.org/installing.html), `Ruby` (we recommend installing Ruby via [RVM](https://rvm.io/)), and [Bundler](https://bundler.io/) (to manage Ruby package dependencies).
 
 ### Setting up FlowKit for development
 
@@ -130,6 +130,15 @@ To run the tests in the `flowapi`, `flowclient`, `flowdb`, `flowmachine`, `autof
 
 ```bash
 cd <directory>
+pipenv install --dev
+pipenv run pytest
+```
+
+AutoFlow additionally has dependencies on Ruby packages, which we manage using [Bundler](https://bundler.io/) which works similarly to pipenv. To run the tests in the `autoflow` directory:
+
+```bash
+cd autoflow
+bundle install
 pipenv install --dev
 pipenv run pytest
 ```

--- a/integration_tests/Gemfile
+++ b/integration_tests/Gemfile
@@ -1,0 +1,1 @@
+../autoflow/Gemfile

--- a/integration_tests/Gemfile.lock
+++ b/integration_tests/Gemfile.lock
@@ -1,0 +1,1 @@
+../autoflow/Gemfile.lock

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -25,7 +25,6 @@ if [ "$CI" != "true" ]; then
     docker exec flowdb bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done'
 fi
 echo "Installing."
-# Copy Gemfile from autoflow dir to ensure we run tests with the same gem versions as in the AutoFlow Docker container.
 bundle install
 pipenv install --deploy
 echo "Running tests."

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -28,7 +28,7 @@ fi
 echo "Installing."
 # Copy Gemfile from autoflow dir to ensure we run tests with the same gem versions as in the AutoFlow Docker container.
 cp ../autoflow/{Gemfile,Gemfile.lock} ./
-bundle install --deployment
+bundle install
 pipenv install --deploy
 echo "Running tests."
 pipenv run pytest $@

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -13,6 +13,7 @@ TrapQuit() {
 	    echo "Bringing down containers."
 	    (pushd .. &&  make down && popd)
 	fi
+    rm Gemfile Gemfile.lock
 }
 
 trap TrapQuit EXIT
@@ -25,6 +26,9 @@ if [ "$CI" != "true" ]; then
     docker exec flowdb bash -c 'i=0; until [ $i -ge 24 ] || (pg_isready -h 127.0.0.1 -p 5432); do let i=i+1; echo Waiting 10s; sleep 10; done'
 fi
 echo "Installing."
+# Copy Gemfile from autoflow dir to ensure we run tests with the same gem versions as in the AutoFlow Docker container.
+cp ../autoflow/{Gemfile,Gemfile.lock} ./
+bundle install --deployment
 pipenv install --deploy
 echo "Running tests."
 pipenv run pytest $@

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -13,7 +13,6 @@ TrapQuit() {
 	    echo "Bringing down containers."
 	    (pushd .. &&  make down && popd)
 	fi
-    rm Gemfile Gemfile.lock
 }
 
 trap TrapQuit EXIT
@@ -27,7 +26,6 @@ if [ "$CI" != "true" ]; then
 fi
 echo "Installing."
 # Copy Gemfile from autoflow dir to ensure we run tests with the same gem versions as in the AutoFlow Docker container.
-cp ../autoflow/{Gemfile,Gemfile.lock} ./
 bundle install
 pipenv install --deploy
 echo "Running tests."


### PR DESCRIPTION
Related to #1582

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

AutoFlow depends on the Ruby gems `asciidoctor` and `asciidoctor-pdf`, and their dependencies. We recently had some CI test failures (e.g. https://app.circleci.com/jobs/github/Flowminder/FlowKit/154613) due to an update to one of `asciidoctor-pdf`'s dependencies (now fixed in a newer `asciidoctor-pdf` release), which shows the need for a lock-file to manage dependency versions.

This PR introduces using [Bundler](https://bundler.io/) for this purpose. It works similarly to Pipenv, with a `Gemfile` and `Gemfile.lock` to specify and lock Ruby gem versions.

Note: to ensure that the Ruby dependencies used when running the integration tests are the same as those used in the Docker container, the `integration_tests/run_tests.sh` script copies the `Gemfile` and `Gemfile.lock` from `autoflow/` to `integration_tests/` and runs `bundle install` before running the tests.