### PR TITLE
Flowclient functions for covid19 aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 -   Added new FlowAPI aggregates; `unique_visitor_counts`, `active_at_reference_location_counts`, `unmoving_counts`, `unmoving_at_reference_location_counts`, `trips_od_matrix`, and `consecutive_trips_od_matrix`
 -   Added new Flows type query to FlowAPI `unique_locations`, which produces the paired regional connectivity [COVID-19 indicator](https://github.com/Flowminder/COVID-19/blob/master/aggregate_5.md)
+-   Added FlowClient function `unique_locations_spec`, which can be used on either side of a `flows` query
+-   Added FlowClient functions: `unique_visitor_counts`, `active_at_reference_location_counts`, `unmoving_counts`, `unmoving_at_reference_location_counts`, `trips_od_matrix`, and `consecutive_trips_od_matrix`. [#2333](https://github.com/Flowminder/FlowKit/issues/2333)
 
 ### Changed
 

--- a/flowclient/flowclient/__init__.py
+++ b/flowclient/flowclient/__init__.py
@@ -54,6 +54,7 @@ from .aggregates import (
     histogram_aggregate,
     active_at_reference_location_counts,
     unmoving_at_reference_location_counts,
+    unmoving_counts,
 )
 
 __all__ = [
@@ -98,4 +99,5 @@ __all__ = [
     "active_at_reference_location_counts",
     "unique_locations_spec",
     "unmoving_at_reference_location_counts",
+    "unmoving_counts",
 ]

--- a/flowclient/flowclient/__init__.py
+++ b/flowclient/flowclient/__init__.py
@@ -35,6 +35,7 @@ from .client import (
     nocturnal_events_spec,
     handset_spec,
     random_sample_spec,
+    unique_locations_spec,
 )
 from .api_query import APIQuery
 from . import aggregates
@@ -51,6 +52,7 @@ from .aggregates import (
     spatial_aggregate,
     joined_spatial_aggregate,
     histogram_aggregate,
+    active_at_reference_location_counts,
 )
 
 __all__ = [
@@ -92,4 +94,6 @@ __all__ = [
     "spatial_aggregate",
     "joined_spatial_aggregate",
     "histogram_aggregate",
+    "active_at_reference_location_counts",
+    "unique_locations_spec",
 ]

--- a/flowclient/flowclient/__init__.py
+++ b/flowclient/flowclient/__init__.py
@@ -56,6 +56,7 @@ from .aggregates import (
     unmoving_at_reference_location_counts,
     unmoving_counts,
     consecutive_trips_od_matrix,
+    trips_od_matrix,
 )
 
 __all__ = [
@@ -102,4 +103,5 @@ __all__ = [
     "unmoving_at_reference_location_counts",
     "unmoving_counts",
     "consecutive_trips_od_matrix",
+    "trips_od_matrix",
 ]

--- a/flowclient/flowclient/__init__.py
+++ b/flowclient/flowclient/__init__.py
@@ -55,6 +55,7 @@ from .aggregates import (
     active_at_reference_location_counts,
     unmoving_at_reference_location_counts,
     unmoving_counts,
+    consecutive_trips_od_matrix,
 )
 
 __all__ = [
@@ -100,4 +101,5 @@ __all__ = [
     "unique_locations_spec",
     "unmoving_at_reference_location_counts",
     "unmoving_counts",
+    "consecutive_trips_od_matrix",
 ]

--- a/flowclient/flowclient/__init__.py
+++ b/flowclient/flowclient/__init__.py
@@ -53,6 +53,7 @@ from .aggregates import (
     joined_spatial_aggregate,
     histogram_aggregate,
     active_at_reference_location_counts,
+    unmoving_at_reference_location_counts,
 )
 
 __all__ = [
@@ -96,4 +97,5 @@ __all__ = [
     "histogram_aggregate",
     "active_at_reference_location_counts",
     "unique_locations_spec",
+    "unmoving_at_reference_location_counts",
 ]

--- a/flowclient/flowclient/aggregates.py
+++ b/flowclient/flowclient/aggregates.py
@@ -955,13 +955,53 @@ def spatial_aggregate(*, connection: Connection, **kwargs) -> APIQuery:
     return APIQuery(connection=connection, parameters=spatial_aggregate_spec(**kwargs))
 
 
+def unmoving_counts_spec(
+    *, unique_locations: Dict[str, Union[str, Dict[str, str]]],
+) -> Dict[str, Union[str, Dict[str, str]]]:
+    """
+    A count by location of subscribers who were unmoving at that location.
+
+    Parameters
+    ----------
+    unique_locations : dict
+        unique locations
+
+    Returns
+    -------
+    dict
+        Query specification
+
+    """
+    return dict(query_kind="unmoving_counts", locations=unique_locations,)
+
+
+@merge_args(unmoving_counts_spec)
+def unmoving_counts(*, connection: Connection, **kwargs) -> APIQuery:
+    """
+    A count by location of subscribers who were unmoving in their reference location.
+
+    Parameters
+    ----------
+    connection : Connection
+        FlowKit API connection
+    unique_locations : dict
+        unique locations
+
+    Returns
+    -------
+    APIQuery
+        unmoving_counts query
+    """
+    return APIQuery(connection=connection, parameters=unmoving_counts_spec(**kwargs),)
+
+
 def unmoving_at_reference_location_counts_spec(
     *,
     reference_locations: Dict[str, Union[str, Dict[str, str]]],
     unique_locations: Dict[str, Union[str, Dict[str, str]]],
 ) -> Dict[str, Union[str, Dict[str, str]]]:
     """
-    A count by location of subscribers who where unmoving in their reference location.
+    A count by location of subscribers who were unmoving in their reference location.
 
     Parameters
     ----------
@@ -978,11 +1018,8 @@ def unmoving_at_reference_location_counts_spec(
     """
     return dict(
         query_kind="unmoving_at_reference_location_counts",
-        unmoving_at_reference_location=dict(
-            query_kind="unmoving_at_reference_location",
-            unique_locations=unique_locations,
-            reference_locations=reference_locations,
-        ),
+        unique_locations=unique_locations,
+        reference_locations=reference_locations,
     )
 
 
@@ -991,7 +1028,7 @@ def unmoving_at_reference_location_counts(
     *, connection: Connection, **kwargs
 ) -> APIQuery:
     """
-    A count by location of subscribers who where unmoving in their reference location.
+    A count by location of subscribers who were unmoving in their reference location.
 
     Parameters
     ----------
@@ -1019,7 +1056,7 @@ def active_at_reference_location_counts_spec(
     unique_locations: Dict[str, Union[str, Dict[str, str]]],
 ) -> Dict[str, Union[str, Dict[str, str]]]:
     """
-    A count by location of subscribers who where active in their reference location.
+    A count by location of subscribers who were active in their reference location.
 
     Parameters
     ----------
@@ -1036,11 +1073,8 @@ def active_at_reference_location_counts_spec(
     """
     return dict(
         query_kind="active_at_reference_location_counts",
-        active_at_reference_location=dict(
-            query_kind="active_at_reference_location",
-            unique_locations=unique_locations,
-            reference_locations=reference_locations,
-        ),
+        unique_locations=unique_locations,
+        reference_locations=reference_locations,
     )
 
 
@@ -1049,7 +1083,7 @@ def active_at_reference_location_counts(
     *, connection: Connection, **kwargs
 ) -> APIQuery:
     """
-    A count by location of subscribers who where active in their reference location.
+    A count by location of subscribers who were active in their reference location.
 
     Parameters
     ----------

--- a/flowclient/flowclient/aggregates.py
+++ b/flowclient/flowclient/aggregates.py
@@ -955,6 +955,64 @@ def spatial_aggregate(*, connection: Connection, **kwargs) -> APIQuery:
     return APIQuery(connection=connection, parameters=spatial_aggregate_spec(**kwargs))
 
 
+def active_at_reference_location_counts_spec(
+    *,
+    reference_locations: Dict[str, Union[str, Dict[str, str]]],
+    unique_locations: Dict[str, Union[str, Dict[str, str]]],
+) -> Dict[str, Union[str, Dict[str, str]]]:
+    """
+    A count by location of subscribers who where active in their reference location.
+
+    Parameters
+    ----------
+    reference_locations : dict
+        Modal or daily location
+    unique_locations : dict
+        unique locations
+
+    Returns
+    -------
+    dict
+        Query specification
+
+    """
+    return dict(
+        query_kind="active_at_reference_location_counts",
+        active_at_reference_location=dict(
+            query_kind="active_at_reference_location",
+            unique_locations=unique_locations,
+            reference_locations=reference_locations,
+        ),
+    )
+
+
+@merge_args(active_at_reference_location_counts_spec)
+def active_at_reference_location_counts(
+    *, connection: Connection, **kwargs
+) -> APIQuery:
+    """
+    A count by location of subscribers who where active in their reference location.
+
+    Parameters
+    ----------
+    connection : Connection
+        FlowKit API connection
+    reference_locations : dict
+        Modal or daily location
+    unique_locations : dict
+        unique locations
+
+    Returns
+    -------
+    APIQuery
+        active_at_reference_location_counts query
+    """
+    return APIQuery(
+        connection=connection,
+        parameters=active_at_reference_location_counts_spec(**kwargs),
+    )
+
+
 def joined_spatial_aggregate_spec(
     *,
     locations: Dict[str, Union[str, Dict[str, str]]],

--- a/flowclient/flowclient/aggregates.py
+++ b/flowclient/flowclient/aggregates.py
@@ -1019,6 +1019,68 @@ def consecutive_trips_od_matrix(*, connection: Connection, **kwargs) -> APIQuery
     )
 
 
+def trips_od_matrix_spec(
+    *,
+    start_date: str,
+    end_date: str,
+    aggregation_unit: str,
+    subscriber_subset: Union[dict, None] = None,
+) -> Dict[str, Union[str, Dict[str, str]]]:
+    """
+    Retrieves the count of subscriber who made visits between locations
+
+    Parameters
+    ----------
+    start_date, end_date : str
+        ISO format dates between which to find trips, e.g. "2016-01-01"
+    aggregation_unit : str
+        Unit of aggregation, e.g. "admin3"
+    subscriber_subset : dict or None
+        Subset of subscribers to retrieve trips for. Must be None
+        (= all subscribers) or a dictionary with the specification of a
+        subset query.
+
+    Returns
+    -------
+    dict
+        trips od matrix query specification.
+
+    """
+    return dict(
+        query_kind="trips_od_matrix",
+        start_date=start_date,
+        end_date=end_date,
+        aggregation_unit=aggregation_unit,
+        subscriber_subset=subscriber_subset,
+    )
+
+
+@merge_args(trips_od_matrix_spec)
+def trips_od_matrix(*, connection: Connection, **kwargs) -> APIQuery:
+    """
+    Retrieves the count of subscriber who made visits between locations
+
+    Parameters
+    ----------
+    connection : Connection
+        FlowKit API connection
+    start_date, end_date : str
+        ISO format dates between which to find trips, e.g. "2016-01-01"
+    aggregation_unit : str
+        Unit of aggregation, e.g. "admin3"
+    subscriber_subset : dict or None
+        Subset of subscribers to retrieve trips for. Must be None
+        (= all subscribers) or a dictionary with the specification of a
+        subset query.
+
+    Returns
+    -------
+    APIQuery
+        trips_od_matrix query
+    """
+    return APIQuery(connection=connection, parameters=trips_od_matrix_spec(**kwargs),)
+
+
 def unmoving_counts_spec(
     *, unique_locations: Dict[str, Union[str, Dict[str, str]]],
 ) -> Dict[str, Union[str, Dict[str, str]]]:

--- a/flowclient/flowclient/aggregates.py
+++ b/flowclient/flowclient/aggregates.py
@@ -955,6 +955,70 @@ def spatial_aggregate(*, connection: Connection, **kwargs) -> APIQuery:
     return APIQuery(connection=connection, parameters=spatial_aggregate_spec(**kwargs))
 
 
+def consecutive_trips_od_matrix_spec(
+    *,
+    start_date: str,
+    end_date: str,
+    aggregation_unit: str,
+    subscriber_subset: Union[dict, None] = None,
+) -> Dict[str, Union[str, Dict[str, str]]]:
+    """
+    Retrieves the count of subscriber who made consecutive visits between locations
+
+    Parameters
+    ----------
+    start_date, end_date : str
+        ISO format dates between which to find trips, e.g. "2016-01-01"
+    aggregation_unit : str
+        Unit of aggregation, e.g. "admin3"
+    subscriber_subset : dict or None
+        Subset of subscribers to retrieve trips for. Must be None
+        (= all subscribers) or a dictionary with the specification of a
+        subset query.
+
+    Returns
+    -------
+    dict
+        Consecutive trips od matrix query specification.
+
+    """
+    return dict(
+        query_kind="consecutive_trips_od_matrix",
+        start_date=start_date,
+        end_date=end_date,
+        aggregation_unit=aggregation_unit,
+        subscriber_subset=subscriber_subset,
+    )
+
+
+@merge_args(consecutive_trips_od_matrix_spec)
+def consecutive_trips_od_matrix(*, connection: Connection, **kwargs) -> APIQuery:
+    """
+    Retrieves the count of subscriber who made consecutive visits between locations
+
+    Parameters
+    ----------
+    connection : Connection
+        FlowKit API connection
+    start_date, end_date : str
+        ISO format dates between which to find trips, e.g. "2016-01-01"
+    aggregation_unit : str
+        Unit of aggregation, e.g. "admin3"
+    subscriber_subset : dict or None
+        Subset of subscribers to retrieve trips for. Must be None
+        (= all subscribers) or a dictionary with the specification of a
+        subset query.
+
+    Returns
+    -------
+    APIQuery
+        consecutive_trips_od_matrix query
+    """
+    return APIQuery(
+        connection=connection, parameters=consecutive_trips_od_matrix_spec(**kwargs),
+    )
+
+
 def unmoving_counts_spec(
     *, unique_locations: Dict[str, Union[str, Dict[str, str]]],
 ) -> Dict[str, Union[str, Dict[str, str]]]:

--- a/flowclient/flowclient/aggregates.py
+++ b/flowclient/flowclient/aggregates.py
@@ -955,6 +955,64 @@ def spatial_aggregate(*, connection: Connection, **kwargs) -> APIQuery:
     return APIQuery(connection=connection, parameters=spatial_aggregate_spec(**kwargs))
 
 
+def unmoving_at_reference_location_counts_spec(
+    *,
+    reference_locations: Dict[str, Union[str, Dict[str, str]]],
+    unique_locations: Dict[str, Union[str, Dict[str, str]]],
+) -> Dict[str, Union[str, Dict[str, str]]]:
+    """
+    A count by location of subscribers who where unmoving in their reference location.
+
+    Parameters
+    ----------
+    reference_locations : dict
+        Modal or daily location
+    unique_locations : dict
+        unique locations
+
+    Returns
+    -------
+    dict
+        Query specification
+
+    """
+    return dict(
+        query_kind="unmoving_at_reference_location_counts",
+        unmoving_at_reference_location=dict(
+            query_kind="unmoving_at_reference_location",
+            unique_locations=unique_locations,
+            reference_locations=reference_locations,
+        ),
+    )
+
+
+@merge_args(unmoving_at_reference_location_counts_spec)
+def unmoving_at_reference_location_counts(
+    *, connection: Connection, **kwargs
+) -> APIQuery:
+    """
+    A count by location of subscribers who where unmoving in their reference location.
+
+    Parameters
+    ----------
+    connection : Connection
+        FlowKit API connection
+    reference_locations : dict
+        Modal or daily location
+    unique_locations : dict
+        unique locations
+
+    Returns
+    -------
+    APIQuery
+        unmoving_at_reference_location_counts query
+    """
+    return APIQuery(
+        connection=connection,
+        parameters=unmoving_at_reference_location_counts_spec(**kwargs),
+    )
+
+
 def active_at_reference_location_counts_spec(
     *,
     reference_locations: Dict[str, Union[str, Dict[str, str]]],

--- a/flowclient/flowclient/aggregates.py
+++ b/flowclient/flowclient/aggregates.py
@@ -1104,7 +1104,7 @@ def unmoving_counts_spec(
 @merge_args(unmoving_counts_spec)
 def unmoving_counts(*, connection: Connection, **kwargs) -> APIQuery:
     """
-    A count by location of subscribers who were unmoving in their reference location.
+    A count by location of subscribers who were unmoving at that location.
 
     Parameters
     ----------

--- a/flowclient/flowclient/aggregates.py
+++ b/flowclient/flowclient/aggregates.py
@@ -1082,7 +1082,7 @@ def unmoving_at_reference_location_counts_spec(
     """
     return dict(
         query_kind="unmoving_at_reference_location_counts",
-        unique_locations=unique_locations,
+        locations=unique_locations,
         reference_locations=reference_locations,
     )
 

--- a/flowclient/flowclient/client.py
+++ b/flowclient/flowclient/client.py
@@ -741,7 +741,7 @@ def unique_locations_spec(
     subscriber_subset: Union[dict, None] = None,
 ) -> dict:
     """
-    Subscriber level query which retrives the unique set of locations visited by each subscriber
+    Subscriber level query which retrieves the unique set of locations visited by each subscriber
     in the time period.
 
     Parameters

--- a/flowclient/flowclient/client.py
+++ b/flowclient/flowclient/client.py
@@ -733,6 +733,43 @@ def run_query(*, connection: Connection, query_spec: dict) -> str:
         )
 
 
+def unique_locations_spec(
+    *,
+    start_date: str,
+    end_date: str,
+    aggregation_unit: str,
+    subscriber_subset: Union[dict, None] = None,
+) -> dict:
+    """
+    Subscriber level query which retrives the unique set of locations visited by each subscriber
+    in the time period.
+
+    Parameters
+    ----------
+    start_date, end_date : str
+        ISO format dates between which to get unique locations, e.g. "2016-01-01"
+    aggregation_unit : str
+        Unit of aggregation, e.g. "admin3"
+    subscriber_subset : dict or None
+        Subset of subscribers to retrieve daily locations for. Must be None
+        (= all subscribers) or a dictionary with the specification of a
+        subset query.
+
+    Returns
+    -------
+    dict
+        Unique locations query specification.
+
+    """
+    return dict(
+        query_kind="unique_locations",
+        start_date=start_date,
+        end_date=end_date,
+        aggregation_unit=aggregation_unit,
+        subscriber_subset=subscriber_subset,
+    )
+
+
 def daily_location_spec(
     *,
     date: str,

--- a/integration_tests/tests/query_tests/test_queries.py
+++ b/integration_tests/tests/query_tests/test_queries.py
@@ -1,7 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+from functools import partial
 
 import geojson
 import flowclient
@@ -11,590 +11,469 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "query_kind, params",
+    "query",
     [
-        (
-            "spatial_aggregate",
-            {
-                "locations": {
-                    "query_kind": "daily_location",
-                    "date": "2016-01-01",
-                    "aggregation_unit": "admin3",
-                    "method": "last",
-                }
-            },
-        ),
-        (
-            "spatial_aggregate",
-            {
-                "locations": {
-                    "query_kind": "daily_location",
-                    "date": "2016-01-01",
-                    "aggregation_unit": "admin3",
-                    "method": "most-common",
-                    "subscriber_subset": None,
-                }
-            },
-        ),
-        (
-            "unique_subscriber_counts",
-            {
-                "start_date": "2016-01-01",
-                "end_date": "2016-01-02",
-                "aggregation_unit": "admin3",
-            },
-        ),
-        (
-            "total_network_objects",
-            {
-                "start_date": "2016-01-01",
-                "end_date": "2016-01-02",
-                "aggregation_unit": "admin3",
-            },
-        ),
-        (
-            "total_network_objects",
-            {
-                "start_date": "2016-01-01",
-                "end_date": "2016-01-02",
-                "aggregation_unit": "admin3",
-                "total_by": "day",
-            },
-        ),
-        (
-            "location_introversion",
-            {
-                "start_date": "2016-01-01",
-                "end_date": "2016-01-02",
-                "aggregation_unit": "admin3",
-            },
-        ),
-        (
-            "location_introversion",
-            {
-                "start_date": "2016-01-01",
-                "end_date": "2016-01-02",
-                "aggregation_unit": "admin3",
-                "direction": "in",
-            },
-        ),
-        (
-            "aggregate_network_objects",
-            {
-                "total_network_objects": {
-                    "query_kind": "total_network_objects",
-                    "start_date": "2016-01-01",
-                    "end_date": "2016-01-02",
-                    "aggregation_unit": "admin3",
-                },
-                "statistic": "median",
-                "aggregate_by": "day",
-            },
-        ),
-        (
-            "joined_spatial_aggregate",
-            {
-                "locations": {
-                    "query_kind": "daily_location",
-                    "date": "2016-01-01",
-                    "aggregation_unit": "admin3",
-                    "method": "last",
-                },
-                "metric": {
-                    "query_kind": "radius_of_gyration",
-                    "start_date": "2016-01-01",
-                    "end_date": "2016-01-02",
-                },
-            },
-        ),
-        (
-            "joined_spatial_aggregate",
-            {
-                "locations": flowclient.daily_location_spec(
-                    date="2016-01-01", aggregation_unit="admin3", method="last"
-                ),
-                "metric": flowclient.radius_of_gyration_spec(
-                    start_date="2016-01-01", end_date="2016-01-02"
-                ),
-            },
-        ),
-        (
-            "joined_spatial_aggregate",
-            {
-                "locations": flowclient.daily_location_spec(
-                    date="2016-01-01", aggregation_unit="admin3", method="last"
-                ),
-                "metric": flowclient.nocturnal_events_spec(
-                    start="2016-01-01", stop="2016-01-02", hours=(20, 4)
-                ),
-            },
-        ),
-        (
-            "joined_spatial_aggregate",
-            {
-                "locations": flowclient.daily_location_spec(
-                    date="2016-01-01", aggregation_unit="admin3", method="last"
-                ),
-                "metric": flowclient.subscriber_degree_spec(
-                    start="2016-01-01", stop="2016-01-02", direction="both"
-                ),
-            },
-        ),
-        (
-            "joined_spatial_aggregate",
-            {
-                "locations": flowclient.daily_location_spec(
-                    date="2016-01-01", aggregation_unit="admin3", method="last"
-                ),
-                "metric": flowclient.unique_location_counts_spec(
-                    start_date="2016-01-01",
-                    end_date="2016-01-02",
-                    aggregation_unit="admin3",
-                ),
-            },
-        ),
-        (
-            "joined_spatial_aggregate",
-            {
-                "locations": flowclient.daily_location_spec(
-                    date="2016-01-01", aggregation_unit="admin3", method="last"
-                ),
-                "metric": flowclient.topup_amount_spec(
-                    start="2016-01-01", stop="2016-01-02", statistic="avg"
-                ),
-            },
-        ),
-        (
-            "joined_spatial_aggregate",
-            {
-                "locations": flowclient.daily_location_spec(
-                    date="2016-01-01", aggregation_unit="admin3", method="last"
-                ),
-                "metric": flowclient.event_count_spec(
-                    start="2016-01-01",
-                    stop="2016-01-02",
-                    direction="both",
-                    event_types=["sms", "calls"],
-                ),
-            },
-        ),
-        (
-            "joined_spatial_aggregate",
-            {
-                "locations": flowclient.daily_location_spec(
-                    date="2016-01-01", aggregation_unit="admin3", method="last"
-                ),
-                "metric": flowclient.displacement_spec(
-                    start="2016-01-01",
-                    stop="2016-01-02",
-                    statistic="avg",
-                    reference_location=flowclient.daily_location_spec(
-                        date="2016-01-01", aggregation_unit="lon-lat", method="last"
-                    ),
-                ),
-            },
-        ),
-        (
-            "joined_spatial_aggregate",
-            {
-                "locations": flowclient.daily_location_spec(
-                    date="2016-01-01", aggregation_unit="admin3", method="last"
-                ),
-                "metric": flowclient.pareto_interactions_spec(
-                    start="2016-01-01", stop="2016-01-02", proportion="0.8"
-                ),
-            },
-        ),
-        (
-            "spatial_aggregate",
-            {
-                "locations": flowclient.modal_location_from_dates_spec(
-                    start_date="2016-01-01",
-                    end_date="2016-01-03",
-                    aggregation_unit="admin3",
-                    method="last",
-                )
-            },
-        ),
-        (
-            "spatial_aggregate",
-            {
-                "locations": {
-                    "query_kind": "modal_location",
-                    "locations": [
-                        {
-                            "query_kind": "daily_location",
-                            "date": "2016-01-01",
-                            "aggregation_unit": "admin3",
-                            "method": "last",
-                        },
-                        {
-                            "query_kind": "daily_location",
-                            "date": "2016-01-02",
-                            "aggregation_unit": "admin3",
-                            "method": "last",
-                        },
-                    ],
-                }
-            },
-        ),
-        (
-            "flows",
-            {
-                "from_location": {
-                    "query_kind": "daily_location",
-                    "date": "2016-01-01",
-                    "aggregation_unit": "admin3",
-                    "method": "last",
-                },
-                "to_location": {
-                    "query_kind": "daily_location",
-                    "date": "2016-01-04",
-                    "aggregation_unit": "admin3",
-                    "method": "last",
-                },
-            },
-        ),
-        (
-            "flows",
-            {
-                "from_location": {
-                    "query_kind": "modal_location",
-                    "locations": [
-                        {
-                            "query_kind": "daily_location",
-                            "date": "2016-01-01",
-                            "aggregation_unit": "admin3",
-                            "method": "last",
-                        },
-                        {
-                            "query_kind": "daily_location",
-                            "date": "2016-01-02",
-                            "aggregation_unit": "admin3",
-                            "method": "last",
-                        },
-                    ],
-                },
-                "to_location": {
-                    "query_kind": "daily_location",
-                    "date": "2016-01-04",
-                    "aggregation_unit": "admin3",
-                    "method": "last",
-                },
-            },
-        ),
-        (
-            "meaningful_locations_aggregate",
-            {
-                "start_date": "2016-01-01",
-                "end_date": "2016-01-02",
-                "aggregation_unit": "admin1",
-                "label": "unknown",
-                "tower_hour_of_day_scores": [
-                    -1,
-                    -1,
-                    -1,
-                    -1,
-                    -1,
-                    -1,
-                    -1,
-                    0,
-                    0,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    0,
-                    0,
-                    0,
-                    0,
-                    -1,
-                    -1,
-                    -1,
-                ],
-                "tower_day_of_week_scores": {
-                    "monday": 1,
-                    "tuesday": 1,
-                    "wednesday": 1,
-                    "thursday": 0,
-                    "friday": -1,
-                    "saturday": -1,
-                    "sunday": -1,
-                },
-                "labels": {
-                    "evening": {
-                        "type": "Polygon",
-                        "coordinates": [
-                            [[1e-06, -0.5], [1e-06, -1.1], [1.1, -1.1], [1.1, -0.5]]
-                        ],
-                    },
-                    "day": {
-                        "type": "Polygon",
-                        "coordinates": [
-                            [[-1.1, -0.5], [-1.1, 0.5], [-1e-06, 0.5], [0, -0.5]]
-                        ],
-                    },
-                },
-            },
-        ),
-        (
-            "meaningful_locations_between_label_od_matrix",
-            {
-                "start_date": "2016-01-01",
-                "end_date": "2016-01-02",
-                "aggregation_unit": "admin1",
-                "label_a": "unknown",
-                "label_b": "evening",
-                "tower_hour_of_day_scores": [
-                    -1,
-                    -1,
-                    -1,
-                    -1,
-                    -1,
-                    -1,
-                    -1,
-                    0,
-                    0,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    0,
-                    0,
-                    0,
-                    0,
-                    -1,
-                    -1,
-                    -1,
-                ],
-                "tower_day_of_week_scores": {
-                    "monday": 1,
-                    "tuesday": 1,
-                    "wednesday": 1,
-                    "thursday": 0,
-                    "friday": -1,
-                    "saturday": -1,
-                    "sunday": -1,
-                },
-                "labels": {
-                    "evening": {
-                        "type": "Polygon",
-                        "coordinates": [
-                            [[1e-06, -0.5], [1e-06, -1.1], [1.1, -1.1], [1.1, -0.5]]
-                        ],
-                    },
-                    "day": {
-                        "type": "Polygon",
-                        "coordinates": [
-                            [[-1.1, -0.5], [-1.1, 0.5], [-1e-06, 0.5], [0, -0.5]]
-                        ],
-                    },
-                },
-            },
-        ),
-        (
-            "location_event_counts",
-            {
-                "start_date": "2016-01-01",
-                "end_date": "2016-01-02",
-                "count_interval": "day",
-                "aggregation_unit": "admin3",
-                "direction": "both",
-                "event_types": ["calls", "sms"],
-                "subscriber_subset": None,
-            },
-        ),
-        (
-            "location_event_counts",
-            {
-                "start_date": "2016-01-01",
-                "end_date": "2016-01-02",
-                "count_interval": "day",
-                "aggregation_unit": "admin3",
-                "direction": "both",
-                "event_types": None,
-                "subscriber_subset": None,
-            },
-        ),
-        (
-            "meaningful_locations_between_dates_od_matrix",
-            {
-                "start_date_a": "2016-01-01",
-                "end_date_a": "2016-01-02",
-                "start_date_b": "2016-01-01",
-                "end_date_b": "2016-01-05",
-                "aggregation_unit": "admin1",
-                "tower_hour_of_day_scores": [
-                    -1,
-                    -1,
-                    -1,
-                    -1,
-                    -1,
-                    -1,
-                    -1,
-                    0,
-                    0,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    0,
-                    0,
-                    0,
-                    0,
-                    -1,
-                    -1,
-                    -1,
-                ],
-                "tower_day_of_week_scores": {
-                    "monday": 1,
-                    "tuesday": 1,
-                    "wednesday": 1,
-                    "thursday": 0,
-                    "friday": -1,
-                    "saturday": -1,
-                    "sunday": -1,
-                },
-                "label": "unknown",
-                "labels": {
-                    "evening": {
-                        "type": "Polygon",
-                        "coordinates": [
-                            [[1e-06, -0.5], [1e-06, -1.1], [1.1, -1.1], [1.1, -0.5]]
-                        ],
-                    },
-                    "day": {
-                        "type": "Polygon",
-                        "coordinates": [
-                            [[-1.1, -0.5], [-1.1, 0.5], [-1e-06, 0.5], [0, -0.5]]
-                        ],
-                    },
-                },
-            },
-        ),
-        (
-            "joined_spatial_aggregate",
-            {
-                "locations": {
-                    "query_kind": "daily_location",
-                    "date": "2016-01-01",
-                    "aggregation_unit": "admin3",
-                    "method": "last",
-                },
-                "metric": {
-                    "query_kind": "topup_balance",
-                    "start_date": "2016-01-01",
-                    "end_date": "2016-01-02",
-                    "statistic": "avg",
-                },
-            },
-        ),
-        (
-            "joined_spatial_aggregate",
-            {
-                "locations": flowclient.daily_location_spec(
-                    date="2016-01-01", aggregation_unit="admin3", method="last"
-                ),
-                "metric": flowclient.topup_balance_spec(
-                    start_date="2016-01-01", end_date="2016-01-02", statistic="avg"
-                ),
-            },
-        ),
-        (
-            "joined_spatial_aggregate",
-            {
-                "locations": {
-                    "query_kind": "daily_location",
-                    "date": "2016-01-01",
-                    "aggregation_unit": "admin3",
-                    "method": "last",
-                },
-                "metric": {
-                    "query_kind": "handset",
-                    "start_date": "2016-01-01",
-                    "end_date": "2016-01-02",
-                    "characteristic": "hnd_type",
-                    "method": "last",
-                },
-                "method": "distr",
-            },
-        ),
-        (
-            "joined_spatial_aggregate",
-            {
-                "locations": flowclient.daily_location_spec(
-                    date="2016-01-01", aggregation_unit="admin3", method="last"
-                ),
-                "metric": flowclient.handset_spec(
-                    start_date="2016-01-01",
-                    end_date="2016-01-02",
-                    characteristic="brand",
-                    method="last",
-                ),
-                "method": "distr",
-            },
-        ),
-        (
-            "spatial_aggregate",
-            {
-                "locations": flowclient.random_sample_spec(
-                    query=flowclient.daily_location_spec(
-                        date="2016-01-01",
-                        aggregation_unit="admin3",
-                        method="most-common",
-                    ),
-                    size=10,
-                    seed=0.5,
-                )
-            },
-        ),
-        (
-            "spatial_aggregate",
-            {
-                "locations": flowclient.random_sample_spec(
-                    query=flowclient.daily_location_spec(
-                        date="2016-01-01",
-                        aggregation_unit="admin3",
-                        method="most-common",
-                    ),
-                    sampling_method="bernoulli",
-                    fraction=0.5,
-                    estimate_count=False,
-                    seed=0.2,
-                )
-            },
-        ),
-        (
-            "histogram_aggregate",
-            dict(
-                metric=flowclient.event_count_spec(
-                    start="2016-01-01", stop="2016-01-02"
-                ),
-                bins=5,
+        partial(
+            flowclient.spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last",
             ),
         ),
+        partial(
+            flowclient.spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01",
+                aggregation_unit="admin3",
+                method="most-common",
+                subscriber_subset=None,
+            ),
+        ),
+        partial(
+            flowclient.unique_subscriber_counts,
+            start_date="2016-01-01",
+            end_date="2016-01-02",
+            aggregation_unit="admin3",
+        ),
+        partial(
+            flowclient.total_network_objects,
+            start_date="2016-01-01",
+            end_date="2016-01-02",
+            aggregation_unit="admin3",
+        ),
+        partial(
+            flowclient.total_network_objects,
+            start_date="2016-01-01",
+            end_date="2016-01-02",
+            aggregation_unit="admin3",
+            total_by="day",
+        ),
+        partial(
+            flowclient.location_introversion,
+            start_date="2016-01-01",
+            end_date="2016-01-02",
+            aggregation_unit="admin3",
+        ),
+        partial(
+            flowclient.location_introversion,
+            start_date="2016-01-01",
+            end_date="2016-01-02",
+            aggregation_unit="admin3",
+            direction="in",
+        ),
+        partial(
+            flowclient.aggregate_network_objects,
+            total_network_objects=flowclient.aggregates.total_network_objects_spec(
+                start_date="2016-01-01",
+                end_date="2016-01-02",
+                aggregation_unit="admin3",
+            ),
+            statistic="median",
+            aggregate_by="day",
+        ),
+        partial(
+            flowclient.joined_spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last",
+            ),
+            metric=flowclient.radius_of_gyration_spec(
+                start_date="2016-01-01", end_date="2016-01-02",
+            ),
+        ),
+        partial(
+            flowclient.joined_spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last"
+            ),
+            metric=flowclient.radius_of_gyration_spec(
+                start_date="2016-01-01", end_date="2016-01-02"
+            ),
+        ),
+        partial(
+            flowclient.joined_spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last"
+            ),
+            metric=flowclient.nocturnal_events_spec(
+                start="2016-01-01", stop="2016-01-02", hours=(20, 4)
+            ),
+        ),
+        partial(
+            flowclient.joined_spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last"
+            ),
+            metric=flowclient.subscriber_degree_spec(
+                start="2016-01-01", stop="2016-01-02", direction="both"
+            ),
+        ),
+        partial(
+            flowclient.joined_spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last"
+            ),
+            metric=flowclient.unique_location_counts_spec(
+                start_date="2016-01-01",
+                end_date="2016-01-02",
+                aggregation_unit="admin3",
+            ),
+        ),
+        partial(
+            flowclient.joined_spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last"
+            ),
+            metric=flowclient.topup_amount_spec(
+                start="2016-01-01", stop="2016-01-02", statistic="avg"
+            ),
+        ),
+        partial(
+            flowclient.joined_spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last"
+            ),
+            metric=flowclient.event_count_spec(
+                start="2016-01-01",
+                stop="2016-01-02",
+                direction="both",
+                event_types=["sms", "calls"],
+            ),
+        ),
+        partial(
+            flowclient.joined_spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last"
+            ),
+            metric=flowclient.displacement_spec(
+                start="2016-01-01",
+                stop="2016-01-02",
+                statistic="avg",
+                reference_location=flowclient.daily_location_spec(
+                    date="2016-01-01", aggregation_unit="lon-lat", method="last"
+                ),
+            ),
+        ),
+        partial(
+            flowclient.joined_spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last"
+            ),
+            metric=flowclient.pareto_interactions_spec(
+                start="2016-01-01", stop="2016-01-02", proportion="0.8"
+            ),
+        ),
+        partial(
+            flowclient.spatial_aggregate,
+            locations=flowclient.modal_location_from_dates_spec(
+                start_date="2016-01-01",
+                end_date="2016-01-03",
+                aggregation_unit="admin3",
+                method="last",
+            ),
+        ),
+        partial(
+            flowclient.spatial_aggregate,
+            locations=flowclient.modal_location_spec(
+                locations=[
+                    flowclient.daily_location_spec(
+                        date="2016-01-01", aggregation_unit="admin3", method="last",
+                    ),
+                    flowclient.daily_location_spec(
+                        date="2016-01-02", aggregation_unit="admin3", method="last",
+                    ),
+                ],
+            ),
+        ),
+        partial(
+            flowclient.flows,
+            from_location=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last",
+            ),
+            to_location=flowclient.daily_location_spec(
+                date="2016-01-04", aggregation_unit="admin3", method="last",
+            ),
+        ),
+        partial(
+            flowclient.flows,
+            from_location=flowclient.modal_location_spec(
+                locations=[
+                    flowclient.daily_location_spec(
+                        date="2016-01-01", aggregation_unit="admin3", method="last",
+                    ),
+                    flowclient.daily_location_spec(
+                        date="2016-01-02", aggregation_unit="admin3", method="last",
+                    ),
+                ],
+            ),
+            to_location=flowclient.daily_location_spec(
+                date="2016-01-04", aggregation_unit="admin3", method="last",
+            ),
+        ),
+        partial(
+            flowclient.meaningful_locations_aggregate,
+            start_date="2016-01-01",
+            end_date="2016-01-02",
+            aggregation_unit="admin1",
+            label="unknown",
+            tower_hour_of_day_scores=[
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                0,
+                0,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                0,
+                0,
+                0,
+                0,
+                -1,
+                -1,
+                -1,
+            ],
+            tower_day_of_week_scores=dict(
+                monday=1,
+                tuesday=1,
+                wednesday=1,
+                thursday=0,
+                friday=-1,
+                saturday=-1,
+                sunday=-1,
+            ),
+            labels=dict(
+                evening=dict(
+                    type="Polygon",
+                    coordinates=[
+                        [[1e-06, -0.5], [1e-06, -1.1], [1.1, -1.1], [1.1, -0.5]]
+                    ],
+                ),
+                day=dict(
+                    type="Polygon",
+                    coordinates=[[[-1.1, -0.5], [-1.1, 0.5], [-1e-06, 0.5], [0, -0.5]]],
+                ),
+            ),
+        ),
+        partial(
+            flowclient.meaningful_locations_between_label_od_matrix,
+            start_date="2016-01-01",
+            end_date="2016-01-02",
+            aggregation_unit="admin1",
+            label_a="unknown",
+            label_b="evening",
+            tower_hour_of_day_scores=[
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                0,
+                0,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                0,
+                0,
+                0,
+                0,
+                -1,
+                -1,
+                -1,
+            ],
+            tower_day_of_week_scores=dict(
+                monday=1,
+                tuesday=1,
+                wednesday=1,
+                thursday=0,
+                friday=-1,
+                saturday=-1,
+                sunday=-1,
+            ),
+            labels=dict(
+                evening=dict(
+                    type="Polygon",
+                    coordinates=[
+                        [[1e-06, -0.5], [1e-06, -1.1], [1.1, -1.1], [1.1, -0.5]]
+                    ],
+                ),
+                day=dict(
+                    type="Polygon",
+                    coordinates=[[[-1.1, -0.5], [-1.1, 0.5], [-1e-06, 0.5], [0, -0.5]]],
+                ),
+            ),
+        ),
+        partial(
+            flowclient.location_event_counts,
+            start_date="2016-01-01",
+            end_date="2016-01-02",
+            count_interval="day",
+            aggregation_unit="admin3",
+            direction="both",
+            event_types=["calls", "sms"],
+            subscriber_subset=None,
+        ),
+        partial(
+            flowclient.location_event_counts,
+            start_date="2016-01-01",
+            end_date="2016-01-02",
+            count_interval="day",
+            aggregation_unit="admin3",
+            direction="both",
+            event_types=None,
+            subscriber_subset=None,
+        ),
+        partial(
+            flowclient.meaningful_locations_between_dates_od_matrix,
+            start_date_a="2016-01-01",
+            end_date_a="2016-01-02",
+            start_date_b="2016-01-01",
+            end_date_b="2016-01-05",
+            aggregation_unit="admin1",
+            tower_hour_of_day_scores=[
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                0,
+                0,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                0,
+                0,
+                0,
+                0,
+                -1,
+                -1,
+                -1,
+            ],
+            tower_day_of_week_scores=dict(
+                monday=1,
+                tuesday=1,
+                wednesday=1,
+                thursday=0,
+                friday=-1,
+                saturday=-1,
+                sunday=-1,
+            ),
+            label="unknown",
+            labels=dict(
+                evening=dict(
+                    type="Polygon",
+                    coordinates=[
+                        [[1e-06, -0.5], [1e-06, -1.1], [1.1, -1.1], [1.1, -0.5]]
+                    ],
+                ),
+                day=dict(
+                    type="Polygon",
+                    coordinates=[[[-1.1, -0.5], [-1.1, 0.5], [-1e-06, 0.5], [0, -0.5]]],
+                ),
+            ),
+        ),
+        partial(
+            flowclient.joined_spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last",
+            ),
+            metric=flowclient.topup_balance_spec(
+                start_date="2016-01-01", end_date="2016-01-02", statistic="avg",
+            ),
+        ),
+        partial(
+            flowclient.joined_spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last"
+            ),
+            metric=flowclient.topup_balance_spec(
+                start_date="2016-01-01", end_date="2016-01-02", statistic="avg"
+            ),
+        ),
+        partial(
+            flowclient.joined_spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last",
+            ),
+            metric=flowclient.handset_spec(
+                start_date="2016-01-01",
+                end_date="2016-01-02",
+                characteristic="hnd_type",
+                method="last",
+            ),
+            method="distr",
+        ),
+        partial(
+            flowclient.joined_spatial_aggregate,
+            locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last"
+            ),
+            metric=flowclient.handset_spec(
+                start_date="2016-01-01",
+                end_date="2016-01-02",
+                characteristic="brand",
+                method="last",
+            ),
+            method="distr",
+        ),
+        partial(
+            flowclient.spatial_aggregate,
+            locations=flowclient.random_sample_spec(
+                query=flowclient.daily_location_spec(
+                    date="2016-01-01", aggregation_unit="admin3", method="most-common",
+                ),
+                size=10,
+                seed=0.5,
+            ),
+        ),
+        partial(
+            flowclient.spatial_aggregate,
+            locations=flowclient.random_sample_spec(
+                query=flowclient.daily_location_spec(
+                    date="2016-01-01", aggregation_unit="admin3", method="most-common",
+                ),
+                sampling_method="bernoulli",
+                fraction=0.5,
+                estimate_count=False,
+                seed=0.2,
+            ),
+        ),
+        partial(
+            flowclient.histogram_aggregate,
+            metric=flowclient.event_count_spec(start="2016-01-01", stop="2016-01-02"),
+            bins=5,
+        ),
     ],
+    ids=lambda val: val.func.__name__,
 )
-def test_run_query(query_kind, params, universal_access_token, flowapi_url):
+def test_run_query(query, universal_access_token, flowapi_url):
     """
     Test that queries can be run, and return a QueryResult object.
     """
     con = flowclient.Connection(url=flowapi_url, token=universal_access_token)
-    query = getattr(flowclient, query_kind)(connection=con, **params)
 
-    query.get_result()
+    query(connection=con).get_result()
     # Ideally we'd check the contents, but several queries will be totally redacted and therefore empty
     # so we can only check it runs without erroring
 
@@ -624,7 +503,7 @@ def test_geo_result(universal_access_token, flowapi_url):
     "query_kind, params",
     [
         (
-            "joined_spatial_aggregate",
+            flowclient.joined_spatial_aggregate,
             {
                 "locations": {
                     "query_kind": "daily_location",
@@ -642,7 +521,7 @@ def test_geo_result(universal_access_token, flowapi_url):
             },
         ),
         (
-            "joined_spatial_aggregate",
+            flowclient.joined_spatial_aggregate,
             {
                 "locations": {
                     "query_kind": "daily_location",
@@ -669,7 +548,7 @@ def test_fail_query_incorrect_parameters(
     Test that queries fail with incorrect parameters.
     """
     con = flowclient.Connection(url=flowapi_url, token=universal_access_token)
-    query = getattr(flowclient, query_kind)(connection=con, **params)
+    query = query_kind(connection=con, **params)
     with pytest.raises(
         flowclient.client.FlowclientConnectionError, match="Must be one of:"
     ):

--- a/integration_tests/tests/query_tests/test_queries.py
+++ b/integration_tests/tests/query_tests/test_queries.py
@@ -188,6 +188,41 @@ import pytest
             from_location=flowclient.daily_location_spec(
                 date="2016-01-01", aggregation_unit="admin3", method="last",
             ),
+            to_location=flowclient.unique_locations_spec(
+                start_date="2016-01-01",
+                end_date="2016-01-04",
+                aggregation_unit="admin3",
+            ),
+        ),
+        partial(
+            flowclient.flows,
+            to_location=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last",
+            ),
+            from_location=flowclient.unique_locations_spec(
+                start_date="2016-01-01",
+                end_date="2016-01-04",
+                aggregation_unit="admin3",
+            ),
+        ),
+        partial(
+            flowclient.flows,
+            from_location=flowclient.unique_locations_spec(
+                start_date="2016-01-01",
+                end_date="2016-01-04",
+                aggregation_unit="admin3",
+            ),
+            to_location=flowclient.unique_locations_spec(
+                start_date="2016-01-01",
+                end_date="2016-01-04",
+                aggregation_unit="admin3",
+            ),
+        ),
+        partial(
+            flowclient.flows,
+            from_location=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="last",
+            ),
             to_location=flowclient.daily_location_spec(
                 date="2016-01-04", aggregation_unit="admin3", method="last",
             ),
@@ -469,7 +504,7 @@ import pytest
             reference_locations=flowclient.daily_location_spec(
                 date="2016-01-01", aggregation_unit="admin3", method="most-common",
             ),
-            unique_locations=flowclient.client.unique_locations_spec(
+            unique_locations=flowclient.unique_locations_spec(
                 start_date="2016-01-01",
                 end_date="2016-01-03",
                 aggregation_unit="admin3",

--- a/integration_tests/tests/query_tests/test_queries.py
+++ b/integration_tests/tests/query_tests/test_queries.py
@@ -535,6 +535,12 @@ import pytest
             end_date="2016-01-03",
             aggregation_unit="admin3",
         ),
+        partial(
+            flowclient.trips_od_matrix,
+            start_date="2016-01-01",
+            end_date="2016-01-03",
+            aggregation_unit="admin3",
+        ),
     ],
     ids=lambda val: val.func.__name__,
 )

--- a/integration_tests/tests/query_tests/test_queries.py
+++ b/integration_tests/tests/query_tests/test_queries.py
@@ -521,6 +521,14 @@ import pytest
                 aggregation_unit="admin3",
             ),
         ),
+        partial(
+            flowclient.unmoving_counts,
+            unique_locations=flowclient.unique_locations_spec(
+                start_date="2016-01-01",
+                end_date="2016-01-03",
+                aggregation_unit="admin3",
+            ),
+        ),
     ],
     ids=lambda val: val.func.__name__,
 )

--- a/integration_tests/tests/query_tests/test_queries.py
+++ b/integration_tests/tests/query_tests/test_queries.py
@@ -464,6 +464,17 @@ import pytest
             metric=flowclient.event_count_spec(start="2016-01-01", stop="2016-01-02"),
             bins=5,
         ),
+        partial(
+            flowclient.active_at_reference_location_counts,
+            reference_locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="most-common",
+            ),
+            unique_locations=flowclient.client.unique_locations_spec(
+                start_date="2016-01-01",
+                end_date="2016-01-03",
+                aggregation_unit="admin3",
+            ),
+        ),
     ],
     ids=lambda val: val.func.__name__,
 )

