### PR TITLE
Fix FlowAuth demo data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- Fixed tokens which used the FlowAuth demo data not being accepted by FlowAPI. [#2108](https://github.com/Flowminder/FlowKit/issues/2108)
 
 ### Removed
 

--- a/flowapi/flowapi/permissions.py
+++ b/flowapi/flowapi/permissions.py
@@ -278,7 +278,7 @@ def expand_scopes(*, scopes: List[str]) -> str:
 
     """
     for scope in scopes:
-        parts = scope.split("&")
+        parts = scope.strip().split("&")
         ps = (x.split(",") for x in parts)
         yield from (set(x) for x in product(*ps))
 

--- a/flowauth/backend/flowauth/models.py
+++ b/flowauth/backend/flowauth/models.py
@@ -639,7 +639,7 @@ def make_demodata():
         db.session.add(x)
     # Add some things that you can do
     with open(Path(__file__).parent / "demo_data" / "api_scopes.txt") as fin:
-        caps = fin.readlines()
+        caps = [x.strip() for x in fin.readlines()]
 
     # Add some servers
     test_server = Server(


### PR DESCRIPTION
Closes #2108

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Strips newlines from the flowauth demo scopes, and strips newlines when unpacking tokens as well.