### PR TITLE
Set pool recycle to avoid tcp timeout by the docker stack router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- FlowAuth no longer errors after a period of inactivity due to timed out database connections. [#2382](https://github.com/Flowminder/FlowKit/issues/2382)
 
 ### Removed
 

--- a/flowauth/backend/flowauth/config.py
+++ b/flowauth/backend/flowauth/config.py
@@ -102,6 +102,7 @@ def get_config():
             ADMIN_USER=environ["FLOWAUTH_ADMIN_USERNAME"],
             ADMIN_PASSWORD=environ["FLOWAUTH_ADMIN_PASSWORD"],
             SQLALCHEMY_DATABASE_URI=db_uri,
+            SQLALCHEMY_ENGINE_OPTIONS=dict(pool_recycle=3600),
             SECRET_KEY=environ["SECRET_KEY"],
             SESSION_PROTECTION="strong",
             SQLALCHEMY_TRACK_MODIFICATIONS=False,


### PR DESCRIPTION
Closes #2382

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Makes flowauth recycle db pool connections on a regular basis to avoid them getting pruned by docker swarm.