### PR TITLE
Flowauth mysql fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- Fixed FlowAuth's MySQL support.
 
 ### Removed
 

--- a/flowauth/Dockerfile
+++ b/flowauth/Dockerfile
@@ -13,12 +13,11 @@ FROM tiangolo/uwsgi-nginx-flask:python3.6-alpine3.8
 COPY Pipfile .
 COPY Pipfile.lock .
 # Install dependencies required for argon crypto & psycopg2
-RUN apk update && apk add --virtual build-dependencies build-base postgresql-dev gcc python3-dev musl-dev \
+RUN apk update && apk add --no-cache --virtual build-dependencies build-base postgresql-dev gcc python3-dev musl-dev \
     libressl-dev libffi-dev mariadb-connector-c-dev && \
     pip install --no-cache-dir pipenv && pipenv install --clear --deploy --system && \
     apk del build-dependencies && \
-    apk add libpq # Required for psycopg2 && \
-    apk add mariadb-connector-c # Required for mysqlclient
+    apk add --no-cache libpq mariadb-connector-c # Required for psycopg2 & mysqlclient
 ENV STATIC_PATH /app/static
 ENV STATIC_INDEX 1
 ENV FLASK_APP flowauth

--- a/flowauth/backend/flowauth/models.py
+++ b/flowauth/backend/flowauth/models.py
@@ -33,8 +33,8 @@ class User(db.Model):
     """
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    username = db.Column(db.String(), unique=True, nullable=False)
-    _password = db.Column(db.String(), nullable=False)
+    username = db.Column(db.String(75), unique=True, nullable=False)
+    _password = db.Column(db.Text, nullable=False)
     is_admin = db.Column(db.Boolean, default=False)
     groups = db.relationship(
         "Group",
@@ -179,7 +179,7 @@ class TwoFactorAuth(db.Model):
     )
     user = db.relationship("User", back_populates="two_factor_auth", lazy=True)
     enabled = db.Column(db.Boolean, nullable=False, default=False)
-    _secret_key = db.Column(db.String(), nullable=False)  # Encrypted in db
+    _secret_key = db.Column(db.Text, nullable=False)  # Encrypted in db
     two_factor_backups = db.relationship(
         "TwoFactorBackup", back_populates="auth", cascade="all, delete, delete-orphan"
     )
@@ -315,7 +315,7 @@ class TwoFactorBackup(db.Model):
     auth = db.relationship(
         "TwoFactorAuth", back_populates="two_factor_backups", lazy=True
     )
-    _backup_code = db.Column(db.String(), nullable=False)
+    _backup_code = db.Column(db.String(75), nullable=False)
 
     def verify(self, plaintext: str) -> bool:
         """
