### PR TITLE
Accept dates and date times via flowapi

### DIFF
--- a/flowmachine/flowmachine/core/date_range.py
+++ b/flowmachine/flowmachine/core/date_range.py
@@ -4,6 +4,8 @@
 
 import datetime as dt
 
+from flowmachine.utils import standardise_date, parse_datestring
+
 
 class DateRange:
     """
@@ -11,36 +13,13 @@ class DateRange:
     """
 
     def __init__(self, start_date, end_date):
-        self.start_date = self._parse_date(start_date)
-        self.end_date = self._parse_date(end_date)
-        self.start_date_as_str = self.start_date.strftime("%Y-%m-%d")
-        self.end_date_as_str = self.end_date.strftime("%Y-%m-%d")
+        self.start_date = parse_datestring(start_date)
+        self.end_date = parse_datestring(end_date)
+        self.start_date_as_str = standardise_date(start_date)
+        self.end_date_as_str = standardise_date(end_date)
 
         self.one_day_past_end_date = self.end_date + dt.timedelta(days=1)
-        self.one_day_past_end_date_as_str = self.one_day_past_end_date.strftime(
-            "%Y-%m-%d"
-        )
+        self.one_day_past_end_date_as_str = standardise_date(self.one_day_past_end_date)
 
     def __repr__(self):
         return f"DatePeriod(start_date={self.start_date_as_str}, end_date={self.end_date_as_str})"
-
-    def _parse_date(self, input_date):
-        if isinstance(input_date, dt.date):
-            if isinstance(input_date, dt.datetime):
-                # a bit of gymnastics because dt.date is a subtype of dt.datetime...
-                raise TypeError(
-                    "Date must be an instance of datetime.date, but got datetime.datetime"
-                )
-            else:
-                return input_date
-        elif isinstance(input_date, str):
-            try:
-                return dt.datetime.strptime(input_date, "%Y-%m-%d").date()
-            except ValueError:
-                raise ValueError(
-                    f"Date string must represent a valid date in the format 'YYYY-MM-DD'. Got: '{input_date}'"
-                )
-        else:
-            raise TypeError(
-                f"Date must be a string of the format YYYY-MM-DD or a datetime.date object. Got: {type(input_date)}"
-            )

--- a/flowmachine/flowmachine/core/server/query_schemas/consecutive_trips_od_matrix.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/consecutive_trips_od_matrix.py
@@ -14,7 +14,7 @@ from flowmachine.features.location.consecutive_trips_od_matrix import (
 )
 from . import BaseExposedQuery
 from .base_schema import BaseSchema
-from .custom_fields import SubscriberSubset
+from .custom_fields import SubscriberSubset, ISODateTime
 from .aggregation_unit import AggregationUnit, get_spatial_unit_obj
 
 __all__ = ["ConsecutiveTripsODMatrixSchema", "ConsecutiveTripsODMatrixExposed"]
@@ -55,8 +55,8 @@ class ConsecutiveTripsODMatrixExposed(BaseExposedQuery):
 class ConsecutiveTripsODMatrixSchema(BaseSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf(["consecutive_trips_od_matrix"]))
-    start_date = fields.Date(required=True)
-    end_date = fields.Date(required=True)
+    start_date = ISODateTime(required=True)
+    end_date = ISODateTime(required=True)
     aggregation_unit = AggregationUnit()
     subscriber_subset = SubscriberSubset()
 

--- a/flowmachine/flowmachine/core/server/query_schemas/custom_fields.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/custom_fields.py
@@ -177,6 +177,11 @@ class DFSMetric(fields.String):
 
 
 class ISODateTime(fields.DateTime):
+    """
+    Like marhsmallow's datetime field, but accepts anything that can be parsed using
+    python's fromisoformat, e.g. "2016-01-01", "2016-01-01T00:00:00", "2016-01-01 00:00:00"
+    """
+
     DESERIALIZATION_FUNCS = {
         "iso": datetime.datetime.fromisoformat,
     }

--- a/flowmachine/flowmachine/core/server/query_schemas/custom_fields.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/custom_fields.py
@@ -4,6 +4,7 @@
 
 # This file contains custom definitions of marshmallow fields for use
 # by the flowmachine query schemas.
+import datetime
 
 from marshmallow import fields, Schema, validates_schema, ValidationError, post_load
 from marshmallow.validate import Range, Length, OneOf
@@ -173,3 +174,13 @@ class DFSMetric(fields.String):
 
         validate = OneOf(["amount", "commission", "fee", "discount"])
         super().__init__(required=required, validate=validate, **kwargs)
+
+
+class ISODateTime(fields.DateTime):
+    DESERIALIZATION_FUNCS = {
+        "iso": datetime.datetime.fromisoformat,
+    }
+
+    DEFAULT_FORMAT = "iso"
+
+    OBJ_TYPE = "datetime"

--- a/flowmachine/flowmachine/core/server/query_schemas/daily_location.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/daily_location.py
@@ -6,7 +6,7 @@ from marshmallow import fields
 from marshmallow.validate import OneOf
 
 from flowmachine.features import daily_location
-from .custom_fields import SubscriberSubset
+from .custom_fields import SubscriberSubset, ISODateTime
 from .aggregation_unit import AggregationUnit, get_spatial_unit_obj
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
@@ -48,7 +48,7 @@ class DailyLocationExposed(BaseExposedQueryWithSampling):
 class DailyLocationSchema(BaseQueryWithSamplingSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf(["daily_location"]))
-    date = fields.Date(required=True)
+    date = ISODateTime(required=True)
     method = fields.String(required=True, validate=OneOf(["last", "most-common"]))
     aggregation_unit = AggregationUnit()
     subscriber_subset = SubscriberSubset()

--- a/flowmachine/flowmachine/core/server/query_schemas/dfs_metric_total_amount.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/dfs_metric_total_amount.py
@@ -8,7 +8,7 @@ from marshmallow.validate import OneOf
 from flowmachine.features.dfs import DFSTotalMetricAmount
 from .base_exposed_query import BaseExposedQuery
 from .base_schema import BaseSchema
-from .custom_fields import DFSMetric
+from .custom_fields import DFSMetric, ISODateTime
 from .aggregation_unit import AggregationUnit
 
 __all__ = ["DFSTotalMetricAmountSchema", "DFSTotalMetricAmountExposed"]
@@ -44,8 +44,8 @@ class DFSTotalMetricAmountSchema(BaseSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf(["dfs_metric_total_amount"]))
     metric = DFSMetric()
-    start_date = fields.Date(required=True)
-    end_date = fields.Date(required=True)
+    start_date = ISODateTime(required=True)
+    end_date = ISODateTime(required=True)
     aggregation_unit = AggregationUnit()
 
     __model__ = DFSTotalMetricAmountExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/displacement.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/displacement.py
@@ -7,7 +7,7 @@ from marshmallow.validate import OneOf
 from marshmallow_oneofschema import OneOfSchema
 
 from flowmachine.features import Displacement
