### PR TITLE
Fix query rerun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- Queries which have been removed Flowmachine's cache, or cancelled can now be rerun. [#1898](https://github.com/Flowminder/FlowKit/issues/1898)
 
 ### Removed
 

--- a/flowmachine/flowmachine/core/query_info_lookup.py
+++ b/flowmachine/flowmachine/core/query_info_lookup.py
@@ -61,4 +61,4 @@ class QueryInfoLookup:
         query_id = self.redis_client.get(query_params_str)
         if query_id is None:
             raise QueryInfoLookupError("No id for these params.")
-        return query_id
+        return query_id.decode()


### PR DESCRIPTION
Closes #1898 

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Uses the info held in redis to reset to known cancelled queries when resubmitted, and to rerun queries which have been previously reset (e.g. if they've been cleared from the cache).