### PR TITLE
Sanitize threadpool env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- FlowMachine server will now ignore values for the `FLOWMACHINE_SERVER_THREADPOOL_SIZE` environment variable which can't be cast to `int`. [#2304](https://github.com/Flowminder/FlowKit/issues/2304)
 
 ### Removed
 

--- a/flowmachine/flowmachine/core/server/server_config.py
+++ b/flowmachine/flowmachine/core/server/server_config.py
@@ -79,7 +79,7 @@ def get_server_config() -> FlowmachineServerConfig:
     try:
         thread_pool_size = int(thread_pool_size)
     except (TypeError, ValueError):
-        pass  # Not an int
+        thread_pool_size = None  # Not an int
 
     return FlowmachineServerConfig(
         port=port,


### PR DESCRIPTION
Closes #2304

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Set server's `thread_pool_size` to `None` if `FLOWMACHINE_SERVER_THREADPOOL_SIZE` can't be cast to int.