-from .custom_fields import SubscriberSubset, Statistic
+from .custom_fields import SubscriberSubset, Statistic, ISODateTime
 from .daily_location import DailyLocationSchema
 from .modal_location import ModalLocationSchema
 from .base_query_with_sampling import (
@@ -67,8 +67,8 @@ class DisplacementExposed(BaseExposedQueryWithSampling):
 
 class DisplacementSchema(BaseQueryWithSamplingSchema):
     query_kind = fields.String(validate=OneOf(["displacement"]))
-    start = fields.Date(required=True)
-    stop = fields.Date(required=True)
+    start = ISODateTime(required=True)
+    stop = ISODateTime(required=True)
     statistic = Statistic()
     reference_location = fields.Nested(InputToDisplacementSchema, many=False)
     subscriber_subset = SubscriberSubset()

--- a/flowmachine/flowmachine/core/server/query_schemas/event_count.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/event_count.py
@@ -6,7 +6,7 @@ from marshmallow import fields, post_load
 from marshmallow.validate import OneOf
 
 from flowmachine.features import EventCount
-from .custom_fields import EventTypes, SubscriberSubset
+from .custom_fields import EventTypes, SubscriberSubset, ISODateTime
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
@@ -55,8 +55,8 @@ class EventCountExposed(BaseExposedQueryWithSampling):
 
 class EventCountSchema(BaseQueryWithSamplingSchema):
     query_kind = fields.String(validate=OneOf(["event_count"]))
-    start = fields.Date(required=True)
-    stop = fields.Date(required=True)
+    start = ISODateTime(required=True)
+    stop = ISODateTime(required=True)
     direction = fields.String(
         required=False, validate=OneOf(["in", "out", "both"]), default="both"
     )  # TODO: use a globally defined enum for this

--- a/flowmachine/flowmachine/core/server/query_schemas/handset.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/handset.py
@@ -6,7 +6,7 @@ from marshmallow import fields, post_load
 from marshmallow.validate import OneOf
 
 from flowmachine.features import SubscriberHandsetCharacteristic
-from .custom_fields import SubscriberSubset
+from .custom_fields import SubscriberSubset, ISODateTime
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
@@ -56,8 +56,8 @@ class HandsetExposed(BaseExposedQueryWithSampling):
 class HandsetSchema(BaseQueryWithSamplingSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf(["handset"]))
-    start_date = fields.Date(required=True)
-    end_date = fields.Date(required=True)
+    start_date = ISODateTime(required=True)
+    end_date = ISODateTime(required=True)
     characteristic = fields.String(
         validate=OneOf(
             ["hnd_type", "brand", "model", "software_os_name", "software_os_vendor"]

--- a/flowmachine/flowmachine/core/server/query_schemas/location_event_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/location_event_counts.py
@@ -9,7 +9,7 @@ from flowmachine.features import TotalLocationEvents
 from flowmachine.features.location.redacted_total_events import RedactedTotalEvents
 from .base_exposed_query import BaseExposedQuery
 from .base_schema import BaseSchema
-from .custom_fields import EventTypes, SubscriberSubset
+from .custom_fields import EventTypes, SubscriberSubset, ISODateTime
 from .aggregation_unit import AggregationUnit, get_spatial_unit_obj
 
 __all__ = ["LocationEventCountsSchema", "LocationEventCountsExposed"]
@@ -62,8 +62,8 @@ class LocationEventCountsExposed(BaseExposedQuery):
 class LocationEventCountsSchema(BaseSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf(["location_event_counts"]))
-    start_date = fields.Date(required=True)
-    end_date = fields.Date(required=True)
+    start_date = ISODateTime(required=True)
+    end_date = ISODateTime(required=True)
     interval = fields.String(
         required=True, validate=OneOf(TotalLocationEvents.allowed_intervals)
     )

--- a/flowmachine/flowmachine/core/server/query_schemas/location_introversion.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/location_introversion.py
@@ -15,6 +15,7 @@ from .aggregation_unit import AggregationUnit, get_spatial_unit_obj
 __all__ = ["LocationIntroversionSchema", "LocationIntroversionExposed"]
 
 from .base_schema import BaseSchema
+from .custom_fields import ISODateTime
 
 
 class LocationIntroversionExposed(BaseExposedQuery):
@@ -48,8 +49,8 @@ class LocationIntroversionExposed(BaseExposedQuery):
 class LocationIntroversionSchema(BaseSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf(["location_introversion"]))
-    start_date = fields.Date(required=True)
-    end_date = fields.Date(required=True)
+    start_date = ISODateTime(required=True)
+    end_date = ISODateTime(required=True)
     aggregation_unit = AggregationUnit()
     direction = fields.String(
         required=False, validate=OneOf(["in", "out", "both"]), default="both"

--- a/flowmachine/flowmachine/core/server/query_schemas/meaningful_locations.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/meaningful_locations.py
@@ -26,7 +26,12 @@ from flowmachine.features.location.redacted_meaningful_locations_od import (
 )
 from .base_exposed_query import BaseExposedQuery
 from .base_schema import BaseSchema
-from .custom_fields import SubscriberSubset, TowerHourOfDayScores, TowerDayOfWeekScores
+from .custom_fields import (
+    SubscriberSubset,
+    TowerHourOfDayScores,
+    TowerDayOfWeekScores,
+    ISODateTime,
+)
 from .aggregation_unit import AggregationUnit, get_spatial_unit_obj
 
 __all__ = [
@@ -229,8 +234,8 @@ class MeaningfulLocationsBetweenDatesODMatrixExposed(BaseExposedQuery):
 class MeaningfulLocationsAggregateSchema(BaseSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf(["meaningful_locations_aggregate"]))
-    start_date = fields.Date(required=True)
-    end_date = fields.Date(required=True)
+    start_date = ISODateTime(required=True)
+    end_date = ISODateTime(required=True)
     aggregation_unit = AggregationUnit(required=True)
     label = fields.String(required=True)
     labels = fields.Dict(
@@ -292,8 +297,8 @@ class MeaningfulLocationsBetweenLabelODMatrixSchema(BaseSchema):
     query_kind = fields.String(
         validate=OneOf(["meaningful_locations_between_label_od_matrix"])
     )
-    start_date = fields.Date(required=True)
-    end_date = fields.Date(required=True)
+    start_date = ISODateTime(required=True)
+    end_date = ISODateTime(required=True)
     aggregation_unit = AggregationUnit(required=True)
     label_a = fields.String(required=True)
     label_b = fields.String(required=True)
@@ -313,10 +318,10 @@ class MeaningfulLocationsBetweenDatesODMatrixSchema(BaseSchema):
     query_kind = fields.String(
         validate=OneOf(["meaningful_locations_between_dates_od_matrix"])
     )
-    start_date_a = fields.Date(required=True)
-    end_date_a = fields.Date(required=True)
-    start_date_b = fields.Date(required=True)
-    end_date_b = fields.Date(required=True)
+    start_date_a = ISODateTime(required=True)
+    end_date_a = ISODateTime(required=True)
+    start_date_b = ISODateTime(required=True)
+    end_date_b = ISODateTime(required=True)
     aggregation_unit = AggregationUnit(required=True)
     label = fields.String(required=True)
     labels = fields.Dict(

--- a/flowmachine/flowmachine/core/server/query_schemas/nocturnal_events.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/nocturnal_events.py
@@ -6,7 +6,7 @@ from marshmallow import fields
 from marshmallow.validate import OneOf, Range
 
 from flowmachine.features import NocturnalEvents
-from .custom_fields import SubscriberSubset
+from .custom_fields import SubscriberSubset, ISODateTime
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
@@ -53,8 +53,8 @@ class NocturnalEventsExposed(BaseExposedQueryWithSampling):
 
 class NocturnalEventsSchema(BaseQueryWithSamplingSchema):
     query_kind = fields.String(validate=OneOf(["nocturnal_events"]))
-    start = fields.Date(required=True)
-    stop = fields.Date(required=True)
+    start = ISODateTime(required=True)
+    stop = ISODateTime(required=True)
     night_start_hour = fields.Integer(
         validate=Range(0, 23)
     )  # Tuples aren't supported by apispec https://github.com/marshmallow-code/apispec/issues/399

--- a/flowmachine/flowmachine/core/server/query_schemas/pareto_interactions.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/pareto_interactions.py
@@ -6,7 +6,7 @@ from marshmallow import fields
 from marshmallow.validate import OneOf, Range
 
 from flowmachine.features import ParetoInteractions
-from .custom_fields import SubscriberSubset
+from .custom_fields import SubscriberSubset, ISODateTime
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
@@ -46,8 +46,8 @@ class ParetoInteractionsExposed(BaseExposedQueryWithSampling):
 
 class ParetoInteractionsSchema(BaseQueryWithSamplingSchema):
     query_kind = fields.String(validate=OneOf(["pareto_interactions"]))
-    start = fields.Date(required=True)
-    stop = fields.Date(required=True)
+    start = ISODateTime(required=True)
+    stop = ISODateTime(required=True)
     proportion = fields.Float(required=True, validate=Range(min=0.0, max=1.0))
     subscriber_subset = SubscriberSubset()
 

--- a/flowmachine/flowmachine/core/server/query_schemas/radius_of_gyration.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/radius_of_gyration.py
@@ -6,7 +6,7 @@ from marshmallow import fields
 from marshmallow.validate import OneOf
 
 from flowmachine.features import RadiusOfGyration
-from .custom_fields import SubscriberSubset
+from .custom_fields import SubscriberSubset, ISODateTime
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
@@ -43,8 +43,8 @@ class RadiusOfGyrationExposed(BaseExposedQueryWithSampling):
 class RadiusOfGyrationSchema(BaseQueryWithSamplingSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf(["radius_of_gyration"]))
-    start_date = fields.Date(required=True)
-    end_date = fields.Date(required=True)
+    start_date = ISODateTime(required=True)
+    end_date = ISODateTime(required=True)
     subscriber_subset = SubscriberSubset()
 
     __model__ = RadiusOfGyrationExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/subscriber_degree.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/subscriber_degree.py
@@ -6,7 +6,7 @@ from marshmallow import fields
 from marshmallow.validate import OneOf
 
 from flowmachine.features import SubscriberDegree
-from .custom_fields import SubscriberSubset
+from .custom_fields import SubscriberSubset, ISODateTime
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
@@ -46,8 +46,8 @@ class SubscriberDegreeExposed(BaseExposedQueryWithSampling):
 
 class SubscriberDegreeSchema(BaseQueryWithSamplingSchema):
     query_kind = fields.String(validate=OneOf(["subscriber_degree"]))
-    start = fields.Date(required=True)
-    stop = fields.Date(required=True)
+    start = ISODateTime(required=True)
+    stop = ISODateTime(required=True)
     direction = fields.String(
         required=False, validate=OneOf(["in", "out", "both"]), default="both"
     )  # TODO: use a globally defined enum for this

--- a/flowmachine/flowmachine/core/server/query_schemas/topup_amount.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/topup_amount.py
@@ -6,7 +6,7 @@ from marshmallow import fields
 from marshmallow.validate import OneOf
 
 from flowmachine.features import TopUpAmount
-from .custom_fields import SubscriberSubset, Statistic
+from .custom_fields import SubscriberSubset, Statistic, ISODateTime
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
@@ -46,8 +46,8 @@ class TopUpAmountExposed(BaseExposedQueryWithSampling):
 
 class TopUpAmountSchema(BaseQueryWithSamplingSchema):
     query_kind = fields.String(validate=OneOf(["topup_amount"]))
-    start = fields.Date(required=True)
-    stop = fields.Date(required=True)
+    start = ISODateTime(required=True)
+    stop = ISODateTime(required=True)
     statistic = Statistic()
     subscriber_subset = SubscriberSubset()
 

--- a/flowmachine/flowmachine/core/server/query_schemas/topup_balance.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/topup_balance.py
@@ -6,7 +6,7 @@ from marshmallow import fields
 from marshmallow.validate import OneOf
 
 from flowmachine.features import TopUpBalance
-from .custom_fields import Statistic, SubscriberSubset
+from .custom_fields import Statistic, SubscriberSubset, ISODateTime
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
@@ -52,8 +52,8 @@ class TopUpBalanceExposed(BaseExposedQueryWithSampling):
 
 class TopUpBalanceSchema(BaseQueryWithSamplingSchema):
     query_kind = fields.String(validate=OneOf(["topup_balance"]))
-    start_date = fields.Date(required=True)
-    end_date = fields.Date(required=True)
+    start_date = ISODateTime(required=True)
+    end_date = ISODateTime(required=True)
     statistic = Statistic()
     subscriber_subset = SubscriberSubset()
 

--- a/flowmachine/flowmachine/core/server/query_schemas/total_network_objects.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/total_network_objects.py
@@ -8,7 +8,7 @@ from marshmallow.validate import OneOf
 from flowmachine.features import TotalNetworkObjects
 from .base_exposed_query import BaseExposedQuery
 from .base_schema import BaseSchema
-from .custom_fields import TotalBy
+from .custom_fields import TotalBy, ISODateTime
 from .aggregation_unit import AggregationUnit, get_spatial_unit_obj
 
 __all__ = ["TotalNetworkObjectsSchema", "TotalNetworkObjectsExposed"]
@@ -43,8 +43,8 @@ class TotalNetworkObjectsExposed(BaseExposedQuery):
 class TotalNetworkObjectsSchema(BaseSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf(["total_network_objects"]))
-    start_date = fields.Date(required=True)
-    end_date = fields.Date(required=True)
+    start_date = ISODateTime(required=True)
+    end_date = ISODateTime(required=True)
     total_by = TotalBy(required=False, missing="day")
     aggregation_unit = AggregationUnit()
 

--- a/flowmachine/flowmachine/core/server/query_schemas/trips_od_matrix.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/trips_od_matrix.py
@@ -10,7 +10,7 @@ from flowmachine.features.utilities.subscriber_locations import SubscriberLocati
 from flowmachine.features.location.trips_od_matrix import TripsODMatrix
 from . import BaseExposedQuery
 from .base_schema import BaseSchema
-from .custom_fields import SubscriberSubset
+from .custom_fields import SubscriberSubset, ISODateTime
 from .aggregation_unit import AggregationUnit, get_spatial_unit_obj
 
 __all__ = ["TripsODMatrixSchema", "TripsODMatrixExposed"]
@@ -51,8 +51,8 @@ class TripsODMatrixExposed(BaseExposedQuery):
 class TripsODMatrixSchema(BaseSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf(["trips_od_matrix"]))
-    start_date = fields.Date(required=True)
-    end_date = fields.Date(required=True)
+    start_date = ISODateTime(required=True)
+    end_date = ISODateTime(required=True)
     aggregation_unit = AggregationUnit()
     subscriber_subset = SubscriberSubset()
 

--- a/flowmachine/flowmachine/core/server/query_schemas/unique_location_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/unique_location_counts.py
@@ -8,7 +8,7 @@ from marshmallow.validate import OneOf
 from flowmachine.features import UniqueLocationCounts
 from . import BaseExposedQuery
 from .base_schema import BaseSchema
-from .custom_fields import SubscriberSubset
+from .custom_fields import SubscriberSubset, ISODateTime
 from .aggregation_unit import AggregationUnit, get_spatial_unit_obj
 
 __all__ = ["UniqueLocationCountsSchema", "UniqueLocationCountsExposed"]
@@ -50,8 +50,8 @@ class UniqueLocationCountsExposed(BaseExposedQuery):
 
 class UniqueLocationCountsSchema(BaseSchema):
     query_kind = fields.String(validate=OneOf(["unique_location_counts"]))
-    start_date = fields.Date(required=True)
-    end_date = fields.Date(required=True)
+    start_date = ISODateTime(required=True)
+    end_date = ISODateTime(required=True)
     aggregation_unit = AggregationUnit()
     subscriber_subset = SubscriberSubset()
 

--- a/flowmachine/flowmachine/core/server/query_schemas/unique_locations.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/unique_locations.py
@@ -7,7 +7,7 @@ from marshmallow.validate import OneOf
 
 from flowmachine.features import SubscriberLocations
 from flowmachine.features.subscriber.unique_locations import UniqueLocations
-from .custom_fields import SubscriberSubset
+from .custom_fields import SubscriberSubset, ISODateTime
 from .aggregation_unit import AggregationUnit, get_spatial_unit_obj
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
@@ -57,8 +57,8 @@ class UniqueLocationsExposed(BaseExposedQueryWithSampling):
 class UniqueLocationsSchema(BaseQueryWithSamplingSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf(["unique_locations"]))
-    start_date = fields.Date(required=True)
-    end_date = fields.Date(required=True)
+    start_date = ISODateTime(required=True)
+    end_date = ISODateTime(required=True)
     aggregation_unit = AggregationUnit()
     subscriber_subset = SubscriberSubset()
 

--- a/flowmachine/flowmachine/core/server/query_schemas/unique_subscriber_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/unique_subscriber_counts.py
@@ -15,6 +15,7 @@ from .aggregation_unit import AggregationUnit, get_spatial_unit_obj
 __all__ = ["UniqueSubscriberCountsSchema", "UniqueSubscriberCountsExposed"]
 
 from .base_schema import BaseSchema
+from .custom_fields import ISODateTime
 
 
 class UniqueSubscriberCountsExposed(BaseExposedQuery):
@@ -46,8 +47,8 @@ class UniqueSubscriberCountsExposed(BaseExposedQuery):
 class UniqueSubscriberCountsSchema(BaseSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf(["unique_subscriber_counts"]))
-    start_date = fields.Date(required=True)
-    end_date = fields.Date(required=True)
+    start_date = ISODateTime(required=True)
+    end_date = ISODateTime(required=True)
     aggregation_unit = AggregationUnit()
 
     __model__ = UniqueSubscriberCountsExposed

--- a/flowmachine/flowmachine/features/location/location_introversion.py
+++ b/flowmachine/flowmachine/features/location/location_introversion.py
@@ -28,7 +28,7 @@ from flowmachine.core.mixins.geodata_mixin import GeoDataMixin
 from flowmachine.core.join_to_location import location_joined_query
 from flowmachine.core.spatial_unit import AnySpatialUnit, make_spatial_unit
 from flowmachine.features.utilities.events_tables_union import EventsTablesUnion
-from flowmachine.utils import make_where
+from flowmachine.utils import make_where, standardise_date
 
 
 class LocationIntroversion(GeoDataMixin, Query):
@@ -85,8 +85,8 @@ class LocationIntroversion(GeoDataMixin, Query):
         subscriber_subset=None,
         subscriber_identifier="msisdn",
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.table = table
         self.spatial_unit = spatial_unit
         self.direction = Direction(direction)

--- a/flowmachine/flowmachine/features/location/pwo.py
+++ b/flowmachine/flowmachine/features/location/pwo.py
@@ -32,7 +32,7 @@ import pandas as pd
 
 from flowmachine.core.query import Query
 from flowmachine.features.subscriber import daily_location
-from flowmachine.utils import list_of_dates
+from flowmachine.utils import list_of_dates, standardise_date
 from flowmachine.features.subscriber import ModalLocation
 from flowmachine.core import make_spatial_unit
 from flowmachine.core.spatial_unit import LonLatSpatialUnit
@@ -211,8 +211,8 @@ class PopulationWeightedOpportunities(Query):
             self.departure_rate = departure_rate
         else:
             raise TypeError(f"{departure_rate} must be a float or dataframe")
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         if spatial_unit is None:
             self.spatial_unit = make_spatial_unit("versioned-site")
         else:

--- a/flowmachine/flowmachine/features/location/total_events.py
+++ b/flowmachine/flowmachine/features/location/total_events.py
@@ -17,7 +17,7 @@ from flowmachine.core.mixins.geodata_mixin import GeoDataMixin
 from flowmachine.core.spatial_unit import AnySpatialUnit, make_spatial_unit
 from flowmachine.features.utilities.events_tables_union import EventsTablesUnion
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where
+from flowmachine.utils import make_where, standardise_date
 
 
 class TotalLocationEvents(GeoDataMixin, Query):
@@ -61,8 +61,8 @@ class TotalLocationEvents(GeoDataMixin, Query):
         subscriber_subset=None,
         subscriber_identifier="msisdn",
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.table = table
         self.spatial_unit = spatial_unit
         self.interval = interval

--- a/flowmachine/flowmachine/features/location/unique_subscriber_counts.py
+++ b/flowmachine/flowmachine/features/location/unique_subscriber_counts.py
@@ -7,6 +7,7 @@
 from typing import List, Union
 
 from ..subscriber.unique_locations import UniqueLocations
+from flowmachine.utils import standardise_date
 
 """
 Class for UniqueSubscriberCounts. UniqueSubscriberCounts counts
@@ -82,8 +83,8 @@ class UniqueSubscriberCounts(GeoDataMixin, Query):
         table="all",
     ):
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.spatial_unit = spatial_unit
         self.hours = hours
         self.table = table

--- a/flowmachine/flowmachine/features/network/total_network_objects.py
+++ b/flowmachine/flowmachine/features/network/total_network_objects.py
@@ -19,6 +19,7 @@ from ...core import location_joined_query, make_spatial_unit
 from ...core.spatial_unit import AnySpatialUnit
 from ...core.query import Query
 from ..utilities import EventsTablesUnion
+from flowmachine.utils import standardise_date
 
 valid_stats = {"avg", "max", "min", "median", "mode", "stddev", "variance"}
 valid_periods = ["second", "minute", "hour", "day", "month", "year"]
@@ -76,15 +77,11 @@ class TotalNetworkObjects(GeoDataMixin, Query):
         subscriber_subset=None,
         subscriber_identifier="msisdn",
     ):
-        self.start = (
-            get_db().min_date(table=table).strftime("%Y-%m-%d")
-            if start is None
-            else start
+        self.start = standardise_date(
+            get_db().min_date(table=table) if start is None else start
         )
-        self.stop = (
-            get_db().max_date(table=table).strftime("%Y-%m-%d")
-            if stop is None
-            else stop
+        self.stop = standardise_date(
+            get_db().max_date(table=table) if stop is None else stop
         )
 
         self.table = table.lower()

--- a/flowmachine/flowmachine/features/subscriber/contact_balance.py
+++ b/flowmachine/flowmachine/features/subscriber/contact_balance.py
@@ -16,7 +16,7 @@ from flowmachine.core.mixins import GraphMixin
 from flowmachine.features.utilities.events_tables_union import EventsTablesUnion
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where
+from flowmachine.utils import make_where, standardise_date
 
 
 class ContactBalance(GraphMixin, SubscriberFeature):
@@ -77,8 +77,8 @@ class ContactBalance(GraphMixin, SubscriberFeature):
         subscriber_subset=None,
     ):
         self.tables = tables
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.hours = hours
         self.direction = Direction(direction)
         self.subscriber_identifier = subscriber_identifier

--- a/flowmachine/flowmachine/features/subscriber/contact_reciprocal.py
+++ b/flowmachine/flowmachine/features/subscriber/contact_reciprocal.py
@@ -13,7 +13,7 @@ from flowmachine.features.subscriber.contact_balance import ContactBalance
 from flowmachine.features.utilities.events_tables_union import EventsTablesUnion
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where
+from flowmachine.utils import make_where, standardise_date
 
 
 class ContactReciprocal(GraphMixin, SubscriberFeature):
@@ -80,8 +80,8 @@ class ContactReciprocal(GraphMixin, SubscriberFeature):
         subscriber_subset=None,
     ):
         self.tables = tables
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.hours = hours
         self.exclude_self_calls = exclude_self_calls
         self.tables = tables

--- a/flowmachine/flowmachine/features/subscriber/daily_location.py
+++ b/flowmachine/flowmachine/features/subscriber/daily_location.py
@@ -18,6 +18,7 @@ from ...core import make_spatial_unit
 from ...core.spatial_unit import AnySpatialUnit
 from .last_location import LastLocation
 from .most_frequent_location import MostFrequentLocation
+from ...utils import parse_datestring
 
 
 def locate_subscribers(
@@ -191,15 +192,17 @@ def daily_location(
     # Temporary band-aid; marshmallow deserialises date strings
     # to date objects, so we convert it back here because the
     # lower-level classes still assume we are passing date strings.
-    if isinstance(date, datetime.date):
+    if isinstance(date, datetime.datetime):
+        date = date.strftime("%Y-%m-%d %H:%M:%S")
+    elif isinstance(date, datetime.date):
         date = date.strftime("%Y-%m-%d")
 
     if stop is None:
         # 'cast' the date object as a date
-        d1 = datetime.date(*map(int, date.split("-")))
+        d1 = parse_datestring(date)
         # One day after this
         d2 = d1 + datetime.timedelta(1)
-        stop = d2.strftime("%Y-%m-%d")
+        stop = d2.strftime("%Y-%m-%d %H:%M:%S")
     return locate_subscribers(
         start=date,
         stop=stop,

--- a/flowmachine/flowmachine/features/subscriber/daily_location.py
+++ b/flowmachine/flowmachine/features/subscriber/daily_location.py
@@ -18,7 +18,7 @@ from ...core import make_spatial_unit
 from ...core.spatial_unit import AnySpatialUnit
 from .last_location import LastLocation
 from .most_frequent_location import MostFrequentLocation
-from ...utils import parse_datestring
+from flowmachine.utils import parse_datestring, standardise_date
 
 
 def locate_subscribers(
@@ -192,17 +192,14 @@ def daily_location(
     # Temporary band-aid; marshmallow deserialises date strings
     # to date objects, so we convert it back here because the
     # lower-level classes still assume we are passing date strings.
-    if isinstance(date, datetime.datetime):
-        date = date.strftime("%Y-%m-%d %H:%M:%S")
-    elif isinstance(date, datetime.date):
-        date = date.strftime("%Y-%m-%d")
+    date = standardise_date(date)
 
     if stop is None:
         # 'cast' the date object as a date
         d1 = parse_datestring(date)
         # One day after this
         d2 = d1 + datetime.timedelta(1)
-        stop = d2.strftime("%Y-%m-%d %H:%M:%S")
+        stop = standardise_date(d2)
     return locate_subscribers(
         start=date,
         stop=stop,

--- a/flowmachine/flowmachine/features/subscriber/displacement.py
+++ b/flowmachine/flowmachine/features/subscriber/displacement.py
@@ -12,7 +12,7 @@ from flowmachine.features.spatial import DistanceMatrix
 from .metaclasses import SubscriberFeature
 from ..utilities.subscriber_locations import SubscriberLocations, BaseLocation
 from flowmachine.core import Query
-
+from flowmachine.utils import standardise_date
 
 valid_stats = {"sum", "avg", "max", "min", "median", "stddev", "variance"}
 
@@ -96,8 +96,8 @@ class Displacement(SubscriberFeature):
     ):
 
         self.return_subscribers_not_seen = return_subscribers_not_seen
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.spatial_unit = reference_location.spatial_unit
         subscriber_locations = SubscriberLocations(
             self.start,

--- a/flowmachine/flowmachine/features/subscriber/distance_counterparts.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_counterparts.py
@@ -12,7 +12,7 @@ from flowmachine.features.utilities.events_tables_union import EventsTablesUnion
 from flowmachine.features.spatial.distance_matrix import DistanceMatrix
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where
+from flowmachine.utils import make_where, standardise_date
 
 valid_stats = {"count", "sum", "avg", "max", "min", "median", "stddev", "variance"}
 
@@ -77,8 +77,8 @@ class DistanceCounterparts(SubscriberFeature):
         exclude_self_calls=True,
     ):
         self.tables = tables
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.hours = hours
         self.direction = Direction(direction)
         self.exclude_self_calls = exclude_self_calls

--- a/flowmachine/flowmachine/features/subscriber/distance_series.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_series.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Union, Tuple
 from flowmachine.features.spatial import DistanceMatrix
 from .metaclasses import SubscriberFeature
 from ..utilities.subscriber_locations import SubscriberLocations, BaseLocation
-
+from flowmachine.utils import standardise_date
 
 valid_stats = {"sum", "avg", "max", "min", "median", "stddev", "variance"}
 valid_time_buckets = [
@@ -86,8 +86,8 @@ class DistanceSeries(SubscriberFeature):
                 f"'{statistic}' is not a valid statistic. Use one of {valid_stats}"
             )
         self.statistic = statistic.lower()
-        self.start = subscriber_locations.start
-        self.stop = subscriber_locations.stop
+        self.start = standardise_date(subscriber_locations.start)
+        self.stop = standardise_date(subscriber_locations.stop)
         if isinstance(reference_location, tuple):
             self.reference_location = reference_location
             self.joined = subscriber_locations

--- a/flowmachine/flowmachine/features/subscriber/entropy.py
+++ b/flowmachine/flowmachine/features/subscriber/entropy.py
@@ -19,7 +19,7 @@ from flowmachine.features.utilities.subscriber_locations import SubscriberLocati
 from flowmachine.features.subscriber.contact_balance import ContactBalance
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where
+from flowmachine.utils import make_where, standardise_date
 
 
 class BaseEntropy(SubscriberFeature, metaclass=ABCMeta):
@@ -130,8 +130,8 @@ class PeriodicEntropy(BaseEntropy):
     ):
 
         self.tables = tables
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.subscriber_identifier = subscriber_identifier
         self.direction = Direction(direction)
         self.hours = hours

--- a/flowmachine/flowmachine/features/subscriber/event_count.py
+++ b/flowmachine/flowmachine/features/subscriber/event_count.py
@@ -9,7 +9,7 @@ from typing import List, Union
 from flowmachine.features.utilities.events_tables_union import EventsTablesUnion
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where
+from flowmachine.utils import make_where, standardise_date
 
 valid_stats = {"count", "sum", "avg", "max", "min", "median", "stddev", "variance"}
 
@@ -65,8 +65,8 @@ class EventCount(SubscriberFeature):
         subscriber_subset=None,
         tables="all",
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.subscriber_identifier = subscriber_identifier
         self.direction = Direction(direction)
         self.hours = hours

--- a/flowmachine/flowmachine/features/subscriber/event_type_proportion.py
+++ b/flowmachine/flowmachine/features/subscriber/event_type_proportion.py
@@ -9,6 +9,7 @@ from typing import Union
 from flowmachine.features.subscriber.event_count import EventCount
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
+from flowmachine.utils import standardise_date
 
 
 class ProportionEventType(SubscriberFeature):
@@ -70,8 +71,8 @@ class ProportionEventType(SubscriberFeature):
         subscriber_subset=None,
         tables="all",
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.subscriber_identifier = subscriber_identifier
         self.direction = Direction(direction)
         self.numerator_direction = Direction(numerator_direction)

--- a/flowmachine/flowmachine/features/subscriber/first_location.py
+++ b/flowmachine/flowmachine/features/subscriber/first_location.py
@@ -16,6 +16,7 @@ from flowmachine.core import make_spatial_unit
 from flowmachine.core.spatial_unit import AnySpatialUnit
 from .metaclasses import SubscriberFeature
 from ..utilities.subscriber_locations import SubscriberLocations
+from flowmachine.utils import standardise_date
 
 
 class FirstLocation(SubscriberFeature):
@@ -82,8 +83,8 @@ class FirstLocation(SubscriberFeature):
                 "Invalid parameter combination: location='any' can only be used with cell spatial unit."
             )
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.location = location
 
         self.ul = SubscriberLocations(

--- a/flowmachine/flowmachine/features/subscriber/interevent_interval.py
+++ b/flowmachine/flowmachine/features/subscriber/interevent_interval.py
@@ -14,7 +14,7 @@ from flowmachine.core import Query
 from flowmachine.features.utilities import EventsTablesUnion
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where
+from flowmachine.utils import make_where, standardise_date
 
 valid_stats = {"count", "sum", "avg", "max", "min", "median", "stddev", "variance"}
 
@@ -84,8 +84,8 @@ class IntereventInterval(SubscriberFeature):
         direction: Union[str, Direction] = Direction.OUT,
     ):
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.hours = hours
         self.tables = tables
         self.subscriber_identifier = subscriber_identifier

--- a/flowmachine/flowmachine/features/subscriber/last_location.py
+++ b/flowmachine/flowmachine/features/subscriber/last_location.py
@@ -16,6 +16,7 @@ from flowmachine.core import Query, make_spatial_unit
 from flowmachine.core.spatial_unit import AnySpatialUnit
 from ..utilities.subscriber_locations import BaseLocation
 from ..utilities.subscriber_locations import SubscriberLocations
+from flowmachine.utils import standardise_date
 
 
 class LastLocation(BaseLocation, Query):
@@ -78,8 +79,8 @@ class LastLocation(BaseLocation, Query):
         subscriber_subset=None,
     ):
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         if spatial_unit is None:
             self.spatial_unit = make_spatial_unit("admin", level=3)
         else:

--- a/flowmachine/flowmachine/features/subscriber/mds_volume.py
+++ b/flowmachine/flowmachine/features/subscriber/mds_volume.py
@@ -10,6 +10,7 @@ Class for calculating MDS volume statistics.
 
 from ..utilities.sets import EventsTablesUnion
 from .metaclasses import SubscriberFeature
+from flowmachine.utils import standardise_date
 
 valid_stats = {"count", "sum", "avg", "max", "min", "median", "stddev", "variance"}
 
@@ -62,8 +63,8 @@ class MDSVolume(SubscriberFeature):
         hours="all",
         subscriber_subset=None,
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.subscriber_identifier = subscriber_identifier
         self.hours = hours
         self.volume = volume

--- a/flowmachine/flowmachine/features/subscriber/most_frequent_location.py
+++ b/flowmachine/flowmachine/features/subscriber/most_frequent_location.py
@@ -14,6 +14,7 @@ from typing import List, Optional
 from flowmachine.core import Query, make_spatial_unit
 from flowmachine.core.spatial_unit import AnySpatialUnit
 from ..utilities.subscriber_locations import BaseLocation, SubscriberLocations
+from flowmachine.utils import standardise_date
 
 
 class MostFrequentLocation(BaseLocation, Query):
@@ -80,8 +81,8 @@ class MostFrequentLocation(BaseLocation, Query):
 
         """
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         if spatial_unit is None:
             self.spatial_unit = make_spatial_unit("admin", level=3)
         else:

--- a/flowmachine/flowmachine/features/subscriber/nocturnal_events.py
+++ b/flowmachine/flowmachine/features/subscriber/nocturnal_events.py
@@ -16,7 +16,7 @@ from typing import Union
 from flowmachine.features.utilities.events_tables_union import EventsTablesUnion
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where
+from flowmachine.utils import make_where, standardise_date
 
 
 class NocturnalEvents(SubscriberFeature):
@@ -70,8 +70,8 @@ class NocturnalEvents(SubscriberFeature):
         subscriber_subset=None,
         tables="all",
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.subscriber_identifier = subscriber_identifier
         self.direction = Direction(direction)
         self.hours = hours

--- a/flowmachine/flowmachine/features/subscriber/pareto_interactions.py
+++ b/flowmachine/flowmachine/features/subscriber/pareto_interactions.py
@@ -16,6 +16,7 @@ from flowmachine.features.subscriber.contact_balance import ContactBalance
 from flowmachine.features.subscriber.subscriber_degree import SubscriberDegree
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
+from flowmachine.utils import standardise_date
 
 
 class ParetoInteractions(SubscriberFeature):
@@ -78,8 +79,8 @@ class ParetoInteractions(SubscriberFeature):
         subscriber_subset=None,
     ):
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.hours = hours
         self.direction = Direction(direction)
         self.tables = tables

--- a/flowmachine/flowmachine/features/subscriber/per_location_event_stats.py
+++ b/flowmachine/flowmachine/features/subscriber/per_location_event_stats.py
@@ -10,7 +10,7 @@ from flowmachine.core.spatial_unit import AnySpatialUnit, make_spatial_unit
 from flowmachine.features.utilities.events_tables_union import EventsTablesUnion
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where
+from flowmachine.utils import make_where, standardise_date
 
 valid_stats = {"count", "sum", "avg", "max", "min", "median", "stddev", "variance"}
 
@@ -76,8 +76,8 @@ class PerLocationEventStats(SubscriberFeature):
         direction: Union[str, Direction] = Direction.BOTH,
         subscriber_subset=None,
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.spatial_unit = spatial_unit
         self.hours = hours
         self.tables = tables

--- a/flowmachine/flowmachine/features/subscriber/radius_of_gyration.py
+++ b/flowmachine/flowmachine/features/subscriber/radius_of_gyration.py
@@ -15,6 +15,7 @@ from typing import List
 from .metaclasses import SubscriberFeature
 from ..utilities.subscriber_locations import SubscriberLocations
 from flowmachine.core import make_spatial_unit
+from flowmachine.utils import standardise_date
 
 
 class RadiusOfGyration(SubscriberFeature):
@@ -97,8 +98,8 @@ class RadiusOfGyration(SubscriberFeature):
                 f"Unrecognised unit {unit}, use one of {self.allowed_units}"
             )
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.ul = SubscriberLocations(
             self.start,
             self.stop,

--- a/flowmachine/flowmachine/features/subscriber/scores.py
+++ b/flowmachine/flowmachine/features/subscriber/scores.py
@@ -15,6 +15,7 @@ from typing import List
 from ..utilities import EventsTablesUnion
 from ...core import Query, location_joined_query, make_spatial_unit
 from ...core.spatial_unit import AnySpatialUnit
+from flowmachine.utils import standardise_date
 
 
 class EventScore(Query):
@@ -146,8 +147,8 @@ class EventScore(Query):
             self.spatial_unit = make_spatial_unit("admin", level=3)
         else:
             self.spatial_unit = spatial_unit
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.hours = hours
         self.subscriber_identifier = subscriber_identifier
         self.sds = location_joined_query(

--- a/flowmachine/flowmachine/features/subscriber/subscriber_call_durations.py
+++ b/flowmachine/flowmachine/features/subscriber/subscriber_call_durations.py
@@ -17,7 +17,7 @@ from flowmachine.core.spatial_unit import AnySpatialUnit, make_spatial_unit
 from flowmachine.features.utilities.events_tables_union import EventsTablesUnion
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where
+from flowmachine.utils import make_where, standardise_date
 
 valid_stats = {"count", "sum", "avg", "max", "min", "median", "stddev", "variance"}
 
@@ -73,8 +73,8 @@ class SubscriberCallDurations(SubscriberFeature):
         hours="all",
         subscriber_subset=None,
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.subscriber_identifier = subscriber_identifier
         self.hours = hours
         self.direction = Direction(direction)
@@ -171,8 +171,8 @@ class PerLocationSubscriberCallDurations(SubscriberFeature):
         hours="all",
         subscriber_subset=None,
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.subscriber_identifier = subscriber_identifier
         self.direction = Direction(direction)
         if spatial_unit is None:
@@ -273,8 +273,8 @@ class PairedSubscriberCallDurations(SubscriberFeature):
         hours="all",
         subscriber_subset=None,
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.subscriber_identifier = subscriber_identifier
 
         self.statistic = statistic.lower()
@@ -374,8 +374,8 @@ class PairedPerLocationSubscriberCallDurations(SubscriberFeature):
         hours="all",
         subscriber_subset=None,
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.subscriber_identifier = subscriber_identifier
         if spatial_unit is None:
             self.spatial_unit = make_spatial_unit("admin", level=3)

--- a/flowmachine/flowmachine/features/subscriber/subscriber_degree.py
+++ b/flowmachine/flowmachine/features/subscriber/subscriber_degree.py
@@ -14,7 +14,7 @@ from typing import List, Union
 from flowmachine.features.utilities.events_tables_union import EventsTablesUnion
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where
+from flowmachine.utils import make_where, standardise_date
 
 
 class SubscriberDegree(SubscriberFeature):
@@ -76,8 +76,8 @@ class SubscriberDegree(SubscriberFeature):
         exclude_self_calls=True,
         subscriber_subset=None,
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.hours = hours
         self.direction = Direction(direction)
         self.subscriber_identifier = subscriber_identifier

--- a/flowmachine/flowmachine/features/subscriber/subscriber_tacs.py
+++ b/flowmachine/flowmachine/features/subscriber/subscriber_tacs.py
@@ -16,6 +16,7 @@ from typing import List
 from ..utilities import EventsTablesUnion
 from .metaclasses import SubscriberFeature
 from ...core import Table
+from flowmachine.utils import standardise_date
 
 valid_characteristics = {
     "brand",
@@ -123,8 +124,8 @@ class SubscriberTACs(SubscriberFeature):
 
         """
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.hours = hours
         self.table = table
         self.subscriber_identifier = subscriber_identifier
@@ -210,8 +211,8 @@ class SubscriberTAC(SubscriberFeature):
         if subscriber_identifier == "imei":
             warnings.warn("IMEI has a one to one mapping to TAC number.")
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.hours = hours
         self.table = table
         self.subscriber_identifier = subscriber_identifier
@@ -304,8 +305,8 @@ class SubscriberHandsets(SubscriberFeature):
 
         """
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.hours = hours
         self.table = table
         self.subscriber_identifier = subscriber_identifier
@@ -386,8 +387,8 @@ class SubscriberHandset(SubscriberFeature):
 
         """
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.hours = hours
         self.table = table
         self.subscriber_identifier = subscriber_identifier
@@ -526,8 +527,8 @@ class SubscriberHandsetCharacteristic(SubscriberFeature):
 
         """
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.hours = hours
         self.table = table
         self.subscriber_identifier = subscriber_identifier

--- a/flowmachine/flowmachine/features/subscriber/topup_amount.py
+++ b/flowmachine/flowmachine/features/subscriber/topup_amount.py
@@ -11,6 +11,7 @@ import warnings
 
 from ..utilities.sets import EventsTablesUnion
 from .metaclasses import SubscriberFeature
+from flowmachine.utils import standardise_date
 
 valid_stats = {"count", "sum", "avg", "max", "min", "median", "stddev", "variance"}
 
@@ -60,8 +61,8 @@ class TopUpAmount(SubscriberFeature):
         hours="all",
         subscriber_subset=None,
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.subscriber_identifier = subscriber_identifier
         self.hours = hours
         self.statistic = statistic.lower()

--- a/flowmachine/flowmachine/features/subscriber/topup_balance.py
+++ b/flowmachine/flowmachine/features/subscriber/topup_balance.py
@@ -11,6 +11,7 @@ import warnings
 
 from ..utilities.sets import EventsTablesUnion
 from .metaclasses import SubscriberFeature
+from flowmachine.utils import standardise_date
 
 valid_stats = {
     "count",
@@ -95,8 +96,8 @@ class TopUpBalance(SubscriberFeature):
         hours="all",
         subscriber_subset=None,
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.subscriber_identifier = subscriber_identifier
         self.hours = hours
         self.statistic = statistic.lower()

--- a/flowmachine/flowmachine/features/subscriber/total_active_periods.py
+++ b/flowmachine/flowmachine/features/subscriber/total_active_periods.py
@@ -24,7 +24,7 @@ from typing import List, Tuple, Union, Optional
 
 from flowmachine.core import Query
 from .metaclasses import SubscriberFeature
-from flowmachine.utils import time_period_add
+from flowmachine.utils import time_period_add, standardise_date
 from ..utilities.sets import UniqueSubscribers
 
 from functools import reduce
@@ -89,7 +89,7 @@ class TotalActivePeriodsSubscriber(SubscriberFeature):
         subscriber_identifier: str = "msisdn",
         subscriber_subset: Optional[Query] = None,
     ):
-        self.start = start
+        self.start = standardise_date(start)
         self.total_periods = total_periods
         self.period_length = period_length
         if period_unit not in self.allowed_units:

--- a/flowmachine/flowmachine/features/utilities/event_table_subset.py
+++ b/flowmachine/flowmachine/features/utilities/event_table_subset.py
@@ -85,9 +85,13 @@ class EventTableSubset(Query):
         # Temporary band-aid; marshmallow deserialises date strings
         # to date objects, so we convert it back here because the
         # lower-level classes still assume we are passing date strings.
-        if isinstance(start, datetime.date):
+        if isinstance(start, datetime.datetime):
+            start = start.strftime("%Y-%m-%d %H:%M:%S")
+        elif isinstance(start, datetime.date):
             start = start.strftime("%Y-%m-%d")
-        if isinstance(stop, datetime.date):
+        if isinstance(stop, datetime.datetime):
+            stop = stop.strftime("%Y-%m-%d %H:%M:%S")
+        elif isinstance(stop, datetime.date):
             stop = stop.strftime("%Y-%m-%d")
 
         if hours != "all" and hour_slices is not None:
@@ -151,6 +155,7 @@ class EventTableSubset(Query):
         )
 
         if self.start == self.stop:
+            print(self.start)
             raise ValueError("Start and stop are the same.")
 
         super().__init__()

--- a/flowmachine/flowmachine/features/utilities/event_table_subset.py
+++ b/flowmachine/flowmachine/features/utilities/event_table_subset.py
@@ -17,7 +17,7 @@ from ...core.sqlalchemy_utils import (
     make_sqlalchemy_column_from_flowmachine_column_description,
     get_sql_string,
 )
-from flowmachine.utils import list_of_dates
+from flowmachine.utils import list_of_dates, standardise_date
 from flowmachine.core.hour_slice import HourSlice, HourInterval
 from flowmachine.core.subscriber_subsetter import make_subscriber_subsetter
 
@@ -82,18 +82,6 @@ class EventTableSubset(Query):
         subscriber_identifier="msisdn",
     ):
 
-        # Temporary band-aid; marshmallow deserialises date strings
-        # to date objects, so we convert it back here because the
-        # lower-level classes still assume we are passing date strings.
-        if isinstance(start, datetime.datetime):
-            start = start.strftime("%Y-%m-%d %H:%M:%S")
-        elif isinstance(start, datetime.date):
-            start = start.strftime("%Y-%m-%d")
-        if isinstance(stop, datetime.datetime):
-            stop = stop.strftime("%Y-%m-%d %H:%M:%S")
-        elif isinstance(stop, datetime.date):
-            stop = stop.strftime("%Y-%m-%d")
-
         if hours != "all" and hour_slices is not None:
             raise ValueError(
                 "The arguments `hours` and `hour_slice` are mutually exclusive."
@@ -126,8 +114,8 @@ class EventTableSubset(Query):
         else:
             self.hour_slices = HourSlice(hour_intervals=[])
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.hours = hours
         self.subscriber_subsetter = make_subscriber_subsetter(subscriber_subset)
         self.subscriber_identifier = subscriber_identifier.lower()
@@ -155,7 +143,6 @@ class EventTableSubset(Query):
         )
 
         if self.start == self.stop:
-            print(self.start)
             raise ValueError("Start and stop are the same.")
 
         super().__init__()
@@ -180,7 +167,7 @@ class EventTableSubset(Query):
             d1 = (
                 get_db()
                 .min_date(self.table_ORIG.fully_qualified_table_name.split(".")[1])
-                .strftime("%Y-%m-%d")
+                .strftime("%Y-%m-%d %H:%M:%S")
             )
         else:
             d1 = self.start.split()[0]
@@ -189,7 +176,7 @@ class EventTableSubset(Query):
             d2 = (
                 get_db()
                 .max_date(self.table_ORIG.fully_qualified_table_name.split(".")[1])
-                .strftime("%Y-%m-%d")
+                .strftime("%Y-%m-%d %H:%M:%S")
             )
         else:
             d2 = self.stop.split()[0]
@@ -237,13 +224,13 @@ class EventTableSubset(Query):
         select_stmt = select(sqlalchemy_columns)
 
         if self.start is not None:
-            ts_start = pd.Timestamp(self.start).strftime("%Y-%m-%d %H:%M:%S")
             select_stmt = select_stmt.where(
-                self.sqlalchemy_table.c.datetime >= ts_start
+                self.sqlalchemy_table.c.datetime >= self.start
             )
         if self.stop is not None:
-            ts_stop = pd.Timestamp(self.stop).strftime("%Y-%m-%d %H:%M:%S")
-            select_stmt = select_stmt.where(self.sqlalchemy_table.c.datetime < ts_stop)
+            select_stmt = select_stmt.where(
+                self.sqlalchemy_table.c.datetime < self.stop
+            )
 
         select_stmt = select_stmt.where(
             self.hour_slices.get_subsetting_condition(self.sqlalchemy_table.c.datetime)

--- a/flowmachine/flowmachine/features/utilities/events_tables_union.py
+++ b/flowmachine/flowmachine/features/utilities/events_tables_union.py
@@ -10,6 +10,7 @@ from ...core import Query
 from ...core.context import get_db
 from ...core.errors import MissingDateError
 from .event_table_subset import EventTableSubset
+from flowmachine.utils import standardise_date
 
 logger = structlog.get_logger("flowmachine.debug", submodule=__name__)
 
@@ -60,8 +61,8 @@ class EventsTablesUnion(Query):
             )
             tables = None
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.columns = columns
         self.tables = self._parse_tables(tables)
         if "*" in columns and len(self.tables) != 1:

--- a/flowmachine/flowmachine/features/utilities/multilocation.py
+++ b/flowmachine/flowmachine/features/utilities/multilocation.py
@@ -12,7 +12,7 @@ dailylocations objects, although they can be.
 """
 
 
-from flowmachine.utils import parse_datestring
+from flowmachine.utils import parse_datestring, standardise_date
 
 from ...core import CustomQuery
 
@@ -41,13 +41,13 @@ class MultiLocation:
     def __init__(self, *daily_locations):
         # TODO: check that all the inputs are actually location objects (of an appropriate kind)
 
-        self.start = str(
+        self.start = standardise_date(
             min(
                 parse_datestring(daily_location.start)
                 for daily_location in daily_locations
             )
         )
-        self.stop = str(
+        self.stop = standardise_date(
             max(
                 parse_datestring(daily_location.start)
                 for daily_location in daily_locations

--- a/flowmachine/flowmachine/features/utilities/sets.py
+++ b/flowmachine/flowmachine/features/utilities/sets.py
@@ -20,6 +20,8 @@ from numpy import inf
 
 import structlog
 
+from flowmachine.utils import standardise_date
+
 logger = structlog.get_logger("flowmachine.debug", submodule=__name__)
 valid_subscriber_identifiers = ("msisdn", "imei", "imsi")
 
@@ -86,8 +88,8 @@ class UniqueSubscribers(Query):
         subscriber_identifier: str = "msisdn",
         subscriber_subset: Optional[Query] = None,
     ):
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.hours = hours
         self.tables = table
         self.subscriber_identifier = subscriber_identifier
@@ -181,8 +183,8 @@ class SubscriberLocationSubset(Query):
 
         from ...features import PerLocationSubscriberCallDurations
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.min_calls = min_calls
         self.subscriber_identifier = subscriber_identifier
         self.direction = Direction(direction)

--- a/flowmachine/flowmachine/features/utilities/subscriber_locations.py
+++ b/flowmachine/flowmachine/features/utilities/subscriber_locations.py
@@ -4,6 +4,8 @@
 
 from typing import List
 
+from flowmachine.utils import standardise_date
+
 """
 Classes for determining elementary location elements.
 These are used for creating base objects that are
@@ -94,8 +96,8 @@ class SubscriberLocations(Query):
         subscriber_subset=None,
     ):
 
-        self.start = start
-        self.stop = stop
+        self.start = standardise_date(start)
+        self.stop = standardise_date(stop)
         self.spatial_unit = spatial_unit
         self.hours = hours
         self.table = table

--- a/flowmachine/flowmachine/utils.py
+++ b/flowmachine/flowmachine/utils.py
@@ -54,6 +54,31 @@ def parse_datestring(
                         )
 
 
+def standardise_date(
+    date: Union[str, datetime.date, datetime.datetime]
+) -> Union[str, None]:
+    """
+    Turn a date, datetime, or date string into a standardised date string (YYYY-MM-DD HH:MM:SS).
+
+    
+    Parameters
+    ----------
+    date : str, date or datetime
+        Date-like-thing to standardise.
+
+    Returns
+    -------
+    str or None
+       YYYY-MM-DD HH:MM:SS formatted date string or None if input was None.
+    """
+    if date is None:
+        return date
+    try:
+        return date.strftime("%Y-%m-%d %H:%M:%S")
+    except AttributeError:
+        return parse_datestring(date).strftime("%Y-%m-%d %H:%M:%S")
+
+
 def list_of_dates(start, stop):
     """
 
@@ -107,17 +132,11 @@ def time_period_add(date, n, unit="days"):
     --------
 
     >>> time_period_add('2016-01-01', 3)
-    '2016-01-04'
+    '2016-01-04 00:00:00'
     """
     new_date = parse_datestring(date) + datetime.timedelta(**{unit: n})
-    # Now for convenience if the date has no time component then we want to
-    # simply return the date string, i.e. without the time component. Otherwise
-    # we need to return the whole thing.
-    date_string = new_date.strftime("%Y-%m-%d %X")
-    if date_string.endswith("00:00:00"):
-        return date_string.split(" ")[0]
-    else:
-        return date_string
+
+    return standardise_date(new_date)
 
 
 def get_dist_query_string(*, lon1, lat1, lon2, lat2):

--- a/flowmachine/flowmachine/utils.py
+++ b/flowmachine/flowmachine/utils.py
@@ -46,9 +46,12 @@ def parse_datestring(
                 try:
                     return datetime.datetime.strptime(datestring, "%Y-%m-%d")
                 except ValueError:
-                    raise ValueError(
-                        "{} could not be parsed as as date.".format(datestring)
-                    )
+                    try:
+                        return datetime.datetime.fromisoformat(datestring)
+                    except ValueError:
+                        raise ValueError(
+                            "{} could not be parsed as as date.".format(datestring)
+                        )
 
 
 def list_of_dates(start, stop):

--- a/flowmachine/tests/test_date_range.py
+++ b/flowmachine/tests/test_date_range.py
@@ -13,10 +13,10 @@ def test_start_and_end_date():
     DateRange knows its start and end date,
     """
     dp = DateRange(start_date="2016-01-01", end_date="2016-01-03")
-    assert dp.start_date == dt.date(2016, 1, 1)
-    assert dp.end_date == dt.date(2016, 1, 3)
-    assert dp.start_date_as_str == "2016-01-01"
-    assert dp.end_date_as_str == "2016-01-03"
+    assert dp.start_date == dt.datetime(2016, 1, 1, 0, 0, 0)
+    assert dp.end_date == dt.datetime(2016, 1, 3, 0, 0, 0)
+    assert dp.start_date_as_str == "2016-01-01 00:00:00"
+    assert dp.end_date_as_str == "2016-01-03 00:00:00"
 
 
 def test_one_day_past_end_date():
@@ -24,12 +24,14 @@ def test_one_day_past_end_date():
     DateRange knows the date after its end date.
     """
     dp = DateRange(start_date="2016-01-07", end_date="2016-01-14")
-    assert dp.one_day_past_end_date == dt.date(2016, 1, 15)
-    assert dp.one_day_past_end_date_as_str == "2016-01-15"
+    assert dp.one_day_past_end_date == dt.datetime(2016, 1, 15, 0, 0, 0)
+    assert dp.one_day_past_end_date_as_str == "2016-01-15 00:00:00"
 
-    dp = DateRange(start_date=dt.date(2016, 4, 12), end_date=dt.date(2016, 5, 31))
-    assert dp.one_day_past_end_date == dt.date(2016, 6, 1)
-    assert dp.one_day_past_end_date_as_str == "2016-06-01"
+    dp = DateRange(
+        start_date=dt.date(2016, 4, 12), end_date=dt.datetime(2016, 5, 31, 0, 0, 0)
+    )
+    assert dp.one_day_past_end_date == dt.datetime(2016, 6, 1, 0, 0, 0)
+    assert dp.one_day_past_end_date_as_str == "2016-06-01 00:00:00"
 
 
 @pytest.mark.parametrize(
@@ -37,8 +39,6 @@ def test_one_day_past_end_date():
     [
         (ValueError, "9999-99-99", "2016-01-03"),
         (ValueError, "2016-01-01", "9999-99-99"),
-        (TypeError, dt.datetime(2016, 1, 1, 11, 22, 33), "2016-01-03"),
-        (TypeError, "2016-01-01", dt.datetime(2016, 1, 1, 11, 22, 33)),
         (TypeError, 42, "2016-01-03"),
         (TypeError, "2016-01-01", 42),
     ],

--- a/flowmachine/tests/test_dependency_graph.py
+++ b/flowmachine/tests/test_dependency_graph.py
@@ -51,20 +51,20 @@ def test_print_dependency_tree():
           - <Query of type: AdminSpatialUnit, query_id: 'xxxxx'>
              - <Table: 'geography.admin3', query_id: 'xxxxx'>
           - <Query of type: SubscriberLocations, query_id: 'xxxxx'>
+             - <Query of type: AdminSpatialUnit, query_id: 'xxxxx'>
+                - <Table: 'geography.admin3', query_id: 'xxxxx'>
              - <Query of type: JoinToLocation, query_id: 'xxxxx'>
-                - <Query of type: AdminSpatialUnit, query_id: 'xxxxx'>
-                   - <Table: 'geography.admin3', query_id: 'xxxxx'>
                 - <Query of type: EventsTablesUnion, query_id: 'xxxxx'>
-                   - <Query of type: EventTableSubset, query_id: 'xxxxx'>
-                      - <Query of type: CustomQuery, query_id: 'xxxxx'>
-                      - <Table: 'events.sms', query_id: 'xxxxx'>
-                         - <Table: 'events.sms', query_id: 'xxxxx'>
                    - <Query of type: EventTableSubset, query_id: 'xxxxx'>
                       - <Query of type: CustomQuery, query_id: 'xxxxx'>
                       - <Table: 'events.calls', query_id: 'xxxxx'>
                          - <Table: 'events.calls', query_id: 'xxxxx'>
-             - <Query of type: AdminSpatialUnit, query_id: 'xxxxx'>
-                - <Table: 'geography.admin3', query_id: 'xxxxx'>
+                   - <Query of type: EventTableSubset, query_id: 'xxxxx'>
+                      - <Query of type: CustomQuery, query_id: 'xxxxx'>
+                      - <Table: 'events.sms', query_id: 'xxxxx'>
+                         - <Table: 'events.sms', query_id: 'xxxxx'>
+                - <Query of type: AdminSpatialUnit, query_id: 'xxxxx'>
+                   - <Table: 'geography.admin3', query_id: 'xxxxx'>
         """
     )
 

--- a/flowmachine/tests/test_query_object_construction.test_construct_query.approved.txt
+++ b/flowmachine/tests/test_query_object_construction.test_construct_query.approved.txt
@@ -1,5 +1,5 @@
 {
-  "0afc83b1732fcd2abfbe6bfb857a2861": {
+  "6353b1246a73d0f70de07ae191a95c8b": {
     "query_kind": "spatial_aggregate",
     "locations": {
       "query_kind": "daily_location",
@@ -16,7 +16,7 @@
       }
     }
   },
-  "5125117df170aaeac6fe8fda56212aee": {
+  "aa18ff4cc8cd4baf0c3d5c72a75a3cd9": {
     "query_kind": "spatial_aggregate",
     "locations": {
       "query_kind": "daily_location",
@@ -27,7 +27,7 @@
       "sampling": null
     }
   },
-  "dd755e303d9e5511055aec91deb7d134": {
+  "40bf78d6c38148cea59e4a9c26a0cefc": {
     "query_kind": "location_event_counts",
     "start_date": "2016-01-01",
     "end_date": "2016-01-02",
@@ -37,7 +37,7 @@
     "event_types": null,
     "subscriber_subset": null
   },
-  "7e1b346d2a9184f40b4f0b218fb7461a": {
+  "b155478a246bca7fa30094c51cce4faf": {
     "query_kind": "spatial_aggregate",
     "locations": {
       "query_kind": "modal_location",
@@ -63,7 +63,7 @@
     "query_kind": "geography",
     "aggregation_unit": "admin3"
   },
-  "bfca485986fd9593ba367b5f07715cdf": {
+  "e3093957d5792d9fca6797eee24758a5": {
     "query_kind": "meaningful_locations_aggregate",
     "aggregation_unit": "admin1",
     "start_date": "2016-01-01",
@@ -156,7 +156,7 @@
     "tower_cluster_call_threshold": 0,
     "subscriber_subset": null
   },
-  "ed2ad39a33e29d0024dc08492b5fecff": {
+  "82b0a2a1b274aade7de018195eaec86c": {
     "query_kind": "meaningful_locations_between_label_od_matrix",
     "aggregation_unit": "admin1",
     "start_date": "2016-01-01",
@@ -250,7 +250,7 @@
     "tower_cluster_call_threshold": 0,
     "subscriber_subset": null
   },
-  "8157c0cb3d55284a041f5b78950379a8": {
+  "9c255f14595818421f0b0a72bc3497b8": {
     "query_kind": "meaningful_locations_between_dates_od_matrix",
     "aggregation_unit": "admin1",
     "start_date_a": "2016-01-01",

--- a/flowmachine/tests/test_total_active_periods_subscriber.py
+++ b/flowmachine/tests/test_total_active_periods_subscriber.py
@@ -35,8 +35,8 @@ def test_multiple_day_periods(get_dataframe):
 
     tap = TotalActivePeriodsSubscriber("2016-01-02", 3, 2)
     df = get_dataframe(tap)
-    starts = ["2016-01-02", "2016-01-04", "2016-01-06"]
-    stops = ["2016-01-04", "2016-01-06", "2016-01-08"]
+    starts = ["2016-01-02 00:00:00", "2016-01-04 00:00:00", "2016-01-06 00:00:00"]
+    stops = ["2016-01-04 00:00:00", "2016-01-06 00:00:00", "2016-01-08 00:00:00"]
     # Check that the start and stop dates are as expected
     assert tap.starts == starts
     assert tap.stops == stops

--- a/flowmachine/tests/test_utils.py
+++ b/flowmachine/tests/test_utils.py
@@ -35,8 +35,8 @@ def test_time_period_add():
     flowmachine.utils.time_period_add does what it says on the tin.
     """
 
-    assert time_period_add("2016-01-01", 3) == "2016-01-04"
-    assert time_period_add("2017-12-31", 1) == "2018-01-01"
+    assert time_period_add("2016-01-01", 3) == "2016-01-04 00:00:00"
+    assert time_period_add("2017-12-31", 1) == "2018-01-01 00:00:00"
 
 
 def test_time_period_add_other_units():

--- a/flowmachine/tests/test_utils.py
+++ b/flowmachine/tests/test_utils.py
@@ -13,6 +13,21 @@ from flowmachine.utils import *
 from flowmachine.utils import _makesafe
 
 
+@pytest.mark.parametrize(
+    "date, expected",
+    [
+        (None, None),
+        (datetime.date(2016, 1, 1), "2016-01-01 00:00:00"),
+        (datetime.datetime(2016, 1, 1), "2016-01-01 00:00:00"),
+        ("2016-01-01", "2016-01-01 00:00:00"),
+        ("2016-01-01T00:00:00", "2016-01-01 00:00:00"),
+        ("2016-01-01 00:00:00", "2016-01-01 00:00:00"),
+    ],
+)
+def test_standardise_date(date, expected):
+    assert standardise_date(date) == expected
+
+
 @pytest.mark.parametrize("crs", (None, 4326, "+proj=longlat +datum=WGS84 +no_defs"))
 def test_proj4string(crs, flowmachine_connect):
     """

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_json_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_json_spec.approved.txt
@@ -126,7 +126,7 @@
             "type": "string"
           },
           "end_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "query_kind": {
@@ -136,7 +136,7 @@
             "type": "string"
           },
           "start_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -168,7 +168,7 @@
             "type": "string"
           },
           "end_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "metric": {
@@ -187,7 +187,7 @@
             "type": "string"
           },
           "start_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           }
         },
@@ -213,7 +213,7 @@
             "type": "string"
           },
           "date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "method": {
@@ -273,7 +273,7 @@
             "nullable": true
           },
           "start": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "statistic": {
@@ -289,7 +289,7 @@
             "type": "string"
           },
           "stop": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -381,11 +381,11 @@
             "nullable": true
           },
           "start": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "stop": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -556,7 +556,7 @@
             "type": "string"
           },
           "end_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "method": {
@@ -581,7 +581,7 @@
             "nullable": true
           },
           "start_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -857,7 +857,7 @@
             "type": "string"
           },
           "end_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "event_types": {
@@ -889,7 +889,7 @@
             "type": "string"
           },
           "start_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -931,7 +931,7 @@
             "type": "string"
           },
           "end_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "query_kind": {
@@ -941,7 +941,7 @@
             "type": "string"
           },
           "start_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           }
         },
@@ -966,7 +966,7 @@
             "type": "string"
           },
           "end_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "label": {
@@ -985,7 +985,7 @@
             "type": "string"
           },
           "start_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -1049,11 +1049,11 @@
             "type": "string"
           },
           "end_date_a": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "end_date_b": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "label": {
@@ -1072,11 +1072,11 @@
             "type": "string"
           },
           "start_date_a": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "start_date_b": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -1141,7 +1141,7 @@
             "type": "string"
           },
           "end_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "label_a": {
@@ -1163,7 +1163,7 @@
             "type": "string"
           },
           "start_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -1276,11 +1276,11 @@
             "nullable": true
           },
           "start": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "stop": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -1321,11 +1321,11 @@
             "nullable": true
           },
           "start": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "stop": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -1347,7 +1347,7 @@
       "RadiusOfGyration": {
         "properties": {
           "end_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "query_kind": {
@@ -1365,7 +1365,7 @@
             "nullable": true
           },
           "start_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -1501,11 +1501,11 @@
             "nullable": true
           },
           "start": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "stop": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -1575,7 +1575,7 @@
             "nullable": true
           },
           "start": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "statistic": {
@@ -1591,7 +1591,7 @@
             "type": "string"
           },
           "stop": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -1613,7 +1613,7 @@
       "TopUpBalance": {
         "properties": {
           "end_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "query_kind": {
@@ -1631,7 +1631,7 @@
             "nullable": true
           },
           "start_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "statistic": {
@@ -1675,7 +1675,7 @@
             "type": "string"
           },
           "end_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "query_kind": {
@@ -1685,7 +1685,7 @@
             "type": "string"
           },
           "start_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "total_by": {
@@ -1722,7 +1722,7 @@
             "type": "string"
           },
           "end_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "query_kind": {
@@ -1732,7 +1732,7 @@
             "type": "string"
           },
           "start_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -1764,7 +1764,7 @@
             "type": "string"
           },
           "end_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "query_kind": {
@@ -1774,7 +1774,7 @@
             "type": "string"
           },
           "start_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -1806,7 +1806,7 @@
             "type": "string"
           },
           "end_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "query_kind": {
@@ -1824,7 +1824,7 @@
             "nullable": true
           },
           "start_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "subscriber_subset": {
@@ -1856,7 +1856,7 @@
             "type": "string"
           },
           "end_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           },
           "query_kind": {
@@ -1866,7 +1866,7 @@
             "type": "string"
           },
           "start_date": {
-            "format": "date",
+            "format": "date-time",
             "type": "string"
           }
         },

--- a/integration_tests/tests/flowmachine_server_tests/test_action_run_query.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_action_run_query.py
@@ -224,7 +224,7 @@ def test_cache_content(
                     "subscriber_subset": None,
                 },
             },
-            {"locations": {"date": ["Not a valid date."]}},
+            {"locations": {"date": ["Not a valid datetime."]}},
         ),
         (
             {

--- a/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
@@ -208,7 +208,7 @@
         "type": "string"
       },
       "date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "method": {

--- a/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
@@ -123,7 +123,7 @@
         "type": "string"
       },
       "end_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "query_kind": {
@@ -133,7 +133,7 @@
         "type": "string"
       },
       "start_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -164,7 +164,7 @@
         "type": "string"
       },
       "end_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "metric": {
@@ -183,7 +183,7 @@
         "type": "string"
       },
       "start_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       }
     },
@@ -267,7 +267,7 @@
         "nullable": true
       },
       "start": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "statistic": {
@@ -283,7 +283,7 @@
         "type": "string"
       },
       "stop": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -373,11 +373,11 @@
         "nullable": true
       },
       "start": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "stop": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -545,7 +545,7 @@
         "type": "string"
       },
       "end_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "method": {
@@ -570,7 +570,7 @@
         "nullable": true
       },
       "start_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -843,7 +843,7 @@
         "type": "string"
       },
       "end_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "event_types": {
@@ -875,7 +875,7 @@
         "type": "string"
       },
       "start_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -916,7 +916,7 @@
         "type": "string"
       },
       "end_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "query_kind": {
@@ -926,7 +926,7 @@
         "type": "string"
       },
       "start_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       }
     },
@@ -950,7 +950,7 @@
         "type": "string"
       },
       "end_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "label": {
@@ -969,7 +969,7 @@
         "type": "string"
       },
       "start_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -1032,11 +1032,11 @@
         "type": "string"
       },
       "end_date_a": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "end_date_b": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "label": {
@@ -1055,11 +1055,11 @@
         "type": "string"
       },
       "start_date_a": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "start_date_b": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -1123,7 +1123,7 @@
         "type": "string"
       },
       "end_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "label_a": {
@@ -1145,7 +1145,7 @@
         "type": "string"
       },
       "start_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -1257,11 +1257,11 @@
         "nullable": true
       },
       "start": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "stop": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -1301,11 +1301,11 @@
         "nullable": true
       },
       "start": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "stop": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -1326,7 +1326,7 @@
   "RadiusOfGyration": {
     "properties": {
       "end_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "query_kind": {
@@ -1344,7 +1344,7 @@
         "nullable": true
       },
       "start_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -1478,11 +1478,11 @@
         "nullable": true
       },
       "start": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "stop": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -1551,7 +1551,7 @@
         "nullable": true
       },
       "start": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "statistic": {
@@ -1567,7 +1567,7 @@
         "type": "string"
       },
       "stop": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -1588,7 +1588,7 @@
   "TopUpBalance": {
     "properties": {
       "end_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "query_kind": {
@@ -1606,7 +1606,7 @@
         "nullable": true
       },
       "start_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "statistic": {
@@ -1649,7 +1649,7 @@
         "type": "string"
       },
       "end_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "query_kind": {
@@ -1659,7 +1659,7 @@
         "type": "string"
       },
       "start_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "total_by": {
@@ -1695,7 +1695,7 @@
         "type": "string"
       },
       "end_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "query_kind": {
@@ -1705,7 +1705,7 @@
         "type": "string"
       },
       "start_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -1736,7 +1736,7 @@
         "type": "string"
       },
       "end_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "query_kind": {
@@ -1746,7 +1746,7 @@
         "type": "string"
       },
       "start_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -1777,7 +1777,7 @@
         "type": "string"
       },
       "end_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "query_kind": {
@@ -1795,7 +1795,7 @@
         "nullable": true
       },
       "start_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "subscriber_subset": {
@@ -1826,7 +1826,7 @@
         "type": "string"
       },
       "end_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       },
       "query_kind": {
@@ -1836,7 +1836,7 @@
         "type": "string"
       },
       "start_date": {
-        "format": "date",
+        "format": "date-time",
         "type": "string"
       }
     },


### PR DESCRIPTION
Closes #2391

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Does two things:

- FlowAPI now accepts datetimes where previously it only accepted dates (this is done by parsing them using `datetime.datetime.fromisoformat` instead of the much more restrictive marshmallow version), which means you can now work at sub-day temporal granularity.
- FlowMachine now uses `YYYY-MM-DD HH:MM:SS` across the board as the internal time string, and converts any provided date string or date to that.