### PR TITLE
Singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- FlowMachine can now use multiple FlowDB backends, redis instances or execution pools via the `flowmachine.connections` or `flowmachine.core.context.context` context managers. [#391](https://github.com/Flowminder/FlowKit/issues/391)
+- `flowmachine.core.connection.Connection` now has a `conn_id` attribute, which is unique per database host. [#391](https://github.com/Flowminder/FlowKit/issues/391)
 
 ### Changed
+- `flowmachine.connect` no longer returns a `Connection` object. The connection should be accessed via `flowmachine.core.context.get_db()`. [#391](https://github.com/Flowminder/FlowKit/issues/391)
+- `connection`, `redis`, and `threadpool` are no longer available as attributes of `Query`, and should be accessed via `flowmachine.core.context.get_db()`, `flowmachine.core.context.get_redis()` and `flowmachine.core.context.get_executor()`. [#391](https://github.com/Flowminder/FlowKit/issues/391)
 
 ### Fixed
 
 ### Removed
+- Removed `Query.connection`, `Query.redis`, and `Query.threadpool`. [#391](https://github.com/Flowminder/FlowKit/issues/391)
 
 ## [1.1.1]
 

--- a/flowmachine/flowmachine/__init__.py
+++ b/flowmachine/flowmachine/__init__.py
@@ -19,7 +19,7 @@ and inherit from FlowMachine's main `Query()` class.
 """
 
 from .versions import __version__
-from .core.init import connect
+from .core.init import connect, connections
 from .features.utilities import GroupValues, feature_collection
 from flowmachine.core.logging import init_logging
 import flowmachine.models
@@ -27,7 +27,7 @@ import flowmachine.features
 import flowmachine.utils
 import flowmachine.core
 
-methods = ["GroupValues", "feature_collection", "connect"]
+methods = ["GroupValues", "feature_collection", "connect", "connections"]
 sub_modules = ["core", "features", "utils", "models"]
 __all__ = methods + sub_modules
 

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -98,7 +98,7 @@ def write_query_to_cache(
 
     """
     logger.debug(f"Trying to switch '{query.query_id}' to executing state.")
-    q_state_machine = QueryStateMachine(redis, query.query_id)
+    q_state_machine = QueryStateMachine(redis, query.query_id, connection.conn_id)
     current_state, this_thread_is_owner = q_state_machine.execute()
     if this_thread_is_owner:
         logger.debug(f"In charge of executing '{query.query_id}'.")
@@ -303,7 +303,9 @@ def resync_redis_with_cache(connection: "Connection", redis: StrictRedis) -> Non
     logger.debug("Flushing redis.")
     for event in (QueryEvent.QUEUE, QueryEvent.EXECUTE, QueryEvent.FINISH):
         for qid in queries_in_cache:
-            new_state, changed = QueryStateMachine(redis, qid[0]).trigger_event(event)
+            new_state, changed = QueryStateMachine(
+                redis, qid[0], connection.conn_id
+            ).trigger_event(event)
             logger.debug(
                 "Redis resync",
                 fast_forwarded=qid[0],

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -802,7 +802,7 @@ async def watch_and_shrink_cache(
     while True:
         logger.debug("Checking if cache should be shrunk.")
 
-        try:
+        try:  # Set the shrink function running with a copy of the current execution context (db conn etc) in background thread
             await asyncio.wait_for(
                 asyncio.get_running_loop().run_in_executor(
                     pool, copy_context().run, shrink_func

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -9,6 +9,7 @@ Functions which deal with inspecting and managing the query cache.
 """
 import asyncio
 import pickle
+from contextvars import copy_context
 from concurrent.futures import Executor, TimeoutError
 from functools import partial
 
@@ -801,7 +802,9 @@ async def watch_and_shrink_cache(
 
         try:
             await asyncio.wait_for(
-                asyncio.get_running_loop().run_in_executor(pool, shrink_func),
+                asyncio.get_running_loop().run_in_executor(
+                    pool, copy_context().run, shrink_func
+                ),
                 timeout=timeout,
             )
         except TimeoutError:

--- a/flowmachine/flowmachine/core/connection.py
+++ b/flowmachine/flowmachine/core/connection.py
@@ -10,6 +10,7 @@ regarding the database.
 import os
 import datetime
 import warnings
+from _md5 import md5
 from collections import defaultdict
 
 from typing import Dict, List, Optional
@@ -93,6 +94,10 @@ class Connection:
             pool_timeout=None,
             connect_args=connect_args,
         )
+        conn_id = md5(str(self.engine.url.host).encode())
+        conn_id.update(str(self.engine.url.port).encode())
+        conn_id.update(str(self.engine.url.database).encode())
+        self.conn_id = conn_id.hexdigest()
 
         self.max_connections = pool_size + overflow
         if self.max_connections > os.cpu_count():

--- a/flowmachine/flowmachine/core/connection.py
+++ b/flowmachine/flowmachine/core/connection.py
@@ -94,6 +94,8 @@ class Connection:
             pool_timeout=None,
             connect_args=connect_args,
         )
+        # Unique-to-db id for this connection, to allow use of a common redis instance with
+        # multiple databases
         conn_id = md5(str(self.engine.url.host).encode())
         conn_id.update(str(self.engine.url.port).encode())
         conn_id.update(str(self.engine.url.database).encode())

--- a/flowmachine/flowmachine/core/context.py
+++ b/flowmachine/flowmachine/core/context.py
@@ -26,19 +26,21 @@ _jupyter_context = (
     dict()
 )  # Required as a workaround for https://github.com/ipython/ipython/issues/11565
 
+_is_notebook = False
 
-@lru_cache
+
 def _is_notebook():
+    global _is_notebook
     try:
         shell = get_ipython().__class__.__name__
         if shell == "ZMQInteractiveShell":
-            return True  # Jupyter notebook or qtconsole
+            _is_notebook = True  # Jupyter notebook or qtconsole
         elif shell == "TerminalInteractiveShell":
-            return False  # Terminal running IPython
+            _is_notebook = False  # Terminal running IPython
         else:
-            return False  # Other type (?)
+            _is_notebook = False  # Other type (?)
     except NameError:
-        return False  # Probably standard Python interpreter
+        _is_notebook = False  # Probably standard Python interpreter
 
 
 def get_db() -> Connection:

--- a/flowmachine/flowmachine/core/context.py
+++ b/flowmachine/flowmachine/core/context.py
@@ -1,6 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Context variables for Flowmachine to talk to FlowDB and Redis, and a common thread pool for
+managing queries.
+"""
+
 from contextvars import ContextVar, copy_context
 from concurrent.futures import Executor, Future
 from contextlib import contextmanager
+from typing import Callable
 
 from redis import StrictRedis
 
@@ -13,6 +23,18 @@ executor = ContextVar("executor")
 
 
 def get_db() -> Connection:
+    """
+    Get the current context's database connection.
+
+    Returns
+    -------
+    Connection
+
+    Raises
+    ------
+    NotConnectedError
+        If there is not a connection for this context
+    """
     try:
         return db.get()
     except LookupError:
@@ -20,6 +42,18 @@ def get_db() -> Connection:
 
 
 def get_redis() -> StrictRedis:
+    """
+    Get the current context's redis client.
+
+    Returns
+    -------
+    StrictRedis
+
+    Raises
+    ------
+    NotConnectedError
+        If there is not a redis client for this context
+    """
     try:
         return redis_connection.get()
     except LookupError:
@@ -27,13 +61,43 @@ def get_redis() -> StrictRedis:
 
 
 def get_executor() -> Executor:
+    """
+    Get the current context's executor pool.
+
+    Returns
+    -------
+    Executor
+
+    Raises
+    ------
+    NotConnectedError
+        If there is not a pool for this context
+    """
     try:
         return executor.get()
     except LookupError:
         raise NotConnectedError
 
 
-def submit_to_executor(func, *args, **kwargs) -> Future:
+def submit_to_executor(func: Callable, *args, **kwargs) -> Future:
+    """
+    Submit a callable to the current context's executor pool and
+    get back a future to monitor execution.
+
+    Parameters
+    ----------
+    func : Callable
+        Callable to be executed
+    args
+        Positional arguments to func
+    kwargs
+        Keyword arguments to func
+
+    Returns
+    -------
+    Future
+
+    """
     current_context = copy_context()
     return get_executor().submit(current_context.run, func, *args, **kwargs)
 
@@ -41,6 +105,20 @@ def submit_to_executor(func, *args, **kwargs) -> Future:
 def bind_context(
     connection: Connection, executor_pool: Executor, redis_conn: StrictRedis
 ):
+    """
+    Set the current context's connection, executor and redis connection, replacing
+    any that were previously set.
+
+    Parameters
+    ----------
+    connection : Connection
+        Connection to set
+    executor_pool : Executor
+        Executor to be the new pool
+    redis_conn : StrictRedis
+        Redis client
+
+    """
     db.set(connection)
     executor.set(executor_pool)
     redis_connection.set(redis_conn)
@@ -48,6 +126,19 @@ def bind_context(
 
 @contextmanager
 def context(connection: Connection, executor_pool: Executor, redis_conn: StrictRedis):
+    """
+    Context manager which can be used to temporarily provide a connection, redis client
+    and pool.
+
+    Parameters
+    ----------
+    connection : Connection
+        Connection which will be used within this context
+    executor_pool : Executor
+        Executor pool which will be used within this context
+    redis_conn : StrictRedis
+        Redis client which will be used within this context
+    """
     db_token = db.set(connection)
     redis_token = redis_connection.set(redis_conn)
     executor_token = executor.set(executor_pool)

--- a/flowmachine/flowmachine/core/context.py
+++ b/flowmachine/flowmachine/core/context.py
@@ -17,16 +17,25 @@ from redis import StrictRedis
 from flowmachine.core import Connection
 from flowmachine.core.errors import NotConnectedError
 
-db = ContextVar("db")
-redis_connection = ContextVar("redis")
-executor = ContextVar("executor")
+try:
+    db
+except NameError:
+    db = ContextVar("db")
+
+try:
+    redis_connection
+except NameError:
+    redis_connection = ContextVar("redis")
+try:
+    executor
+except NameError:
+    executor = ContextVar("executor")
 
 _jupyter_context = (
     dict()
 )  # Required as a workaround for https://github.com/ipython/ipython/issues/11565
 
 _is_notebook = False
-
 try:
     shell = get_ipython().__class__.__name__
     if shell == "ZMQInteractiveShell":

--- a/flowmachine/flowmachine/core/context.py
+++ b/flowmachine/flowmachine/core/context.py
@@ -10,7 +10,6 @@ managing queries.
 from contextvars import ContextVar, copy_context
 from concurrent.futures import Executor, Future
 from contextlib import contextmanager
-from functools import lru_cache
 from typing import Callable
 
 from redis import StrictRedis

--- a/flowmachine/flowmachine/core/context.py
+++ b/flowmachine/flowmachine/core/context.py
@@ -1,0 +1,59 @@
+from contextvars import ContextVar, copy_context
+from concurrent.futures import Executor, Future
+from contextlib import contextmanager
+
+from redis import StrictRedis
+
+from flowmachine.core import Connection
+from flowmachine.core.errors import NotConnectedError
+
+db = ContextVar("db")
+redis_connection = ContextVar("redis")
+executor = ContextVar("executor")
+
+
+def get_db() -> Connection:
+    try:
+        return db.get()
+    except LookupError:
+        raise NotConnectedError
+
+
+def get_redis() -> StrictRedis:
+    try:
+        return redis_connection.get()
+    except LookupError:
+        raise NotConnectedError
+
+
+def get_executor() -> Executor:
+    try:
+        return executor.get()
+    except LookupError:
+        raise NotConnectedError
+
+
+def submit_to_executor(func, *args, **kwargs) -> Future:
+    current_context = copy_context()
+    return get_executor().submit(current_context.run, func, *args, **kwargs)
+
+
+def bind_context(
+    connection: Connection, executor_pool: Executor, redis_conn: StrictRedis
+):
+    db.set(connection)
+    executor.set(executor_pool)
+    redis_connection.set(redis_conn)
+
+
+@contextmanager
+def context(connection: Connection, executor_pool: Executor, redis_conn: StrictRedis):
+    db_token = db.set(connection)
+    redis_token = redis_connection.set(redis_conn)
+    executor_token = executor.set(executor_pool)
+    try:
+        yield
+    finally:
+        db.reset(db_token)
+        redis_connection.reset(redis_token)
+        executor.reset(executor_token)

--- a/flowmachine/flowmachine/core/context.py
+++ b/flowmachine/flowmachine/core/context.py
@@ -63,7 +63,7 @@ def get_db() -> Connection:
     """
     try:
         if _is_notebook:
-            return _jupyter_context["db"]
+            return db.get(_jupyter_context["db"])
         else:
             return db.get()
     except (LookupError, KeyError):
@@ -85,7 +85,7 @@ def get_redis() -> StrictRedis:
     """
     try:
         if _is_notebook:
-            return _jupyter_context["redis_connection"]
+            return redis_connection.get(_jupyter_context["redis_connection"])
         else:
             return redis_connection.get()
     except (LookupError, KeyError):
@@ -107,7 +107,7 @@ def get_executor() -> Executor:
     """
     try:
         if _is_notebook:
-            return _jupyter_context["executor"]
+            return executor.get(_jupyter_context["executor"])
         else:
             return executor.get()
     except (LookupError, KeyError):

--- a/flowmachine/flowmachine/core/context.py
+++ b/flowmachine/flowmachine/core/context.py
@@ -28,19 +28,16 @@ _jupyter_context = (
 
 _is_notebook = False
 
-
-def _is_notebook():
-    global _is_notebook
-    try:
-        shell = get_ipython().__class__.__name__
-        if shell == "ZMQInteractiveShell":
-            _is_notebook = True  # Jupyter notebook or qtconsole
-        elif shell == "TerminalInteractiveShell":
-            _is_notebook = False  # Terminal running IPython
-        else:
-            _is_notebook = False  # Other type (?)
-    except NameError:
-        _is_notebook = False  # Probably standard Python interpreter
+try:
+    shell = get_ipython().__class__.__name__
+    if shell == "ZMQInteractiveShell":
+        _is_notebook = True  # Jupyter notebook or qtconsole
+    elif shell == "TerminalInteractiveShell":
+        _is_notebook = False  # Terminal running IPython
+    else:
+        _is_notebook = False  # Other type (?)
+except NameError:
+    _is_notebook = False  # Probably standard Python interpreter
 
 
 def get_db() -> Connection:
@@ -57,7 +54,7 @@ def get_db() -> Connection:
         If there is not a connection for this context
     """
     try:
-        if _is_notebook():
+        if _is_notebook:
             return _jupyter_context["db"]
         else:
             return db.get()
@@ -79,7 +76,7 @@ def get_redis() -> StrictRedis:
         If there is not a redis client for this context
     """
     try:
-        if _is_notebook():
+        if _is_notebook:
             return _jupyter_context["redis_connection"]
         else:
             return redis_connection.get()
@@ -101,7 +98,7 @@ def get_executor() -> Executor:
         If there is not a pool for this context
     """
     try:
-        if _is_notebook():
+        if _is_notebook:
             return _jupyter_context["executor"]
         else:
             return executor.get()
@@ -149,7 +146,7 @@ def bind_context(
         Redis client
 
     """
-    if _is_notebook():
+    if _is_notebook:
         global _jupyter_context
         _jupyter_context["db"] = connection
         _jupyter_context["executor"] = executor_pool

--- a/flowmachine/flowmachine/core/dependency_graph.py
+++ b/flowmachine/flowmachine/core/dependency_graph.py
@@ -10,7 +10,7 @@ from io import BytesIO
 from typing import Union, Tuple, Dict, Sequence, Callable, Any, Optional
 from concurrent.futures import wait
 
-from flowmachine.core.context import get_redis
+from flowmachine.core.context import get_redis, get_db
 from flowmachine.core.errors import UnstorableQueryError
 from flowmachine.core.query_state import QueryStateMachine
 

--- a/flowmachine/flowmachine/core/dependency_graph.py
+++ b/flowmachine/flowmachine/core/dependency_graph.py
@@ -9,6 +9,8 @@ import structlog
 from io import BytesIO
 from typing import Union, Tuple, Dict, Sequence, Callable, Any, Optional
 from concurrent.futures import wait
+
+from flowmachine.core.context import get_redis
 from flowmachine.core.errors import UnstorableQueryError
 from flowmachine.core.query_state import QueryStateMachine
 
@@ -224,7 +226,7 @@ def unstored_dependencies_graph(query_obj: "Query") -> nx.DiGraph:
                 # We don't want to include this query in the graph, only its dependencies.
                 y = None
             # Wait for query to complete before checking whether it's stored.
-            q_state_machine = QueryStateMachine(x.redis, x.query_id)
+            q_state_machine = QueryStateMachine(get_redis(), x.query_id)
             q_state_machine.wait_until_complete()
             if not x.is_stored:
                 deps.append((y, x))

--- a/flowmachine/flowmachine/core/dependency_graph.py
+++ b/flowmachine/flowmachine/core/dependency_graph.py
@@ -226,7 +226,9 @@ def unstored_dependencies_graph(query_obj: "Query") -> nx.DiGraph:
                 # We don't want to include this query in the graph, only its dependencies.
                 y = None
             # Wait for query to complete before checking whether it's stored.
-            q_state_machine = QueryStateMachine(get_redis(), x.query_id)
+            q_state_machine = QueryStateMachine(
+                get_redis(), x.query_id, get_db().conn_id
+            )
             q_state_machine.wait_until_complete()
             if not x.is_stored:
                 deps.append((y, x))

--- a/flowmachine/flowmachine/core/dummy_query.py
+++ b/flowmachine/flowmachine/core/dummy_query.py
@@ -6,6 +6,8 @@ A dummy query class, primarily useful for testing.
 """
 
 import structlog
+
+from .context import get_redis
 from .query import Query
 from .query_state import QueryStateMachine
 
@@ -38,14 +40,14 @@ class DummyQuery(Query):
         """
         Determine dummy 'stored' status from redis, instead of checking the database.
         """
-        q_state_machine = QueryStateMachine(self.redis, self.query_id)
+        q_state_machine = QueryStateMachine(get_redis(), self.query_id)
         return q_state_machine.is_completed
 
     def store(self, store_dependencies=False):
         logger.debug(
             "Storing dummy query by marking the query state as 'finished' (but without actually writing to the database)."
         )
-        q_state_machine = QueryStateMachine(self.redis, self.query_id)
+        q_state_machine = QueryStateMachine(get_redis(), self.query_id)
         q_state_machine.enqueue()
         q_state_machine.execute()
         q_state_machine.finish()

--- a/flowmachine/flowmachine/core/dummy_query.py
+++ b/flowmachine/flowmachine/core/dummy_query.py
@@ -7,7 +7,7 @@ A dummy query class, primarily useful for testing.
 
 import structlog
 
-from .context import get_redis
+from .context import get_redis, get_db
 from .query import Query
 from .query_state import QueryStateMachine
 
@@ -40,14 +40,18 @@ class DummyQuery(Query):
         """
         Determine dummy 'stored' status from redis, instead of checking the database.
         """
-        q_state_machine = QueryStateMachine(get_redis(), self.query_id)
+        q_state_machine = QueryStateMachine(
+            get_redis(), self.query_id, get_db().conn_id
+        )
         return q_state_machine.is_completed
 
     def store(self, store_dependencies=False):
         logger.debug(
             "Storing dummy query by marking the query state as 'finished' (but without actually writing to the database)."
         )
-        q_state_machine = QueryStateMachine(get_redis(), self.query_id)
+        q_state_machine = QueryStateMachine(
+            get_redis(), self.query_id, get_db().conn_id
+        )
         q_state_machine.enqueue()
         q_state_machine.execute()
         q_state_machine.finish()

--- a/flowmachine/flowmachine/core/init.py
+++ b/flowmachine/flowmachine/core/init.py
@@ -10,6 +10,7 @@ perspective, only the `connect` method is relevant.
 From a developer perspective, this is where one-time operations
 should live - for example configuring loggers.
 """
+import warnings
 from contextlib import contextmanager
 
 import redis
@@ -21,7 +22,8 @@ from redis import StrictRedis
 
 import flowmachine
 from flowmachine.core import Connection
-from flowmachine.core.context import bind_context, context
+from flowmachine.core.context import bind_context, context, get_db
+from flowmachine.core.errors import NotConnectedError
 from flowmachine.core.logging import set_log_level
 from get_secret_or_env_var import environ, getenv
 
@@ -43,6 +45,52 @@ def connections(
     redis_password: Optional[str] = None,
     conn: Optional[Connection] = None,
 ) -> None:
+    """
+    Context manager which connects flowmachine to a database, and performs initial set-up routines.
+    You may provide a Settings object here, which can specify the database
+    you wish to connect to, logging behaviour, available tables and so on.
+
+    After connecting, you should use `flowmachine.core.context.get_db()` to access
+    the database connection, `flowmachine.core.context.get_redis()` to get the redis
+    connection, and `flowmachine.core.context.get_executor()` to get the threadpool.
+
+    Parameters
+    ----------
+    log_level : str, default "error"
+        Level to log at
+    flowdb_port : int, default 9000
+        Port number to connect to flowdb
+    flowdb_user : str, default "flowmachine"
+        Name of user to connect to flowdb as
+    flowdb_password : str
+        Password to connect to flowdb
+    flowdb_host : str, default "localhost"
+        Hostname of flowdb server
+    flowdb_connection_pool_size : int, default 5
+        Default number of database connections to use
+    flowdb_connection_pool_overflow : int, default 1
+        Number of extra database connections to allow
+    redis_host : str, default "localhost"
+        Hostname for redis server.
+    redis_port : int, default 6379
+        Port the redis server is available on
+    redis_password : str
+        Password for the redis instance
+    conn : flowmachine.core.Connection
+        Optionally provide an existing Connection object to use, overriding any the db options specified here.
+
+    Notes
+    -----
+    All parameters can also be provided as environment variables.
+    If a parameter is provided, and an environment variable is set,
+    then the provided value is used. If neither is provided, the defaults as given
+    in the docstring are used.
+
+    Parameters can _also_ be set using Docker secrets, in which case a file with the name
+    of the parameter in upper case should be present at /run/secrets/THE_PARAM.
+    If a secret is available, the secret takes precedence over both the environment variable, and
+    the default.
+    """
     with context(
         *_do_connect(
             log_level=log_level,
@@ -80,6 +128,10 @@ def connect(
     You may provide a Settings object here, which can specify the database
     you wish to connect to, logging behaviour, available tables and so on.
 
+    After connecting, you should use `flowmachine.core.context.get_db()` to access
+    the database connection, `flowmachine.core.context.get_redis()` to get the redis
+    connection, and `flowmachine.core.context.get_executor()` to get the threadpool.
+
     Parameters
     ----------
     log_level : str, default "error"
@@ -105,10 +157,6 @@ def connect(
     conn : flowmachine.core.Connection
         Optionally provide an existing Connection object to use, overriding any the db options specified here.
 
-    Returns
-    -------
-    Connection
-
     Notes
     -----
     All parameters can also be provided as environment variables.
@@ -121,6 +169,11 @@ def connect(
     If a secret is available, the secret takes precedence over both the environment variable, and
     the default.
     """
+    try:
+        get_db()
+        warnings.warn("FlowMachine already started. Overwriting existing context.")
+    except NotConnectedError:
+        pass
     bind_context(
         *_do_connect(
             log_level=log_level,
@@ -245,6 +298,7 @@ def _do_connect(
         )
 
     set_log_level("flowmachine.debug", log_level)
+
     if conn is None:
         conn = Connection(
             host=flowdb_host,

--- a/flowmachine/flowmachine/core/init.py
+++ b/flowmachine/flowmachine/core/init.py
@@ -10,35 +10,148 @@ perspective, only the `connect` method is relevant.
 From a developer perspective, this is where one-time operations
 should live - for example configuring loggers.
 """
+from contextlib import contextmanager
 
 import redis
 import structlog
-import warnings
 from concurrent.futures import ThreadPoolExecutor
-from typing import Union
+from typing import Tuple, Optional
+
+from redis import StrictRedis
 
 import flowmachine
-from flowmachine.core import Connection, Query
+from flowmachine.core import Connection
+from flowmachine.core.context import bind_context, context
 from flowmachine.core.logging import set_log_level
 from get_secret_or_env_var import environ, getenv
 
 logger = structlog.get_logger("flowmachine.debug", submodule=__name__)
 
 
+@contextmanager
+def connections(
+    *,
+    log_level: Optional[str] = None,
+    flowdb_port: Optional[int] = None,
+    flowdb_user: Optional[str] = None,
+    flowdb_password: Optional[str] = None,
+    flowdb_host: Optional[str] = None,
+    flowdb_connection_pool_size: Optional[int] = None,
+    flowdb_connection_pool_overflow: Optional[int] = None,
+    redis_host: Optional[str] = None,
+    redis_port: Optional[int] = None,
+    redis_password: Optional[str] = None,
+    conn: Optional[Connection] = None,
+) -> None:
+    with context(
+        *_do_connect(
+            log_level=log_level,
+            flowdb_port=flowdb_port,
+            flowdb_user=flowdb_user,
+            flowdb_password=flowdb_password,
+            flowdb_host=flowdb_host,
+            flowdb_connection_pool_size=flowdb_connection_pool_size,
+            flowdb_connection_pool_overflow=flowdb_connection_pool_overflow,
+            redis_host=redis_host,
+            redis_port=redis_port,
+            redis_password=redis_password,
+            conn=conn,
+        )
+    ):
+        yield
+
+
 def connect(
     *,
-    log_level: Union[str, None] = None,
-    flowdb_port: Union[int, None] = None,
-    flowdb_user: Union[str, None] = None,
-    flowdb_password: Union[str, None] = None,
-    flowdb_host: Union[str, None] = None,
-    flowdb_connection_pool_size: Union[int, None] = None,
-    flowdb_connection_pool_overflow: Union[int, None] = None,
-    redis_host: Union[str, None] = None,
-    redis_port: Union[int, None] = None,
-    redis_password: Union[str, None] = None,
-    conn: Union[Connection, None] = None,
-) -> Connection:
+    log_level: Optional[str] = None,
+    flowdb_port: Optional[int] = None,
+    flowdb_user: Optional[str] = None,
+    flowdb_password: Optional[str] = None,
+    flowdb_host: Optional[str] = None,
+    flowdb_connection_pool_size: Optional[int] = None,
+    flowdb_connection_pool_overflow: Optional[int] = None,
+    redis_host: Optional[str] = None,
+    redis_port: Optional[int] = None,
+    redis_password: Optional[str] = None,
+    conn: Optional[Connection] = None,
+) -> None:
+    """
+    Connects flowmachine to a database, and performs initial set-up routines.
+    You may provide a Settings object here, which can specify the database
+    you wish to connect to, logging behaviour, available tables and so on.
+
+    Parameters
+    ----------
+    log_level : str, default "error"
+        Level to log at
+    flowdb_port : int, default 9000
+        Port number to connect to flowdb
+    flowdb_user : str, default "flowmachine"
+        Name of user to connect to flowdb as
+    flowdb_password : str
+        Password to connect to flowdb
+    flowdb_host : str, default "localhost"
+        Hostname of flowdb server
+    flowdb_connection_pool_size : int, default 5
+        Default number of database connections to use
+    flowdb_connection_pool_overflow : int, default 1
+        Number of extra database connections to allow
+    redis_host : str, default "localhost"
+        Hostname for redis server.
+    redis_port : int, default 6379
+        Port the redis server is available on
+    redis_password : str
+        Password for the redis instance
+    conn : flowmachine.core.Connection
+        Optionally provide an existing Connection object to use, overriding any the db options specified here.
+
+    Returns
+    -------
+    Connection
+
+    Notes
+    -----
+    All parameters can also be provided as environment variables.
+    If a parameter is provided, and an environment variable is set,
+    then the provided value is used. If neither is provided, the defaults as given
+    in the docstring are used.
+
+    Parameters can _also_ be set using Docker secrets, in which case a file with the name
+    of the parameter in upper case should be present at /run/secrets/THE_PARAM.
+    If a secret is available, the secret takes precedence over both the environment variable, and
+    the default.
+    """
+    bind_context(
+        *_do_connect(
+            log_level=log_level,
+            flowdb_port=flowdb_port,
+            flowdb_user=flowdb_user,
+            flowdb_password=flowdb_password,
+            flowdb_host=flowdb_host,
+            flowdb_connection_pool_size=flowdb_connection_pool_size,
+            flowdb_connection_pool_overflow=flowdb_connection_pool_overflow,
+            redis_host=redis_host,
+            redis_port=redis_port,
+            redis_password=redis_password,
+            conn=conn,
+        )
+    )
+
+
+def _do_connect(
+    *,
+    log_level: Optional[str] = None,
+    flowdb_port: Optional[int] = None,
+    flowdb_user: Optional[str] = None,
+    flowdb_password: Optional[str] = None,
+    flowdb_host: Optional[str] = None,
+    flowdb_connection_pool_size: Optional[int] = None,
+    flowdb_connection_pool_overflow: Optional[int] = None,
+    redis_host: Optional[str] = None,
+    redis_port: Optional[int] = None,
+    redis_password: Optional[str] = None,
+    conn: Optional[Connection] = None,
+) -> Tuple[Connection, ThreadPoolExecutor, StrictRedis]:
     """
     Connects flowmachine to a database, and performs initial set-up routines.
     You may provide a Settings object here, which can specify the database
@@ -131,50 +244,27 @@ def connect(
             f"You must provide a secret named {e.args[0]}, set an environment variable named {e.args[0]}, or provide the value as a parameter."
         )
 
-    try:
-        Query.connection
-        warnings.warn("FlowMachine already started. Ignoring.")
-    except AttributeError:
-        set_log_level("flowmachine.debug", log_level)
-        if conn is None:
-            conn = Connection(
-                host=flowdb_host,
-                port=flowdb_port,
-                user=flowdb_user,
-                password=flowdb_password,
-                database="flowdb",
-                pool_size=flowdb_connection_pool_size,
-                overflow=flowdb_connection_pool_overflow,
-            )
-        Query.connection = conn
-
-        Query.redis = redis.StrictRedis(
-            host=redis_host, port=redis_port, password=redis_password
+    set_log_level("flowmachine.debug", log_level)
+    if conn is None:
+        conn = Connection(
+            host=flowdb_host,
+            port=flowdb_port,
+            user=flowdb_user,
+            password=flowdb_password,
+            database="flowdb",
+            pool_size=flowdb_connection_pool_size,
+            overflow=flowdb_connection_pool_overflow,
         )
-        _start_threadpool(thread_pool_size=flowdb_connection_pool_size)
-        conn.available_dates
 
-        print(f"FlowMachine version: {flowmachine.__version__}")
+    redis_connection = redis.StrictRedis(
+        host=redis_host, port=redis_port, password=redis_password
+    )
+    thread_pool = ThreadPoolExecutor(flowdb_connection_pool_size)
+    conn.available_dates
 
-        print(
-            f"Flowdb running on: {flowdb_host}:{flowdb_port}/flowdb (connecting user: {flowdb_user})"
-        )
-    return Query.connection
+    print(f"FlowMachine version: {flowmachine.__version__}")
 
-
-def _start_threadpool(*, thread_pool_size=None):
-    """
-    Start the threadpool flowmachine uses for executing queries
-    asynchronously.
-
-    Parameters
-    ----------
-    thread_pool_size : int
-        Size of thread pool to use.
-
-    See Also
-    --------
-    ThreadPoolExecutor
-
-    """
-    Query.thread_pool_executor = ThreadPoolExecutor(thread_pool_size)
+    print(
+        f"Flowdb running on: {flowdb_host}:{flowdb_port}/flowdb (connecting user: {flowdb_user})"
+    )
+    return conn, thread_pool, redis_connection

--- a/flowmachine/flowmachine/core/mixins/geodata_mixin.py
+++ b/flowmachine/flowmachine/core/mixins/geodata_mixin.py
@@ -16,6 +16,8 @@ from flowmachine.utils import proj4string
 
 import structlog
 
+from ..context import get_db
+
 logger = structlog.get_logger("flowmachine.debug", submodule=__name__)
 
 
@@ -143,7 +145,7 @@ class GeoDataMixin:
         """
         features = [
             {"type": x[0], "id": x[1], "geometry": x[2], "properties": x[3]}
-            for x in self.connection.fetch(self.geojson_query(crs=proj4))
+            for x in get_db().fetch(self.geojson_query(crs=proj4))
         ]
         js = {
             "properties": {"crs": proj4},
@@ -164,7 +166,7 @@ class GeoDataMixin:
         dict
             This query as a GeoJson FeatureCollection in dict form.
         """
-        proj4_string = proj4string(self.connection, crs)
+        proj4_string = proj4string(get_db(), crs)
         try:
             js = self._geojson.get(proj4_string, self._get_geojson(proj4_string))
         except AttributeError:

--- a/flowmachine/flowmachine/core/model_result.py
+++ b/flowmachine/flowmachine/core/model_result.py
@@ -181,11 +181,11 @@ class ModelResult(Query):
             if store_dependencies:
                 store_all_unstored_dependencies(self)
             self._df.to_sql(name, connection, schema=schema, index=False)
-            QueryStateMachine(get_redis(), self.query_id).finish()
+            QueryStateMachine(get_redis(), self.query_id, get_db().conn_id).finish()
             return self._runtime
 
         current_state, changed_to_queue = QueryStateMachine(
-            get_redis(), self.query_id
+            get_redis(), self.query_id, get_db().conn_id
         ).enqueue()
         logger.debug(
             f"Attempted to enqueue query '{self.query_id}', query state is now {current_state} and change happened {'here and now' if changed_to_queue else 'elsewhere'}."

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -27,9 +27,7 @@ from sqlalchemy.exc import ResourceClosedError
 
 from flowmachine.core.cache import touch_cache
 from flowmachine.core.context import (
-    db,
     get_db,
-    get_executor,
     get_redis,
     submit_to_executor,
 )

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -76,11 +76,6 @@ class Query(metaclass=ABCMeta):
     def __init__(self, cache=True):
         obj = Query._QueryPool.get(self.query_id)
         if obj is None:
-            try:
-                get_db()
-            except AttributeError:
-                raise NotConnectedError()
-
             self._cache = cache
             Query._QueryPool[self.query_id] = self
         else:

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -26,6 +26,13 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import ResourceClosedError
 
 from flowmachine.core.cache import touch_cache
+from flowmachine.core.context import (
+    db,
+    get_db,
+    get_executor,
+    get_redis,
+    submit_to_executor,
+)
 from flowmachine.core.errors.flowmachine_errors import QueryResetFailedException
 from flowmachine.core.query_state import QueryStateMachine
 from abc import ABCMeta, abstractmethod
@@ -70,7 +77,7 @@ class Query(metaclass=ABCMeta):
         obj = Query._QueryPool.get(self.query_id)
         if obj is None:
             try:
-                self.connection
+                get_db()
             except AttributeError:
                 raise NotConnectedError()
 
@@ -163,7 +170,7 @@ class Query(metaclass=ABCMeta):
         return f"<{', '.join(all_descriptions)}>"
 
     def __iter__(self):
-        con = self.connection.engine
+        con = get_db().engine
         qur = self.get_query()
         with con.begin():
             self._query_object = con.execute(qur)
@@ -187,7 +194,7 @@ class Query(metaclass=ABCMeta):
                   """.format(
                 everything=self.get_query()
             )
-            self._len = self.connection.fetch(sql)[0][0]
+            self._len = get_db().fetch(sql)[0][0]
             return self._len
 
     def turn_on_caching(self):
@@ -234,7 +241,7 @@ class Query(metaclass=ABCMeta):
         flowmachine.core.query_state.QueryState
             The current query state
         """
-        state_machine = QueryStateMachine(self.redis, self.query_id)
+        state_machine = QueryStateMachine(get_redis(), self.query_id)
         return state_machine.current_query_state
 
     @property
@@ -264,13 +271,13 @@ class Query(metaclass=ABCMeta):
         try:
             table_name = self.fully_qualified_table_name
             schema, name = table_name.split(".")
-            state_machine = QueryStateMachine(self.redis, self.query_id)
+            state_machine = QueryStateMachine(get_redis(), self.query_id)
             state_machine.wait_until_complete()
-            if state_machine.is_completed and self.connection.has_table(
+            if state_machine.is_completed and get_db().has_table(
                 schema=schema, name=name
             ):
                 try:
-                    touch_cache(self.connection, self.query_id)
+                    touch_cache(get_db(), self.query_id)
                 except ValueError:
                     pass  # Cache record not written yet, which can happen for Models
                     # which will call through to this method from their `_make_query` method while writing metadata.
@@ -304,16 +311,16 @@ class Query(metaclass=ABCMeta):
                     return self._df.copy()
                 except AttributeError:
                     qur = f"SELECT {self.column_names_as_string_list} FROM ({self.get_query()}) _"
-                    with self.connection.engine.begin():
-                        self._df = pd.read_sql_query(qur, con=self.connection.engine)
+                    with get_db().engine.begin():
+                        self._df = pd.read_sql_query(qur, con=get_db().engine)
 
                     return self._df.copy()
             else:
                 qur = f"SELECT {self.column_names_as_string_list} FROM ({self.get_query()}) _"
-                with self.connection.engine.begin():
-                    return pd.read_sql_query(qur, con=self.connection.engine)
+                with get_db().engine.begin():
+                    return pd.read_sql_query(qur, con=get_db().engine)
 
-        df_future = self.thread_pool_executor.submit(do_get)
+        df_future = submit_to_executor(do_get)
         return df_future
 
     def get_dataframe(self):
@@ -373,7 +380,7 @@ class Query(metaclass=ABCMeta):
             return self._df.head(n)
         except AttributeError:
             Q = f"SELECT {self.column_names_as_string_list} FROM ({self.get_query()}) h LIMIT {n};"
-            con = self.connection.engine
+            con = get_db().engine
             with con.begin():
                 df = pd.read_sql_query(Q, con=con)
                 return df
@@ -526,7 +533,7 @@ class Query(metaclass=ABCMeta):
             full_name = name
         queries = []
         # Deal with the table already existing potentially
-        if self.connection.has_table(name, schema=schema):
+        if get_db().has_table(name, schema=schema):
             logger.info("Table already exists")
             return []
 
@@ -609,19 +616,19 @@ class Query(metaclass=ABCMeta):
             ddl_ops_func = self._make_sql
 
         current_state, changed_to_queue = QueryStateMachine(
-            self.redis, self.query_id
+            get_redis(), self.query_id
         ).enqueue()
         logger.debug(
             f"Attempted to enqueue query '{self.query_id}', query state is now {current_state} and change happened {'here and now' if changed_to_queue else 'elsewhere'}."
         )
         # name, redis, query, connection, ddl_ops_func, write_func, schema = None, sleep_duration = 1
-        store_future = self.thread_pool_executor.submit(
+        store_future = submit_to_executor(
             write_query_to_cache,
             name=name,
             schema=schema,
             query=self,
-            connection=self.connection,
-            redis=self.redis,
+            connection=get_db(),
+            redis=get_redis(),
             ddl_ops_func=ddl_ops_func,
             write_func=write_query,
         )
@@ -655,7 +662,7 @@ class Query(metaclass=ABCMeta):
             opts.append("ANALYZE")
         Q = "EXPLAIN ({})".format(", ".join(opts)) + self.get_query()
 
-        exp = self.connection.fetch(Q)
+        exp = get_db().fetch(Q)
 
         if format == "TEXT":
             return "\n".join(
@@ -700,7 +707,7 @@ class Query(metaclass=ABCMeta):
 
         try:
             schema, name = self.fully_qualified_table_name.split(".")
-            return self.connection.has_table(name, schema)
+            return get_db().has_table(name, schema)
         except NotImplementedError:
             return False
 
@@ -815,10 +822,10 @@ class Query(metaclass=ABCMeta):
         drop : bool
             Set to false to remove the cache record without dropping the table
         """
-        q_state_machine = QueryStateMachine(self.redis, self.query_id)
+        q_state_machine = QueryStateMachine(get_redis(), self.query_id)
         current_state, this_thread_is_owner = q_state_machine.reset()
         if this_thread_is_owner:
-            con = self.connection.engine
+            con = get_db().engine
             try:
                 table_reference_to_this_query = self.get_table()
                 if table_reference_to_this_query is not self:
@@ -828,7 +835,7 @@ class Query(metaclass=ABCMeta):
             except (ValueError, NotImplementedError) as e:
                 pass  # This cache record isn't actually stored
             try:
-                deps = self.connection.fetch(
+                deps = get_db().fetch(
                     """SELECT obj FROM cache.cached LEFT JOIN cache.dependencies
                     ON cache.cached.query_id=cache.dependencies.query_id
                     WHERE depends_on='{}'""".format(
@@ -984,7 +991,7 @@ class Query(metaclass=ABCMeta):
 
         """
         try:
-            Query.connection
+            get_db()
         except:
             raise NotConnectedError()
 
@@ -993,7 +1000,7 @@ class Query(metaclass=ABCMeta):
         else:
             qry = "SELECT obj FROM cache.cached WHERE class='{}'".format(cls.__name__)
         logger.debug(qry)
-        objs = Query.connection.fetch(qry)
+        objs = get_db().fetch(qry)
         return (pickle.loads(obj[0]) for obj in objs)
 
     def random_sample(self, sampling_method="random_ids", **params):

--- a/flowmachine/flowmachine/core/query_info_lookup.py
+++ b/flowmachine/flowmachine/core/query_info_lookup.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import rapidjson
 import structlog
 from redis import StrictRedis

--- a/flowmachine/flowmachine/core/query_state.py
+++ b/flowmachine/flowmachine/core/query_state.py
@@ -100,7 +100,6 @@ class QueryStateMachine:
     """
 
     def __init__(self, redis_client: StrictRedis, query_id: str):
-        self.redis_client = redis_client
         self.query_id = query_id
         must_populate = redis_client.get(f"finist:{query_id}-state") is None
         self.state_machine = Finist(redis_client, f"{query_id}-state", QueryState.KNOWN)

--- a/flowmachine/flowmachine/core/query_state.py
+++ b/flowmachine/flowmachine/core/query_state.py
@@ -91,6 +91,8 @@ class QueryStateMachine:
         Client for redis
     query_id : str
         Unique query identifier
+    db_id : str
+        FlowDB connection id
 
     Notes
     -----
@@ -99,10 +101,12 @@ class QueryStateMachine:
 
     """
 
-    def __init__(self, redis_client: StrictRedis, query_id: str):
+    def __init__(self, redis_client: StrictRedis, query_id: str, db_id: str):
         self.query_id = query_id
-        must_populate = redis_client.get(f"finist:{query_id}-state") is None
-        self.state_machine = Finist(redis_client, f"{query_id}-state", QueryState.KNOWN)
+        must_populate = redis_client.get(f"finist:{db_id}:{query_id}-state") is None
+        self.state_machine = Finist(
+            redis_client, f"{db_id}:{query_id}-state", QueryState.KNOWN
+        )
         if must_populate:  # Need to create the state machine for this query
             self.state_machine.on(QueryEvent.QUEUE, QueryState.KNOWN, QueryState.QUEUED)
             self.state_machine.on(

--- a/flowmachine/flowmachine/core/server/action_handlers.py
+++ b/flowmachine/flowmachine/core/server/action_handlers.py
@@ -14,6 +14,7 @@
 # action handler and also gracefully handles any potential errors.
 #
 import asyncio
+from contextvars import copy_context
 from functools import partial
 import json
 import textwrap
@@ -124,8 +125,11 @@ async def action_handler__run_query(
             # Set the query running (it's safe to call this even if the query was set running before)
             query_id = await asyncio.get_running_loop().run_in_executor(
                 executor=config.server_thread_pool,
-                func=partial(
-                    query_obj.store_async, store_dependencies=config.store_dependencies
+                func=copy_context().run(
+                    partial(
+                        query_obj.store_async,
+                        store_dependencies=config.store_dependencies,
+                    )
                 ),
             )
         except Exception as e:

--- a/flowmachine/flowmachine/core/server/action_handlers.py
+++ b/flowmachine/flowmachine/core/server/action_handlers.py
@@ -21,8 +21,7 @@ from typing import Callable, Union
 
 from marshmallow import ValidationError
 
-from build.lib.flowmachine.core.context import get_db
-from flowmachine.core import Query
+from flowmachine.core.context import get_db, get_redis
 from flowmachine.core.cache import get_query_object_by_id
 from flowmachine.core.query_info_lookup import (
     QueryInfoLookup,
@@ -37,8 +36,6 @@ from .query_schemas.flowmachine_query import get_query_schema
 from .zmq_helpers import ZMQReply
 
 __all__ = ["perform_action"]
-
-from ..context import get_redis
 
 
 async def action_handler__ping(config: "FlowmachineServerConfig") -> ZMQReply:

--- a/flowmachine/flowmachine/core/server/action_handlers.py
+++ b/flowmachine/flowmachine/core/server/action_handlers.py
@@ -125,11 +125,12 @@ async def action_handler__run_query(
             # Set the query running (it's safe to call this even if the query was set running before)
             query_id = await asyncio.get_running_loop().run_in_executor(
                 executor=config.server_thread_pool,
-                func=copy_context().run(
+                func=partial(
+                    copy_context().run,
                     partial(
                         query_obj.store_async,
                         store_dependencies=config.store_dependencies,
-                    )
+                    ),
                 ),
             )
         except Exception as e:

--- a/flowmachine/flowmachine/core/table.py
+++ b/flowmachine/flowmachine/core/table.py
@@ -10,7 +10,7 @@ database.
 from typing import List
 
 from flowmachine.core.query_state import QueryStateMachine
-from .context import db, get_db, get_redis
+from .context import get_db, get_redis
 from .errors import NotConnectedError
 from .query import Query
 from .subset import subset_factory
@@ -61,14 +61,6 @@ class Table(Query):
     """
 
     def __init__(self, name=None, schema=None, columns=None):
-        """
-
-        """
-        try:
-            get_db()
-        except AttributeError:
-            raise NotConnectedError()
-
         if "." in name:
             extracted_schema, name = name.split(".")
             if schema is not None:

--- a/flowmachine/flowmachine/core/table.py
+++ b/flowmachine/flowmachine/core/table.py
@@ -119,7 +119,9 @@ class Table(Query):
         self.columns = columns
         super().__init__()
         # Table is immediately in a 'finished executing' state
-        q_state_machine = QueryStateMachine(get_redis(), self.query_id)
+        q_state_machine = QueryStateMachine(
+            get_redis(), self.query_id, get_db().conn_id
+        )
         if not q_state_machine.is_completed:
             q_state_machine.enqueue()
             q_state_machine.execute()

--- a/flowmachine/flowmachine/features/network/total_network_objects.py
+++ b/flowmachine/flowmachine/features/network/total_network_objects.py
@@ -13,6 +13,7 @@ at the network level.
 
 from typing import List, Optional
 
+from ...core.context import get_db
 from ...core.mixins import GeoDataMixin
 from ...core import location_joined_query, make_spatial_unit
 from ...core.spatial_unit import AnySpatialUnit
@@ -76,12 +77,12 @@ class TotalNetworkObjects(GeoDataMixin, Query):
         subscriber_identifier="msisdn",
     ):
         self.start = (
-            self.connection.min_date(table=table).strftime("%Y-%m-%d")
+            get_db().min_date(table=table).strftime("%Y-%m-%d")
             if start is None
             else start
         )
         self.stop = (
-            self.connection.max_date(table=table).strftime("%Y-%m-%d")
+            get_db().max_date(table=table).strftime("%Y-%m-%d")
             if stop is None
             else stop
         )

--- a/flowmachine/flowmachine/features/utilities/events_tables_union.py
+++ b/flowmachine/flowmachine/features/utilities/events_tables_union.py
@@ -7,6 +7,7 @@ import warnings
 from typing import List
 
 from ...core import Query
+from ...core.context import get_db
 from ...core.errors import MissingDateError
 from .event_table_subset import EventTableSubset
 
@@ -83,7 +84,7 @@ class EventsTablesUnion(Query):
 
     def _parse_tables(self, tables):
         if tables is None:
-            return [f"events.{t}" for t in self.connection.subscriber_tables]
+            return [f"events.{t}" for t in get_db().subscriber_tables]
         elif isinstance(tables, str):
             return [tables]
         else:

--- a/flowmachine/flowmachine/features/utilities/sets.py
+++ b/flowmachine/flowmachine/features/utilities/sets.py
@@ -12,6 +12,7 @@ from typing import List, Optional, Union, Tuple
 from .event_table_subset import EventTableSubset
 from .events_tables_union import EventsTablesUnion
 from ...core import Query, make_spatial_unit
+from ...core.context import get_db
 from ...core.spatial_unit import AnySpatialUnit
 
 from numpy import inf
@@ -113,7 +114,7 @@ class UniqueSubscribers(Query):
         """
         Returns all unique subscribers as a set.
         """
-        return {u[0] for u in self.connection.fetch(self.get_query())}
+        return {u[0] for u in get_db().fetch(self.get_query())}
 
 
 SubsetDates = EventTableSubset  # Backwards compatibility for unpicking queries from db

--- a/flowmachine/setup.py
+++ b/flowmachine/setup.py
@@ -93,6 +93,7 @@ setup(
     setup_requires=["pytest-runner"],
     tests_require=test_requirements,
     extras_require={"test": test_requirements},
+    python_require=">=3.7",
     include_package_data=True,
     zip_safe=False,
     platforms=["MacOS X", "Linux"],

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -25,9 +25,9 @@ from approvaltests.reporters.generic_diff_reporter_factory import (
 )
 
 import flowmachine
-from flowmachine.core import make_spatial_unit, Connection
+from flowmachine.core import make_spatial_unit
 from flowmachine.core.cache import reset_cache
-from flowmachine.core.context import redis_connection, context, get_db, get_redis
+from flowmachine.core.context import redis_connection, get_db, get_redis
 from flowmachine.core.init import connections
 from flowmachine.features import EventTableSubset
 
@@ -252,8 +252,8 @@ class DummyRedis:
             self._store = {}
 
 
-@pytest.fixture(scope="function")
-def dummy_redis(monkeypatch):
+@pytest.fixture
+def dummy_redis(flowmachine_connect):
     dummy_redis = DummyRedis()
     token = redis_connection.set(dummy_redis)
     yield dummy_redis

--- a/flowmachine/tests/conftest.py
+++ b/flowmachine/tests/conftest.py
@@ -164,7 +164,7 @@ def mocked_connections(monkeypatch):
     connection_mock.return_value.engine.begin.return_value.__enter__ = Mock()
     connection_mock.return_value.engine.begin.return_value.__exit__ = Mock()
     connection_mock.return_value.fetch.return_value = MagicMock(return_value=[])
-    redis_mock = Mock()
+    redis_mock = Mock(name="mocked_connections_redis")
     tp_mock = Mock(return_value=None)
     monkeypatch.setattr(flowmachine.core.init, "set_log_level", logging_mock)
     monkeypatch.setattr(flowmachine.core.init, "Connection", connection_mock)
@@ -256,6 +256,7 @@ class DummyRedis:
 def dummy_redis(flowmachine_connect):
     dummy_redis = DummyRedis()
     token = redis_connection.set(dummy_redis)
+    print("Replaced redis with dummy redis.")
     yield dummy_redis
     redis_connection.reset(token)
 

--- a/flowmachine/tests/server/conftest.py
+++ b/flowmachine/tests/server/conftest.py
@@ -45,10 +45,10 @@ def dummy_zmq_server(monkeypatch):
     yield dummy
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(autouse=True)
 def flowmachine_connect():
     """Overrides the flowmachine connection fixture to replace all applicable parts with mocks."""
-    with context(Mock(), get_executor(), Mock()):
+    with context(Mock(), ThreadPoolExecutor(), Mock()):
         print("Replacing connections with mocks.")
         yield
 

--- a/flowmachine/tests/server/conftest.py
+++ b/flowmachine/tests/server/conftest.py
@@ -12,6 +12,7 @@ from asynctest import Mock as AMock
 import pytest
 import zmq
 from flowmachine.core import Query
+from flowmachine.core.context import context, executor, get_executor
 from flowmachine.core.server.server_config import FlowmachineServerConfig
 
 
@@ -47,9 +48,9 @@ def dummy_zmq_server(monkeypatch):
 @pytest.fixture(scope="session", autouse=True)
 def flowmachine_connect():
     """Overrides the flowmachine connection fixture to replace all applicable parts with mocks."""
-    Query.connection = Mock()
-    Query.redis = Mock()
-    print("Replacing connections with mocks.")
+    with context(Mock(), get_executor(), Mock()):
+        print("Replacing connections with mocks.")
+        yield
 
 
 @pytest.fixture(scope="session")

--- a/flowmachine/tests/server/conftest.py
+++ b/flowmachine/tests/server/conftest.py
@@ -1,18 +1,14 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import json
-from concurrent.futures.thread import ThreadPoolExecutor
-from json import JSONDecodeError
 
-from _pytest.capture import CaptureResult
+from concurrent.futures.thread import ThreadPoolExecutor
 from unittest.mock import Mock
 from asynctest import Mock as AMock
 
 import pytest
 import zmq
-from flowmachine.core import Query
-from flowmachine.core.context import context, executor, get_executor
+from flowmachine.core.context import context
 from flowmachine.core.server.server_config import FlowmachineServerConfig
 
 
@@ -48,7 +44,7 @@ def dummy_zmq_server(monkeypatch):
 @pytest.fixture(autouse=True)
 def flowmachine_connect():
     """Overrides the flowmachine connection fixture to replace all applicable parts with mocks."""
-    with context(Mock(), ThreadPoolExecutor(), Mock()):
+    with context(Mock(), ThreadPoolExecutor(), Mock(name="connect_redis")):
         print("Replacing connections with mocks.")
         yield
 

--- a/flowmachine/tests/server/test_action_handlers.py
+++ b/flowmachine/tests/server/test_action_handlers.py
@@ -6,7 +6,7 @@ from marshmallow import Schema, fields
 
 import flowmachine
 from flowmachine.core import Query
-from flowmachine.core.context import get_redis
+from flowmachine.core.context import get_redis, get_db
 from flowmachine.core.query_state import QueryState, QueryStateMachine
 
 from flowmachine.core.server.action_handlers import (
@@ -100,7 +100,7 @@ async def test_get_sql_error_states(query_state, dummy_redis, server_config):
     is not finished.
     """
     dummy_redis.set("DUMMY_QUERY_ID", "KNOWN")
-    state_machine = QueryStateMachine(dummy_redis, "DUMMY_QUERY_ID")
+    state_machine = QueryStateMachine(dummy_redis, "DUMMY_QUERY_ID", get_db().conn_id)
     dummy_redis.set(state_machine.state_machine._name, query_state)
     msg = await action_handler__get_sql(config=server_config, query_id="DUMMY_QUERY_ID")
     assert msg.status == ZMQReplyStatus.ERROR

--- a/flowmachine/tests/server/test_action_handlers.py
+++ b/flowmachine/tests/server/test_action_handlers.py
@@ -6,6 +6,7 @@ from marshmallow import Schema, fields
 
 import flowmachine
 from flowmachine.core import Query
+from flowmachine.core.context import get_redis
 from flowmachine.core.query_state import QueryState, QueryStateMachine
 
 from flowmachine.core.server.action_handlers import (
@@ -82,7 +83,7 @@ async def test_get_query_bad_id(server_config):
     """
     Get sql handler should send back an error status for a nonexistent id
     """
-    Query.redis.get.return_value = None
+    get_redis().get.return_value = None
     msg = await action_handler__get_query_params(
         config=server_config, query_id="DUMMY_ID"
     )

--- a/flowmachine/tests/server/test_action_handlers.py
+++ b/flowmachine/tests/server/test_action_handlers.py
@@ -6,7 +6,7 @@ from marshmallow import Schema, fields
 
 import flowmachine
 from flowmachine.core import Query
-from flowmachine.core.context import get_redis, get_db
+from flowmachine.core.context import get_redis, get_db, redis_connection
 from flowmachine.core.query_state import QueryState, QueryStateMachine
 
 from flowmachine.core.server.action_handlers import (
@@ -99,9 +99,11 @@ async def test_get_sql_error_states(query_state, dummy_redis, server_config):
     Test that get_sql handler replies with an error state when the query
     is not finished.
     """
+    redis_reset = redis_connection.set(dummy_redis)
     dummy_redis.set("DUMMY_QUERY_ID", "KNOWN")
     state_machine = QueryStateMachine(dummy_redis, "DUMMY_QUERY_ID", get_db().conn_id)
     dummy_redis.set(state_machine.state_machine._name, query_state)
     msg = await action_handler__get_sql(config=server_config, query_id="DUMMY_QUERY_ID")
     assert msg.status == ZMQReplyStatus.ERROR
     assert msg.payload["query_state"] == query_state
+    redis_connection.reset(redis_reset)

--- a/flowmachine/tests/server/test_query_logging.py
+++ b/flowmachine/tests/server/test_query_logging.py
@@ -8,6 +8,7 @@ import pytest
 import sys
 from logging import getLogger
 
+from flowmachine.core.context import get_redis
 from flowmachine.core.logging import set_log_level
 from flowmachine.core.server.server import get_reply_for_message
 from flowmachine.core import Query
@@ -26,7 +27,7 @@ async def test_query_run_logged(json_log, server_config):
     set_log_level(
         "flowmachine.debug", "ERROR"
     )  # Logging of query runs should be independent of other logs
-    Query.redis.get.return_value = (
+    get_redis().get.return_value = (
         b"known"  # Mock enough redis to get to the log messages
     )
     reply = await get_reply_for_message(

--- a/flowmachine/tests/test_async.py
+++ b/flowmachine/tests/test_async.py
@@ -64,15 +64,15 @@ def test_get_query_blocks_on_store():
     dl.store().result()
     timer = []
 
-    def unlock(timer, redis):
-        qsm = QueryStateMachine(redis, dl.query_id)
+    def unlock(timer, redis, db_id):
+        qsm = QueryStateMachine(redis, dl.query_id, db_id)
         qsm.enqueue()
         for i in range(101):
             timer.append(i)
         qsm.execute()
         qsm.finish()
 
-    timeout = Thread(target=unlock, args=(timer, get_redis()))
+    timeout = Thread(target=unlock, args=(timer, get_redis(), get_db().conn_id))
     timeout.start()
     dl.get_query()
     assert len(timer) == 101
@@ -91,15 +91,15 @@ def test_blocks_on_store_cascades():
     hl = ModalLocation(dl, dl2)
     timer = []
 
-    def unlock(timer, redis):
-        qsm = QueryStateMachine(redis, dl.query_id)
+    def unlock(timer, redis, db_id):
+        qsm = QueryStateMachine(redis, dl.query_id, db_id)
         qsm.enqueue()
         for i in range(101):
             timer.append(i)
         qsm.execute()
         qsm.finish()
 
-    timeout = Thread(target=unlock, args=(timer, get_redis()))
+    timeout = Thread(target=unlock, args=(timer, get_redis(), get_db().conn_id))
     timeout.start()
     hl.get_query()
     assert len(timer) == 101

--- a/flowmachine/tests/test_async.py
+++ b/flowmachine/tests/test_async.py
@@ -4,6 +4,7 @@
 
 from concurrent.futures import Future
 
+from flowmachine.core.context import get_db, get_redis
 from flowmachine.core.query_state import QueryStateMachine
 from flowmachine.features.subscriber import *
 from threading import Thread
@@ -50,7 +51,7 @@ def test_store_async():
     table_name = dl.fully_qualified_table_name.split(".")[1]
     store_future = dl.store()
     store_future.result()
-    assert dl.connection.has_table(table_name, schema=schema)
+    assert get_db().has_table(table_name, schema=schema)
     dl = daily_location("2016-01-01", spatial_unit=make_spatial_unit("cell"))
     assert table_name in dl.get_query()
 
@@ -63,15 +64,15 @@ def test_get_query_blocks_on_store():
     dl.store().result()
     timer = []
 
-    def unlock(timer):
-        qsm = QueryStateMachine(dl.redis, dl.query_id)
+    def unlock(timer, redis):
+        qsm = QueryStateMachine(redis, dl.query_id)
         qsm.enqueue()
         for i in range(101):
             timer.append(i)
         qsm.execute()
         qsm.finish()
 
-    timeout = Thread(target=unlock, args=(timer,))
+    timeout = Thread(target=unlock, args=(timer, get_redis()))
     timeout.start()
     dl.get_query()
     assert len(timer) == 101
@@ -90,15 +91,15 @@ def test_blocks_on_store_cascades():
     hl = ModalLocation(dl, dl2)
     timer = []
 
-    def unlock(timer):
-        qsm = QueryStateMachine(dl.redis, dl.query_id)
+    def unlock(timer, redis):
+        qsm = QueryStateMachine(redis, dl.query_id)
         qsm.enqueue()
         for i in range(101):
             timer.append(i)
         qsm.execute()
         qsm.finish()
 
-    timeout = Thread(target=unlock, args=(timer,))
+    timeout = Thread(target=unlock, args=(timer, get_redis()))
     timeout.start()
     hl.get_query()
     assert len(timer) == 101

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -562,7 +562,7 @@ def test_cache_ddl_op_error(dummy_redis):
     """
 
     query_mock = Mock(query_id="DUMMY_MD5")
-    qsm = QueryStateMachine(dummy_redis, "DUMMY_MD5", get_db().conn_id)
+    qsm = QueryStateMachine(dummy_redis, "DUMMY_MD5", "DUMMY_CONNECTION")
     qsm.enqueue()
 
     with pytest.raises(TestException):
@@ -570,7 +570,7 @@ def test_cache_ddl_op_error(dummy_redis):
             name="DUMMY_QUERY",
             redis=dummy_redis,
             query=query_mock,
-            connection=Mock(),
+            connection=Mock(conn_id="DUMMY_CONNECTION"),
             ddl_ops_func=Mock(side_effect=TestException),
             write_func=Mock(),
         )

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -460,19 +460,25 @@ def test_redis_resync(flowmachine_connect):
     """
     stored_query = daily_location("2016-01-01").store().result()
     assert (
-        QueryStateMachine(get_redis(), stored_query.query_id).current_query_state
+        QueryStateMachine(
+            get_redis(), stored_query.query_id, get_db().conn_id
+        ).current_query_state
         == QueryState.COMPLETED
     )
     assert stored_query.is_stored
     get_redis().flushdb()
     assert stored_query.is_stored
     assert (
-        QueryStateMachine(get_redis(), stored_query.query_id).current_query_state
+        QueryStateMachine(
+            get_redis(), stored_query.query_id, get_db().conn_id
+        ).current_query_state
         == QueryState.KNOWN
     )
     resync_redis_with_cache(get_db(), get_redis())
     assert (
-        QueryStateMachine(get_redis(), stored_query.query_id).current_query_state
+        QueryStateMachine(
+            get_redis(), stored_query.query_id, get_db().conn_id
+        ).current_query_state
         == QueryState.COMPLETED
     )
 
@@ -483,13 +489,17 @@ def test_cache_reset(flowmachine_connect):
     """
     stored_query = daily_location("2016-01-01").store().result()
     assert (
-        QueryStateMachine(get_redis(), stored_query.query_id).current_query_state
+        QueryStateMachine(
+            get_redis(), stored_query.query_id, get_db().conn_id
+        ).current_query_state
         == QueryState.COMPLETED
     )
     assert stored_query.is_stored
     reset_cache(get_db(), get_redis())
     assert (
-        QueryStateMachine(get_redis(), stored_query.query_id).current_query_state
+        QueryStateMachine(
+            get_redis(), stored_query.query_id, get_db().conn_id
+        ).current_query_state
         == QueryState.KNOWN
     )
     assert not stored_query.is_stored
@@ -513,7 +523,9 @@ def test_redis_resync_runtimeerror(flowmachine_connect, dummy_redis):
     """
     stored_query = daily_location("2016-01-01").store().result()
     assert (
-        QueryStateMachine(get_redis(), stored_query.query_id).current_query_state
+        QueryStateMachine(
+            get_redis(), stored_query.query_id, get_db().conn_id
+        ).current_query_state
         == QueryState.COMPLETED
     )
     dummy_redis.allow_flush = False
@@ -537,7 +549,9 @@ def test_cache_metadata_write_error(flowmachine_connect, dummy_redis, monkeypatc
         store_future.result()
     assert not dl_query.is_stored
     assert (
-        QueryStateMachine(get_redis(), dl_query.query_id).current_query_state
+        QueryStateMachine(
+            get_redis(), dl_query.query_id, get_db().conn_id
+        ).current_query_state
         == QueryState.ERRORED
     )
 
@@ -548,7 +562,7 @@ def test_cache_ddl_op_error(dummy_redis):
     """
 
     query_mock = Mock(query_id="DUMMY_MD5")
-    qsm = QueryStateMachine(dummy_redis, "DUMMY_MD5")
+    qsm = QueryStateMachine(dummy_redis, "DUMMY_MD5", get_db().conn_id)
     qsm.enqueue()
 
     with pytest.raises(TestException):

--- a/flowmachine/tests/test_context.py
+++ b/flowmachine/tests/test_context.py
@@ -1,0 +1,89 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from unittest.mock import Mock
+import importlib
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reload_context(monkeypatch):
+    """
+    Need to forcibly reimport context at exit because we've fiddled with it
+    in the tests.
+    """
+    import flowmachine
+
+    yield
+    monkeypatch.delattr(flowmachine.core.context, "get_ipython", raising=False)
+    importlib.reload(flowmachine.core.context)
+
+
+@pytest.fixture
+def flowmachine_connect():  # Override the autoused fixture from the parent
+    pass
+
+
+@pytest.mark.parametrize(
+    "shell, expected_result",
+    [
+        ("ZMQInteractiveShell", True),
+        ("NOT_A_SHELL", False),
+        ("TerminalInteractiveShell", False),
+    ],
+)
+def test_notebook_detection_with_ipython_shell(shell, expected_result, monkeypatch):
+    """
+    If get_ipython is defined, test that we're detecting if in a notebook.
+    """
+    get_ipython = Mock()
+    get_ipython.return_value = Mock(__class__=Mock(__name__=shell))
+    import flowmachine
+
+    monkeypatch.setattr(
+        flowmachine.core.context, "get_ipython", get_ipython, raising=False
+    )
+    importlib.reload(flowmachine.core.context)
+
+    assert flowmachine.core.context._is_notebook == expected_result
+
+
+def test_notebook_detection_without_ipython_shell(monkeypatch):
+    """
+    Test that we aren't detecting ipython if it isn't there.
+    """
+    import flowmachine
+
+    monkeypatch.delattr(flowmachine.core.context, "get_ipython", raising=False)
+    importlib.reload(flowmachine.core.context)
+
+    assert not flowmachine.core.context._is_notebook
+    assert len(flowmachine.core.context._jupyter_context) == 0
+
+
+def test_notebook_workaround(monkeypatch):
+    """
+    If get_ipython is defined, test that we're detecting if in a notebook and applying workaround.
+    """
+    get_ipython = Mock()
+    get_ipython.return_value = Mock(__class__=Mock(__name__="ZMQInteractiveShell"))
+    import flowmachine
+
+    monkeypatch.setattr(
+        flowmachine.core.context, "get_ipython", get_ipython, raising=False
+    )
+    importlib.reload(flowmachine.core.context)
+
+    flowmachine.core.context.bind_context(
+        Mock(mock_name="db"), Mock(mock_name="pool"), Mock(mock_name="redis")
+    )
+    assert flowmachine.core.context._jupyter_context["db"].mock_name == "db"
+    assert flowmachine.core.context._jupyter_context["executor"].mock_name == "pool"
+    assert (
+        flowmachine.core.context._jupyter_context["redis_connection"].mock_name
+        == "redis"
+    )
+    assert flowmachine.core.context.get_db().mock_name == "db"
+    assert flowmachine.core.context.get_executor().mock_name == "pool"
+    assert flowmachine.core.context.get_redis().mock_name == "redis"

--- a/flowmachine/tests/test_geomixin.py
+++ b/flowmachine/tests/test_geomixin.py
@@ -15,6 +15,7 @@ import geojson
 import pytest
 
 from flowmachine.core import Query
+from flowmachine.core.context import get_db
 from flowmachine.core.mixins import GeoDataMixin
 from flowmachine.core import make_spatial_unit
 from flowmachine.features import daily_location
@@ -155,7 +156,7 @@ def test_reprojection():
     assert js["features"][0]["geometry"]["coordinates"] == pytest.approx(
         [-8094697.52, 9465052.88]
     )
-    assert js["properties"]["crs"] == proj4string(dl.connection, 2770)
+    assert js["properties"]["crs"] == proj4string(get_db(), 2770)
 
 
 def test_geojson_cache():
@@ -166,7 +167,7 @@ def test_geojson_cache():
         "2016-01-01", "2016-01-02", spatial_unit=make_spatial_unit("lon-lat")
     ).aggregate()
     js = dl.to_geojson(crs=2770)  # OSGB36
-    assert js == dl._geojson[proj4string(dl.connection, 2770)]
+    assert js == dl._geojson[proj4string(get_db(), 2770)]
 
 
 def test_geojson_cache_exluded_from_pickle():
@@ -186,7 +187,7 @@ def test_geojson_caching_off():
     js = dl.to_geojson(crs=2770)  # OSGB36
     dl.turn_off_caching()  # Check caching for geojson switches off
     with pytest.raises(KeyError):
-        dl._geojson[proj4string(dl.connection, 2770)]
+        dl._geojson[proj4string(get_db(), 2770)]
     js = dl.to_geojson(crs=2770)  # OSGB36
     with pytest.raises(KeyError):
-        dl._geojson[proj4string(dl.connection, 2770)]
+        dl._geojson[proj4string(get_db(), 2770)]

--- a/flowmachine/tests/test_indexes.py
+++ b/flowmachine/tests/test_indexes.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from flowmachine.core import make_spatial_unit
+from flowmachine.core.context import get_db
 from flowmachine.features.subscriber import *
 
 
@@ -29,4 +30,4 @@ def test_index_created(flowmachine_connect):
     ix_qur = "SELECT * FROM pg_indexes WHERE tablename='{}'".format(
         dl.fully_qualified_table_name.split(".")[1]
     )
-    assert len(flowmachine_connect.fetch(ix_qur)) == 2
+    assert len(get_db().fetch(ix_qur)) == 2

--- a/flowmachine/tests/test_init.py
+++ b/flowmachine/tests/test_init.py
@@ -10,7 +10,6 @@ from flowmachine.core import connect
 
 @pytest.fixture(autouse=True)
 def reset_connect(monkeypatch):
-    monkeypatch.delattr("flowmachine.core.Query.connection")
     logging.getLogger("flowmachine.debug").handlers = []
 
 
@@ -88,7 +87,7 @@ def test_param_priority(mocked_connections, monkeypatch):
         host="dummy_redis_host", port=1213, password="dummy_redis_password"
     )
     core_init_start_threadpool_mock.assert_called_with(
-        thread_pool_size=6789
+        6789
     )  # for the time being, we should have num_threads = num_db_connections
 
 
@@ -128,7 +127,7 @@ def test_env_priority(mocked_connections, monkeypatch):
         host="DUMMY_ENV_REDIS_HOST", port=5050, password="DUMMY_ENV_REDIS_PASSWORD"
     )
     core_init_start_threadpool_mock.assert_called_with(
-        thread_pool_size=7777
+        7777
     )  # for the time being, we should have num_threads = num_db_connections
 
 
@@ -156,7 +155,7 @@ def test_connect_defaults(mocked_connections, monkeypatch):
         host="localhost", port=6379, password="fm_redis"
     )
     core_init_start_threadpool_mock.assert_called_with(
-        thread_pool_size=5
+        5
     )  # for the time being, we should have num_threads = num_db_connections
 
 

--- a/flowmachine/tests/test_query.py
+++ b/flowmachine/tests/test_query.py
@@ -31,7 +31,7 @@ def test_bad_sql_logged_and_raised(caplog):
         fut = BadQuery().store()
         exec = fut.exception()
         raise exec
-    assert "Error executing SQL" in caplog.messages[0]
+    assert "Error executing SQL" in caplog.messages[-1]
 
 
 def test_method_not_implemented():

--- a/flowmachine/tests/test_query_state.py
+++ b/flowmachine/tests/test_query_state.py
@@ -13,6 +13,7 @@ import pytest
 
 import flowmachine
 from flowmachine.core import Query
+from flowmachine.core.context import get_redis
 from flowmachine.core.errors.flowmachine_errors import (
     QueryCancelledException,
     QueryErroredException,
@@ -143,7 +144,7 @@ def test_query_cancellation(start_state, succeeds, dummy_redis):
 def test_store_exceptions(fail_event, expected_exception):
     """Test that exceptions are raised when watching a store op triggered elsewhere."""
     q = DummyQuery(dummy_id=1, sleep_time=5)
-    qsm = QueryStateMachine(q.redis, q.query_id)
+    qsm = QueryStateMachine(get_redis(), q.query_id)
     # Mark the query as having begun executing elsewhere
     qsm.enqueue()
     qsm.execute()
@@ -159,7 +160,7 @@ def test_drop_query_blocks(monkeypatch):
         flowmachine.core.query, "_sleep", Mock(side_effect=BlockingIOError)
     )
     q = DummyQuery(dummy_id=1, sleep_time=5)
-    qsm = QueryStateMachine(q.redis, q.query_id)
+    qsm = QueryStateMachine(get_redis(), q.query_id)
     # Mark the query as in the process of resetting
     qsm.enqueue()
     qsm.execute()
@@ -172,7 +173,7 @@ def test_drop_query_blocks(monkeypatch):
 def test_drop_query_errors():
     """Test that resetting a query's cache will error if in a state where that isn't possible."""
     q = DummyQuery(dummy_id=1, sleep_time=5)
-    qsm = QueryStateMachine(q.redis, q.query_id)
+    qsm = QueryStateMachine(get_redis(), q.query_id)
     # Mark the query as in the process of resetting
     qsm.enqueue()
     qsm.execute()

--- a/flowmachine/tests/test_subscriber_subsetting.py
+++ b/flowmachine/tests/test_subscriber_subsetting.py
@@ -10,6 +10,7 @@ Tests for the subscriber subsetting functionality
 import pytest
 
 from flowmachine.core import Table
+from flowmachine.core.context import get_db
 from flowmachine.features import (
     RadiusOfGyration,
     ModalLocation,
@@ -62,7 +63,7 @@ def subscriber_list():
 
 @pytest.fixture
 def subscriber_list_table(subscriber_list, flowmachine_connect):
-    engine = flowmachine_connect.engine
+    engine = get_db().engine
     with engine.begin():
         sql = """CREATE TABLE subscriber_list (subscriber TEXT)"""
         engine.execute(sql)

--- a/flowmachine/tests/test_to_sql.py
+++ b/flowmachine/tests/test_to_sql.py
@@ -9,6 +9,7 @@ Unit tests for the Query() base class.
 import pytest
 
 from flowmachine.core import Table
+from flowmachine.core.context import get_db
 from flowmachine.features.utilities.event_table_subset import EventTableSubset
 
 
@@ -18,9 +19,9 @@ def test_table_schema(flowmachine_connect):
     Fixture which creates a schema called 'tests' before every test
     and destroys it again after the test has finished.
     """
-    flowmachine_connect.engine.execute("CREATE SCHEMA IF NOT EXISTS tests")
+    get_db().engine.execute("CREATE SCHEMA IF NOT EXISTS tests")
     yield
-    flowmachine_connect.engine.execute("DROP SCHEMA tests CASCADE")
+    get_db().engine.execute("DROP SCHEMA tests CASCADE")
 
 
 def test_stores_table(flowmachine_connect):
@@ -29,7 +30,7 @@ def test_stores_table(flowmachine_connect):
     """
     query = EventTableSubset(start="2016-01-01", stop="2016-01-01 01:00:00")
     query.to_sql(name="test_table", schema="tests").result()
-    assert flowmachine_connect.has_table(name="test_table", schema="tests")
+    assert get_db().has_table(name="test_table", schema="tests")
 
 
 def test_can_force_rewrite(flowmachine_connect, get_length):
@@ -41,7 +42,7 @@ def test_can_force_rewrite(flowmachine_connect, get_length):
     # We're going to delete everything from the table, then
     # force a rewrite, and check that the table now has data.
     sql = """DELETE FROM tests.test_rewrite"""
-    flowmachine_connect.engine.execute(sql)
+    get_db().engine.execute(sql)
     assert 0 == get_length(Table("tests.test_rewrite"))
     query.invalidate_db_cache(name="test_rewrite", schema="tests")
     query.to_sql(name="test_rewrite", schema="tests").result()

--- a/flowmachine/tests/test_utils.py
+++ b/flowmachine/tests/test_utils.py
@@ -8,6 +8,7 @@ Tests for flowmachine small helper functions
 import pytest
 import pglast
 
+from flowmachine.core.context import get_db
 from flowmachine.utils import *
 from flowmachine.utils import _makesafe
 
@@ -17,9 +18,7 @@ def test_proj4string(crs, flowmachine_connect):
     """
     Test proj4string behaviour for known codes
     """
-    assert (
-        proj4string(flowmachine_connect, crs) == "+proj=longlat +datum=WGS84 +no_defs"
-    )
+    assert proj4string(get_db(), crs) == "+proj=longlat +datum=WGS84 +no_defs"
 
 
 @pytest.mark.parametrize("crs", (-1, (1, 1)))
@@ -28,7 +27,7 @@ def test_proj4string_valueerror(crs, flowmachine_connect):
     Test proj4string valueerrors for bad values
     """
     with pytest.raises(ValueError):
-        proj4string(flowmachine_connect, crs)
+        proj4string(get_db(), crs)
 
 
 def test_time_period_add():

--- a/integration_tests/tests/flowmachine_server_tests/test_action_run_query.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_action_run_query.py
@@ -8,6 +8,7 @@ from flowmachine.core.server.utils import (
     send_zmq_message_and_receive_reply,
     send_zmq_message_and_await_reply,
 )
+from flowmachine.core.context import get_db
 from flowmachine.core import make_spatial_unit
 from flowmachine.core.dependency_graph import unstored_dependencies_graph
 from flowmachine.features.location.spatial_aggregate import SpatialAggregate
@@ -87,8 +88,8 @@ def test_run_query(zmq_port, zmq_host, fm_conn, redis):
     #
     # Check that we are starting with a clean slate (no cache tables, empty redis).
     #
-    reset_cache(fm_conn, redis, protect_table_objects=False)
-    assert cache_schema_is_empty(fm_conn)
+    reset_cache(get_db(), redis, protect_table_objects=False)
+    assert cache_schema_is_empty(get_db())
     assert not redis.exists(expected_query_id)
 
     #
@@ -113,10 +114,12 @@ def test_run_query(zmq_port, zmq_host, fm_conn, redis):
     # and that it contains the expected number of rows.
     #
     output_cache_table = f"x{expected_query_id}"
-    assert output_cache_table in get_cache_tables(fm_conn)
-    num_rows = fm_conn.engine.execute(
-        f"SELECT COUNT(*) FROM cache.{output_cache_table}"
-    ).fetchone()[0]
+    assert output_cache_table in get_cache_tables(get_db())
+    num_rows = (
+        get_db()
+        .engine.execute(f"SELECT COUNT(*) FROM cache.{output_cache_table}")
+        .fetchone()[0]
+    )
     assert num_rows == 14
 
     #
@@ -128,9 +131,13 @@ def test_run_query(zmq_port, zmq_host, fm_conn, redis):
         ("524 1 03 13", 20),
         ("524 3 08 43", 35),
     ]
-    first_few_rows = fm_conn.engine.execute(
-        f"SELECT * FROM cache.{output_cache_table} ORDER BY pcod LIMIT 3"
-    ).fetchall()
+    first_few_rows = (
+        get_db()
+        .engine.execute(
+            f"SELECT * FROM cache.{output_cache_table} ORDER BY pcod LIMIT 3"
+        )
+        .fetchall()
+    )
     assert first_few_rows_expected == first_few_rows
 
 
@@ -183,7 +190,7 @@ def test_cache_content(
                 pass
 
     # Check that we are starting with an empty cache.
-    assert cache_schema_is_empty(fm_conn, check_internal_tables_are_empty=False)
+    assert cache_schema_is_empty(get_db(), check_internal_tables_are_empty=False)
 
     # Send message to run the daily_location query, and check it was accepted
     reply = send_zmq_message_and_receive_reply(
@@ -196,7 +203,7 @@ def test_cache_content(
     poll_until_done(zmq_port, query_id)
 
     # Check that the cache contains the correct tables.
-    assert sorted(expected_cache_tables) == get_cache_tables(fm_conn)
+    assert sorted(expected_cache_tables) == get_cache_tables(get_db())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #391

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [ ] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [x] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This makes the database connection, redis connection, and thread pool [context variables](https://docs.python.org/3.7/library/contextvars.html) which are accessed by getter methods rather than stuck on `Query`.

This means they can be more easily manipulated, there's no longer a hard requirement that they're set during query init, and that they can be temporarily overridden using a context manager (so, for example, one could connect to multiple flowdb instances from flowmachine).