### PR TITLE
Progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- FlowAPI now reports the proportion of subqueries cached for a query when polling. [#1202](https://github.com/Flowminder/FlowKit/issues/1202)
+- FlowClient now logs info messages with the proportion of subqueries cached for a query when polling. [#1202](https://github.com/Flowminder/FlowKit/issues/1202)
 
 ### Changed
 

--- a/flowapi/flowapi/query_endpoints.py
+++ b/flowapi/flowapi/query_endpoints.py
@@ -31,6 +31,20 @@ async def run_query():
               schema:
                 format: url
                 type: string
+          content:
+            application/json:
+              schema:
+                properties:
+                  query_id:
+                    type: string
+                  completed:
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
+                    maxItems: 2
+                    minItems: 2
+                type: object
         '401':
           description: Unauthorized.
         '403':
@@ -111,6 +125,13 @@ async def poll_query(query_id):
                       - executing
                       - queued
                     type: string
+                  completed:
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
+                    maxItems: 2
+                    minItems: 2
                 type: object
           description: Request accepted.
         '303':

--- a/flowapi/tests/unit/test_access_control.py
+++ b/flowapi/tests/unit/test_access_control.py
@@ -47,7 +47,10 @@ async def test_granular_run_access(
     dummy_zmq_server.return_value = {
         "status": "success",
         "msg": "",
-        "payload": {"query_id": "DUMMY_QUERY_ID"},
+        "payload": {
+            "query_id": "DUMMY_QUERY_ID",
+            "progress": {"eligible": 0, "queued": 0, "executing": 0},
+        },
     }
     responses = {}
     for q_kind in query_kinds:

--- a/flowapi/tests/unit/test_poll_query.py
+++ b/flowapi/tests/unit/test_poll_query.py
@@ -75,7 +75,11 @@ async def test_poll_query(
         ),
         then=ZMQReply(
             status="success",
-            payload={"query_id": "DUMMY_QUERY_ID", "query_state": query_state},
+            payload={
+                "query_id": "DUMMY_QUERY_ID",
+                "query_state": query_state,
+                "progress": {"eligible": 0, "queued": 0, "executing": 0},
+            },
         ),
     )
     response = await app.client.get(

--- a/flowapi/tests/unit/test_run_query.py
+++ b/flowapi/tests/unit/test_run_query.py
@@ -20,7 +20,11 @@ async def test_post_query(app, dummy_zmq_server, access_token_builder):
         ]
     )
     dummy_zmq_server.return_value = ZMQReply(
-        status="success", payload={"query_id": "DUMMY_QUERY_ID"}
+        status="success",
+        payload={
+            "query_id": "DUMMY_QUERY_ID",
+            "progress": {"eligible": 0, "queued": 0, "executing": 0},
+        },
     )
     response = await app.client.post(
         f"/api/0/run",

--- a/flowclient/flowclient/client.py
+++ b/flowclient/flowclient/client.py
@@ -261,6 +261,7 @@ def query_is_ready(
         )
         return True, reply  # Query is ready, so exit the loop
     elif reply.status_code == 202:
+        logger.info(f"Completed {'/'.join(reply.json()['completed'])} parts")
         return False, reply
     else:
         raise FlowclientConnectionError(

--- a/flowclient/flowclient/client.py
+++ b/flowclient/flowclient/client.py
@@ -261,7 +261,9 @@ def query_is_ready(
         )
         return True, reply  # Query is ready, so exit the loop
     elif reply.status_code == 202:
-        logger.info(f"Completed {'/'.join(reply.json()['completed'])} parts")
+        logger.info(
+            f"Completed {'{}/{}'.format(*reply.json()['payload']['completed'])} parts"
+        )
         return False, reply
     else:
         raise FlowclientConnectionError(

--- a/flowclient/flowclient/client.py
+++ b/flowclient/flowclient/client.py
@@ -263,7 +263,7 @@ def query_is_ready(
     elif reply.status_code == 202:
         logger.info(
             "{eligible} parts to run, {queued} in queue and {executing} running.".format(
-                **reply.json()["payload"]["completed"]
+                **reply.json()["payload"]["progress"]
             )
         )
         return False, reply

--- a/flowclient/flowclient/client.py
+++ b/flowclient/flowclient/client.py
@@ -262,8 +262,8 @@ def query_is_ready(
         return True, reply  # Query is ready, so exit the loop
     elif reply.status_code == 202:
         logger.info(
-            "{eligible} parts to run, {queued} in queue and {executing} running.".format(
-                **reply.json()["payload"]["progress"]
+            "{eligible} parts to run, {queued} in queue and {running} running.".format(
+                **reply.json()["progress"]
             )
         )
         return False, reply

--- a/flowclient/flowclient/client.py
+++ b/flowclient/flowclient/client.py
@@ -262,7 +262,9 @@ def query_is_ready(
         return True, reply  # Query is ready, so exit the loop
     elif reply.status_code == 202:
         logger.info(
-            f"Completed {'{}/{}'.format(*reply.json()['payload']['completed'])} parts"
+            "{eligible} parts to run, {queued} in queue and {executing} running.".format(
+                **reply.json()["payload"]["completed"]
+            )
         )
         return False, reply
     else:

--- a/flowclient/tests/unit/test_get_status.py
+++ b/flowclient/tests/unit/test_get_status.py
@@ -14,7 +14,10 @@ def test_get_status_reports_running(running_status):
     """ Test that status code 202 is interpreted as query running or queued. """
     con_mock = Mock()
     con_mock.get_url.return_value = Mock(status_code=202)
-    con_mock.get_url.return_value.json.return_value = {"status": running_status}
+    con_mock.get_url.return_value.json.return_value = {
+        "status": running_status,
+        "payload": {"completed": [1, 1]},
+    }
     status = get_status(connection=con_mock, query_id="foo")
     assert status == running_status
 

--- a/flowclient/tests/unit/test_get_status.py
+++ b/flowclient/tests/unit/test_get_status.py
@@ -16,7 +16,7 @@ def test_get_status_reports_running(running_status):
     con_mock.get_url.return_value = Mock(status_code=202)
     con_mock.get_url.return_value.json.return_value = {
         "status": running_status,
-        "payload": {"progress": {"eligible": 0, "queued": 0, "executing": 0}},
+        "progress": {"eligible": 0, "queued": 0, "running": 0},
     }
     status = get_status(connection=con_mock, query_id="foo")
     assert status == running_status

--- a/flowclient/tests/unit/test_get_status.py
+++ b/flowclient/tests/unit/test_get_status.py
@@ -16,7 +16,7 @@ def test_get_status_reports_running(running_status):
     con_mock.get_url.return_value = Mock(status_code=202)
     con_mock.get_url.return_value.json.return_value = {
         "status": running_status,
-        "payload": {"completed": [1, 1]},
+        "payload": {"progress": {"eligible": 0, "queued": 0, "executing": 0}},
     }
     status = get_status(connection=con_mock, query_id="foo")
     assert status == running_status

--- a/flowclient/tests/unit/test_query_ready.py
+++ b/flowclient/tests/unit/test_query_ready.py
@@ -14,6 +14,10 @@ def test_query_ready_reports_false():
     """ Test that status code 202 is interpreted as query running. """
     con_mock = Mock()
     con_mock.get_url.return_value = Mock(status_code=202)
+    con_mock.get_url.return_value.json.return_value = {
+        "status": "completed",
+        "payload": {"completed": [1, 1]},
+    }
     is_ready, reply = query_is_ready(connection=con_mock, query_id="foo")
     assert not is_ready
 

--- a/flowclient/tests/unit/test_query_ready.py
+++ b/flowclient/tests/unit/test_query_ready.py
@@ -16,7 +16,7 @@ def test_query_ready_reports_false():
     con_mock.get_url.return_value = Mock(status_code=202)
     con_mock.get_url.return_value.json.return_value = {
         "status": "completed",
-        "payload": {"completed": [1, 1]},
+        "payload": {"progress": {"eligible": 0, "queued": 0, "executing": 0}},
     }
     is_ready, reply = query_is_ready(connection=con_mock, query_id="foo")
     assert not is_ready

--- a/flowclient/tests/unit/test_query_ready.py
+++ b/flowclient/tests/unit/test_query_ready.py
@@ -16,7 +16,7 @@ def test_query_ready_reports_false():
     con_mock.get_url.return_value = Mock(status_code=202)
     con_mock.get_url.return_value.json.return_value = {
         "status": "completed",
-        "payload": {"progress": {"eligible": 0, "queued": 0, "executing": 0}},
+        "progress": {"eligible": 0, "queued": 0, "running": 0},
     }
     is_ready, reply = query_is_ready(connection=con_mock, query_id="foo")
     assert not is_ready

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -1054,3 +1054,6 @@ class Query(metaclass=ABCMeta):
 
         random_class = random_factory(self.__class__, sampling_method=sampling_method)
         return random_class(query=self, **params)
+
+    def __hash__(self):
+        return hash(self.query_id)

--- a/flowmachine/flowmachine/core/server/action_handlers.py
+++ b/flowmachine/flowmachine/core/server/action_handlers.py
@@ -38,7 +38,7 @@ from .zmq_helpers import ZMQReply
 
 __all__ = ["perform_action"]
 
-from ..dependency_graph import stored_dependencies_ratio
+from ..dependency_graph import query_progress
 
 
 async def action_handler__ping(config: "FlowmachineServerConfig") -> ZMQReply:
@@ -162,7 +162,7 @@ async def action_handler__run_query(
         status="success",
         payload={
             "query_id": query_id,
-            "completed": stored_dependencies_ratio(query_obj._flowmachine_query_obj),
+            "progress": query_progress(query_obj._flowmachine_query_obj),
         },
     )
 
@@ -212,7 +212,7 @@ async def action_handler__poll_query(
             "query_id": query_id,
             "query_kind": query_kind,
             "query_state": q_state_machine.current_query_state,
-            "completed": stored_dependencies_ratio(
+            "progress": query_progress(
                 FlowmachineQuerySchema()
                 .load(QueryInfoLookup(get_redis()).get_query_params(query_id))
                 ._flowmachine_query_obj

--- a/flowmachine/tests/test_dependency_graph.py
+++ b/flowmachine/tests/test_dependency_graph.py
@@ -250,6 +250,6 @@ def test_query_progress(dummy_redis):
     executing_qsm.execute()
 
     nested = DummyQuery(dummy_param=[dummy, stored_dummy, executing_dummy])
-    assert query_progress(nested) == (3, 1, 1)
+    assert query_progress(nested) == dict(eligible=3, running=1, queued=1,)
     nested.store()
-    assert query_progress(nested) == (0, 0, 0)
+    assert query_progress(nested) == dict(eligible=0, running=0, queued=0,)

--- a/flowmachine/tests/test_dependency_graph.py
+++ b/flowmachine/tests/test_dependency_graph.py
@@ -12,7 +12,9 @@ import IPython
 from io import StringIO
 
 from flowmachine.core import CustomQuery, Query
+from flowmachine.core.context import get_db
 from flowmachine.core.dummy_query import DummyQuery
+from flowmachine.core.query_state import QueryStateMachine
 from flowmachine.core.subscriber_subsetter import make_subscriber_subsetter
 from flowmachine.features import daily_location, EventTableSubset
 
@@ -22,9 +24,10 @@ from flowmachine.core.dependency_graph import (
     unstored_dependencies_graph,
     plot_dependency_graph,
     store_queries_in_order,
-    storable_dependencies,
-    stored_dependencies,
-    stored_dependencies_ratio,
+    dependencies_eligible_for_store,
+    queued_dependencies,
+    executing_dependencies,
+    query_progress,
 )
 
 
@@ -169,7 +172,7 @@ def test_store_queries_in_order():
     store_queries_in_order(graph)
 
 
-def test_storable_dependencies():
+def test_dependencies_eligible_for_store():
     """
     Test that the set of only storeable dependencies is returned.
     """
@@ -183,30 +186,70 @@ def test_storable_dependencies():
     unstoreable_dummy = UnStoreableQuery(dummy_param="UNSTOREABLE_DUMMY")
 
     nested = DummyQuery(dummy_param=[dummy, unstoreable_dummy])
-    assert storable_dependencies(nested) == {dummy, nested}
+    assert dependencies_eligible_for_store(nested) == {dummy, nested}
 
 
-def test_stored_dependencies(dummy_redis):
+def test_queued_dependencies(dummy_redis):
     """
-    Test that the set of already stored dependencies is returned.
-    """
-    dummy = DummyQuery(dummy_param="DUMMY")
-    stored_dummy = DummyQuery(dummy_param="STORED_DUMMY")
-    stored_dummy.store()
-
-    nested = DummyQuery(dummy_param=[dummy, stored_dummy])
-    assert stored_dependencies(nested) == {stored_dummy}
-
-
-def test_stored_dependencies_ratio(dummy_redis):
-    """
-    Test correct ratio of stored to unstored dependencies is returned.
+    Test that only queued dependencies are returned.
     """
     dummy = DummyQuery(dummy_param="DUMMY")
+    queued_qsm = QueryStateMachine(dummy_redis, dummy.query_id, get_db().conn_id)
+    queued_qsm.enqueue()
     stored_dummy = DummyQuery(dummy_param="STORED_DUMMY")
     stored_dummy.store()
+    executing_dummy = DummyQuery(dummy_param="EXECUTING_DUMMY")
+    executing_qsm = QueryStateMachine(
+        dummy_redis, executing_dummy.query_id, get_db().conn_id
+    )
+    executing_qsm.enqueue()
+    executing_qsm.execute()
 
-    nested = DummyQuery(dummy_param=[dummy, stored_dummy])
-    assert stored_dependencies_ratio(nested) == (1, 3)
+    nested = DummyQuery(dummy_param=[dummy, stored_dummy, executing_dummy])
+    assert queued_dependencies(set([nested, dummy, stored_dummy, executing_dummy])) == [
+        dummy
+    ]
+
+
+def test_executing_dependencies(dummy_redis):
+    """
+    Test that only executing dependencies are returned.
+    """
+    dummy = DummyQuery(dummy_param="DUMMY")
+    queued_qsm = QueryStateMachine(dummy_redis, dummy.query_id, get_db().conn_id)
+    queued_qsm.enqueue()
+    stored_dummy = DummyQuery(dummy_param="STORED_DUMMY")
+    stored_dummy.store()
+    executing_dummy = DummyQuery(dummy_param="EXECUTING_DUMMY")
+    executing_qsm = QueryStateMachine(
+        dummy_redis, executing_dummy.query_id, get_db().conn_id
+    )
+    executing_qsm.enqueue()
+    executing_qsm.execute()
+
+    nested = DummyQuery(dummy_param=[dummy, stored_dummy, executing_dummy])
+    assert executing_dependencies(
+        set([nested, dummy, stored_dummy, executing_dummy])
+    ) == [executing_dummy]
+
+
+def test_query_progress(dummy_redis):
+    """
+    Test correct counts for dependency progress are returned.
+    """
+    dummy = DummyQuery(dummy_param="DUMMY")
+    queued_qsm = QueryStateMachine(dummy_redis, dummy.query_id, get_db().conn_id)
+    queued_qsm.enqueue()
+    stored_dummy = DummyQuery(dummy_param="STORED_DUMMY")
+    stored_dummy.store()
+    executing_dummy = DummyQuery(dummy_param="EXECUTING_DUMMY")
+    executing_qsm = QueryStateMachine(
+        dummy_redis, executing_dummy.query_id, get_db().conn_id
+    )
+    executing_qsm.enqueue()
+    executing_qsm.execute()
+
+    nested = DummyQuery(dummy_param=[dummy, stored_dummy, executing_dummy])
+    assert query_progress(nested) == (3, 1, 1)
     nested.store()
-    assert stored_dependencies_ratio(nested) == (1, 1)
+    assert query_progress(nested) == (0, 0, 0)

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_json_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_json_spec.approved.txt
@@ -2597,6 +2597,15 @@
               "application/json": {
                 "schema": {
                   "properties": {
+                    "completed": {
+                      "items": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "maxItems": 2,
+                      "minItems": 2,
+                      "type": "array"
+                    },
                     "msg": {
                       "type": "string"
                     },
@@ -2664,6 +2673,27 @@
         },
         "responses": {
           "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "completed": {
+                      "items": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "maxItems": 2,
+                      "minItems": 2,
+                      "type": "array"
+                    },
+                    "query_id": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
             "description": "Request accepted.",
             "headers": {
               "Location": {

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_json_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_json_spec.approved.txt
@@ -2597,17 +2597,22 @@
               "application/json": {
                 "schema": {
                   "properties": {
-                    "completed": {
-                      "items": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "maxItems": 2,
-                      "minItems": 2,
-                      "type": "array"
-                    },
                     "msg": {
                       "type": "string"
+                    },
+                    "progress": {
+                      "schema": {
+                        "eligible": {
+                          "type": "integer"
+                        },
+                        "queued": {
+                          "type": "integer"
+                        },
+                        "running": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
                     },
                     "status": {
                       "enum": [
@@ -2677,14 +2682,19 @@
               "application/json": {
                 "schema": {
                   "properties": {
-                    "completed": {
-                      "items": {
-                        "format": "int32",
-                        "type": "integer"
+                    "progress": {
+                      "schema": {
+                        "eligible": {
+                          "type": "integer"
+                        },
+                        "queued": {
+                          "type": "integer"
+                        },
+                        "running": {
+                          "type": "integer"
+                        }
                       },
-                      "maxItems": 2,
-                      "minItems": 2,
-                      "type": "array"
+                      "type": "object"
                     },
                     "query_id": {
                       "type": "string"

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_yaml_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_yaml_spec.approved.txt
@@ -2597,6 +2597,15 @@
               "application/json": {
                 "schema": {
                   "properties": {
+                    "completed": {
+                      "items": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "maxItems": 2,
+                      "minItems": 2,
+                      "type": "array"
+                    },
                     "msg": {
                       "type": "string"
                     },
@@ -2664,6 +2673,27 @@
         },
         "responses": {
           "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "completed": {
+                      "items": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "maxItems": 2,
+                      "minItems": 2,
+                      "type": "array"
+                    },
+                    "query_id": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
             "description": "Request accepted.",
             "headers": {
               "Location": {

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_yaml_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_yaml_spec.approved.txt
@@ -2597,17 +2597,22 @@
               "application/json": {
                 "schema": {
                   "properties": {
-                    "completed": {
-                      "items": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "maxItems": 2,
-                      "minItems": 2,
-                      "type": "array"
-                    },
                     "msg": {
                       "type": "string"
+                    },
+                    "progress": {
+                      "schema": {
+                        "eligible": {
+                          "type": "integer"
+                        },
+                        "queued": {
+                          "type": "integer"
+                        },
+                        "running": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
                     },
                     "status": {
                       "enum": [
@@ -2677,14 +2682,19 @@
               "application/json": {
                 "schema": {
                   "properties": {
-                    "completed": {
-                      "items": {
-                        "format": "int32",
-                        "type": "integer"
+                    "progress": {
+                      "schema": {
+                        "eligible": {
+                          "type": "integer"
+                        },
+                        "queued": {
+                          "type": "integer"
+                        },
+                        "running": {
+                          "type": "integer"
+                        }
                       },
-                      "maxItems": 2,
-                      "minItems": 2,
-                      "type": "array"
+                      "type": "object"
                     },
                     "query_id": {
                       "type": "string"

--- a/integration_tests/tests/flowmachine_server_tests/test_action_poll_query.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_action_poll_query.py
@@ -22,7 +22,7 @@ def test_poll_existing_query(zmq_port, zmq_host):
     expected_reply = {
         "status": "success",
         "msg": "",
-        "payload": {"query_id": expected_query_id},
+        "payload": {"completed": [1, 1], "query_id": expected_query_id},
     }
     assert expected_reply == reply
 
@@ -42,6 +42,7 @@ def test_poll_existing_query(zmq_port, zmq_host):
             "query_id": expected_query_id,
             "query_kind": "dummy_query",
             "query_state": "completed",
+            "completed": [1, 1],
         },
     }
     assert expected_reply == reply

--- a/integration_tests/tests/flowmachine_server_tests/test_action_poll_query.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_action_poll_query.py
@@ -22,7 +22,10 @@ def test_poll_existing_query(zmq_port, zmq_host):
     expected_reply = {
         "status": "success",
         "msg": "",
-        "payload": {"completed": [1, 1], "query_id": expected_query_id},
+        "payload": {
+            "progress": {"eligible": 0, "queued": 0, "running": 0},
+            "query_id": expected_query_id,
+        },
     }
     assert expected_reply == reply
 
@@ -42,7 +45,7 @@ def test_poll_existing_query(zmq_port, zmq_host):
             "query_id": expected_query_id,
             "query_kind": "dummy_query",
             "query_state": "completed",
-            "completed": [1, 1],
+            "progress": {"eligible": 0, "queued": 0, "running": 0},
         },
     }
     assert expected_reply == reply

--- a/integration_tests/tests/flowmachine_server_tests/test_server.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.py
@@ -125,7 +125,7 @@ def test_run_daily_location_query(zmq_host, zmq_port):
 
     assert "success" == reply["status"]
     assert expected_query_id == reply["payload"]["query_id"]
-    assert ["query_id"] == list(reply["payload"].keys())
+    assert ["query_id", "completed"] == list(reply["payload"].keys())
 
     # FIXME: At the moment we have to explicitly wait for all running queries
     # to finish before finishing the test, otherwise unexpected behaviour may
@@ -189,7 +189,7 @@ def test_run_modal_location_query(zmq_host, zmq_port):
 
     assert "success" == reply["status"]
     assert expected_query_id == reply["payload"]["query_id"]
-    assert ["query_id"] == list(reply["payload"].keys())
+    assert ["query_id", "completed"] == list(reply["payload"].keys())
 
     # FIXME: At the moment we have to explicitly wait for all running queries
     # to finish before finishing the test, otherwise unexpected behaviour may
@@ -225,7 +225,7 @@ def test_run_dfs_metric_total_amount_query(zmq_host, zmq_port):
 
     assert "success" == reply["status"]
     assert expected_query_id == reply["payload"]["query_id"]
-    assert ["query_id"] == list(reply["payload"].keys())
+    assert ["query_id", "completed"] == list(reply["payload"].keys())
 
     # FIXME: At the moment we have to explicitly wait for all running queries
     # to finish before finishing the test, otherwise unexpected behaviour may

--- a/integration_tests/tests/flowmachine_server_tests/test_server.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.py
@@ -125,7 +125,7 @@ def test_run_daily_location_query(zmq_host, zmq_port):
 
     assert "success" == reply["status"]
     assert expected_query_id == reply["payload"]["query_id"]
-    assert ["query_id", "completed"] == list(reply["payload"].keys())
+    assert ["query_id", "progress"] == list(reply["payload"].keys())
 
     # FIXME: At the moment we have to explicitly wait for all running queries
     # to finish before finishing the test, otherwise unexpected behaviour may
@@ -189,7 +189,7 @@ def test_run_modal_location_query(zmq_host, zmq_port):
 
     assert "success" == reply["status"]
     assert expected_query_id == reply["payload"]["query_id"]
-    assert ["query_id", "completed"] == list(reply["payload"].keys())
+    assert ["query_id", "progress"] == list(reply["payload"].keys())
 
     # FIXME: At the moment we have to explicitly wait for all running queries
     # to finish before finishing the test, otherwise unexpected behaviour may
@@ -225,7 +225,7 @@ def test_run_dfs_metric_total_amount_query(zmq_host, zmq_port):
 
     assert "success" == reply["status"]
     assert expected_query_id == reply["payload"]["query_id"]
-    assert ["query_id", "completed"] == list(reply["payload"].keys())
+    assert ["query_id", "progress"] == list(reply["payload"].keys())
 
     # FIXME: At the moment we have to explicitly wait for all running queries
     # to finish before finishing the test, otherwise unexpected behaviour may


### PR DESCRIPTION
Closes #1202

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Adds supplementary information to poll and run returns, with the number of queries in cache vs number of cacheable subqueries for the query. This is currently written out to info level logging in flowclient, but I imagine we'd want something more apparent as part of #1980

While looking at this, it occurred to me that we'll shortly want to revisit the caching strategy, because it doesn't make sense to set all uncached queries running if they're in a layer below a totally cached one (which is entirely possible if the cache cleanup is working properly).