### PR TITLE
Read access in etl schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - AutoFlow now uses [Bundler](https://bundler.io/) to manage Ruby dependencies.
 - The `end_date` parameter of `flowclient.modal_location_from_dates` now refers to the day _after_ the final date included in the range, so is now consistent with other queries that have start/end date parameters. [#819](https://github.com/Flowminder/FlowKit/issues/819)
 - Date intervals in AutoFlow date stencils are now interpreted as half-open intervals (i.e. including start date, excluding end date), for consistency with date ranges elsewhere in FlowKit.
+- `flowmachine` user now has read access to ETL metadata tables in FlowDB
 
 ### Fixed
 - Quickstart should no longer fail on systems which do not include the `netstat` tool. [#1472](https://github.com/Flowminder/FlowKit/issues/1472)

--- a/flowdb/bin/build/9000_last_create_roles.sh
+++ b/flowdb/bin/build/9000_last_create_roles.sh
@@ -125,7 +125,7 @@ do
         "
 done
 
-declare -a schema_list_restricted=("events" "dfs" "infrastructure" "routing" "interactions")
+declare -a schema_list_restricted=("events" "dfs" "infrastructure" "routing" "interactions" "etl")
 for schema in "${schema_list_restricted[@]}"
 do
     echo "Restricting permissions to $FLOWMACHINE_FLOWDB_USER on $schema."


### PR DESCRIPTION
flowmachine user now has read access to the etl schema both so that it can read etl metadata, and so that etl'd tables are properly readable.