### PR TITLE
Limit join to location caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- `JoinToLocation` is cacheable only if the joined query is also cacheable.
 
 ### Fixed
 

--- a/flowmachine/flowmachine/core/join_to_location.py
+++ b/flowmachine/flowmachine/core/join_to_location.py
@@ -61,6 +61,11 @@ class JoinToLocation(Query):
         self.time_col = time_col
         super().__init__()
 
+    @property
+    def fully_qualified_table_name(self):
+        self.left.fully_qualified_table_name  # Avoid caching if the joinee shouldn't be
+        return super().fully_qualified_table_name
+
     def __getattr__(self, name):
         # Don't extend this to hidden variables, such as _df
         # and _len

--- a/flowmachine/tests/test_join_to_location.py
+++ b/flowmachine/tests/test_join_to_location.py
@@ -24,6 +24,15 @@ def test_join_to_location_column_names(exemplar_spatial_unit_param):
     assert joined.head(0).columns.tolist() == joined.column_names
 
 
+def test_join_to_location_no_cache_if_joinee_no_cache():
+    with pytest.raises(NotImplementedError):
+        table = SubscriberLocations(
+            "2016-01-05", "2016-01-07", spatial_unit=make_spatial_unit("admin", level=3)
+        )
+        joined = JoinToLocation(table, spatial_unit=make_spatial_unit("admin", level=3))
+        joined.fully_qualified_table_name
+
+
 def test_join_to_location_raises_value_error():
     """
     Test that JoinToLocation raises an InvalidSpatialUnitError if spatial_unit


### PR DESCRIPTION
I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Disables caching of jointolocation unless the joined query is a cacheable one.