### PR TITLE
Fix IPVS cutting idle connections to flowdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - FlowAuth backend now sends a meaningful 400 response when trying to create a user with an empty password. [#1637](https://github.com/Flowminder/FlowKit/issues/1637)
 - Usernames of deleted users can now be re-used as usernames for new users. [#1638](https://github.com/Flowminder/FlowKit/issues/1638)
 - RedactedJoinedSpatialAggregate now only redacts rows with too few subscribers. [#1747](https://github.com/Flowminder/FlowKit/issues/1747)
+- FlowDB now uses a more conservative default setting for `tcp_keepalives_idle` of 10 minutes, to avoid connections being killed after 15 minutes when running in a docker swarm. [#1771](https://github.com/Flowminder/FlowKit/issues/1771) 
 
 ### Removed
 - Removed pg_cron.

--- a/flowdb/bin/build/pg_config_template.conf
+++ b/flowdb/bin/build/pg_config_template.conf
@@ -101,3 +101,5 @@ jit = {use_jit}
 default_statistics_target = {stats_target}
 
 
+# Lower the tcp_keepalives_idle to below 15 minutes https://github.com/Flowminder/FlowKit/issues/1771
+tcp_keepalives_idle = 600


### PR DESCRIPTION
Closes #1771

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Sets `tcp_keepalives_idle` to 10 minutes in FlowDB, which should ensure that connections send a keep alive before getting killed by IPVS when in swarm mode.  