@@ -369,7 +369,7 @@ class Token(db.Model):
     """
 
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(), nullable=False)
+    name = db.Column(db.String(75), nullable=False)
     _token = db.Column(db.Text, nullable=False)
     expires = db.Column(db.DateTime, nullable=False)
     owner_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
@@ -432,7 +432,7 @@ class Server(db.Model):
     """
 
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(), unique=True, nullable=False)
+    name = db.Column(db.String(75), unique=True, nullable=False)
     latest_token_expiry = db.Column(db.DateTime, nullable=False)
     longest_token_life = db.Column(db.Integer, nullable=False)
     tokens = db.relationship(
@@ -529,7 +529,7 @@ class Group(db.Model):
     """
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    name = db.Column(db.String(), unique=True, nullable=False)
+    name = db.Column(db.String(75), unique=True, nullable=False)
     user_group = db.Column(db.Boolean, default=False)
     server_token_limits = db.relationship(
         "GroupServerTokenLimits",

--- a/flowauth/backend/flowauth/models.py
+++ b/flowauth/backend/flowauth/models.py
@@ -461,7 +461,7 @@ class ServerCapability(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     server_id = db.Column(db.Integer, db.ForeignKey("server.id"), nullable=False)
     server = db.relationship("Server", back_populates="capabilities", lazy=True)
-    capability = db.Column(db.String, nullable=False)
+    capability = db.Column(db.Text, nullable=False)
     enabled = db.Column(db.Boolean, default=False)
     group_uses = db.relationship(
         "GroupServerPermission",

--- a/flowauth/backend/flowauth/models.py
+++ b/flowauth/backend/flowauth/models.py
@@ -461,7 +461,7 @@ class ServerCapability(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     server_id = db.Column(db.Integer, db.ForeignKey("server.id"), nullable=False)
     server = db.relationship("Server", back_populates="capabilities", lazy=True)
-    capability = db.Column(db.Text, nullable=False)
+    capability = db.Column(db.String(65535), nullable=False)
     enabled = db.Column(db.Boolean, default=False)
     group_uses = db.relationship(
         "GroupServerPermission",

--- a/flowauth/backend/flowauth/models.py
+++ b/flowauth/backend/flowauth/models.py
@@ -317,7 +317,7 @@ class TwoFactorBackup(db.Model):
     auth = db.relationship(
         "TwoFactorAuth", back_populates="two_factor_backups", lazy=True
     )
-    _backup_code = db.Column(db.String(75), nullable=False)
+    _backup_code = db.Column(db.Text, nullable=False)
 
     def verify(self, plaintext: str) -> bool:
         """

--- a/flowauth/backend/flowauth/models.py
+++ b/flowauth/backend/flowauth/models.py
@@ -461,7 +461,7 @@ class ServerCapability(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     server_id = db.Column(db.Integer, db.ForeignKey("server.id"), nullable=False)
     server = db.relationship("Server", back_populates="capabilities", lazy=True)
-    capability = db.Column(db.String(65535), nullable=False)
+    capability = db.Column(db.String(21845), nullable=False)
     enabled = db.Column(db.Boolean, default=False)
     group_uses = db.relationship(
         "GroupServerPermission",

--- a/flowauth/backend/flowauth/servers.py
+++ b/flowauth/backend/flowauth/servers.py
@@ -84,7 +84,7 @@ def edit_server_capabilities(server_id):
             cap = ServerCapability(
                 server_id=server_id,
                 capability=cap,
-                capability_hash=md5(cap).hexdigest(),
+                capability_hash=md5(cap.encode()).hexdigest(),
             )
         cap.enabled = enabled
         caps.append(cap)

--- a/flowauth/backend/flowauth/servers.py
+++ b/flowauth/backend/flowauth/servers.py
@@ -81,7 +81,11 @@ def edit_server_capabilities(server_id):
                 server_id=server_id, capability=cap
             ).one()
         except NoResultFound:
-            cap = ServerCapability(server_id=server_id, capability=cap)
+            cap = ServerCapability(
+                server_id=server_id,
+                capability=cap,
+                capability_hash=md5(cap).hexdigest(),
+            )
         cap.enabled = enabled
         caps.append(cap)
     db.session.bulk_save_objects(caps)

--- a/flowauth/backend/tests/conftest.py
+++ b/flowauth/backend/tests/conftest.py
@@ -24,7 +24,7 @@ from flowauth.models import (
     User,
     db,
 )
-from flowauth.user_settings import generate_backup_codes
+from flowauth.user_settings import generate_backup_codes, md5
 
 TestUser = namedtuple("TestUser", ["id", "username", "password"])
 TestTwoFactorUser = namedtuple(
@@ -180,16 +180,19 @@ def test_data(app, test_admin, test_user, test_group):
             ("DUMMY_ROUTE_A", "DUMMY_ROUTE_B"),
             (f"admin{x}" for x in range(4)),
         ):
+            cap = f"{action}&{cap}.aggregation_unit.{admin_unit}"
             sc_a = ServerCapability(
-                capability=f"{action}&{cap}.aggregation_unit.{admin_unit}",
+                capability=cap,
                 server=dummy_server_a,
+                capability_hash=md5(cap.encode()).hexdigest(),
                 enabled=True,
             )
             scs.append(sc_a)
             db.session.add(sc_a)
             sc_b = ServerCapability(
-                capability=f"{action}&{cap}.aggregation_unit.{admin_unit}",
+                capability=cap,
                 server=dummy_server_b,
+                capability_hash=md5(cap.encode()).hexdigest(),
                 enabled=True,
             )
             scs.append(sc_b)

--- a/flowauth/backend/tests/test_access_reflects_server_limits.py
+++ b/flowauth/backend/tests/test_access_reflects_server_limits.py
@@ -1,3 +1,5 @@
+from hashlib import md5
+
 import datetime
 
 from flowauth.models import (
@@ -29,7 +31,10 @@ def test_disallow_right_on_server_disallows_for_group(app):
         )
         session.add(server)
         server_capability = ServerCapability(
-            server=server, capability="get_result&DUMMY_ROUTE", enabled=True
+            server=server,
+            capability="get_result&DUMMY_ROUTE",
+            enabled=True,
+            capability_hash=md5(b"get_result&DUMMY_ROUTE").hexdigest(),
         )
         session.add(server_capability)
         gsp = GroupServerPermission(


### PR DESCRIPTION
### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Slightly tweaks the schema, and adds a missing runtime library to fix FlowAuth being run against mysql.