--- a/integration_tests/tests/query_tests/test_queries.py
+++ b/integration_tests/tests/query_tests/test_queries.py
@@ -510,6 +510,17 @@ import pytest
                 aggregation_unit="admin3",
             ),
         ),
+        partial(
+            flowclient.unmoving_at_reference_location_counts,
+            reference_locations=flowclient.daily_location_spec(
+                date="2016-01-01", aggregation_unit="admin3", method="most-common",
+            ),
+            unique_locations=flowclient.unique_locations_spec(
+                start_date="2016-01-01",
+                end_date="2016-01-03",
+                aggregation_unit="admin3",
+            ),
+        ),
     ],
     ids=lambda val: val.func.__name__,
 )

--- a/integration_tests/tests/query_tests/test_queries.py
+++ b/integration_tests/tests/query_tests/test_queries.py
@@ -529,6 +529,12 @@ import pytest
                 aggregation_unit="admin3",
             ),
         ),
+        partial(
+            flowclient.consecutive_trips_od_matrix,
+            start_date="2016-01-01",
+            end_date="2016-01-03",
+            aggregation_unit="admin3",
+        ),
     ],
     ids=lambda val: val.func.__name__,
 )


### PR DESCRIPTION
Closes #2333

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

-   Added FlowClient function `unique_locations_spec`, which can be used on either side of a `flows` query
-   Added FlowClient functions: `unique_visitor_counts`, `active_at_reference_location_counts`, `unmoving_counts`, `unmoving_at_reference_location_counts`, `trips_od_matrix`, and `consecutive_trips_od_matrix`.