### PR TITLE
Bump python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 defaults:
   - &base_docker
-    - image: circleci/python:3.7
+    - image: circleci/python:3.8
       environment:
         FLOWDB_PORT: 5432
         MPLBACKEND: "agg"
@@ -110,7 +110,7 @@ executors:
       FLOWDB_HOST: localhost
       FLOWAPI_IDENTIFIER: TEST_SERVER
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
       - image: flowminder/flowdb-<<parameters.flowdb_image>>:$CIRCLE_SHA1
         environment:
           N_DAYS: <<parameters.num_days>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -580,7 +580,7 @@ jobs:
 
   run_flowclient_tests:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     working_directory: /home/circleci/project/flowclient
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -456,7 +456,7 @@ jobs:
 
   run_token_generator_tests:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     environment:
       FLOWAPI_IDENTIFIER: TEST_SERVER
     working_directory: /home/circleci/project/flowkit_jwt_generator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,10 @@ defaults:
 executors:
   python_with_flowdb: # Synthetic data generation execution environment
     parameters:
+      python_version:
+        type: enum
+        enum: ["3.7", "3.8"]
+        default: "3.8"
       flowdb_image:
         type: enum
         enum: ["synthetic-data", "testdata"]
@@ -110,7 +114,7 @@ executors:
       FLOWDB_HOST: localhost
       FLOWAPI_IDENTIFIER: TEST_SERVER
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:<<parameters.python_version>>
       - image: flowminder/flowdb-<<parameters.flowdb_image>>:$CIRCLE_SHA1
         environment:
           N_DAYS: <<parameters.num_days>>
@@ -440,6 +444,7 @@ jobs:
       name: python_with_flowdb
       flowdb_image: "synthetic-data"
       synthetic_data_generator: <<parameters.synthetic_data_generator>>
+      python_version: "3.7"
     working_directory: /home/circleci/project/flowdb
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -597,7 +597,7 @@ jobs:
 
   run_autoflow_tests:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     working_directory: /home/circleci/project/autoflow
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,7 +503,7 @@ jobs:
 
   run_flowauth_backend_tests:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.8
     environment: &flowauth_env
       FLOWAUTH_FERNET_KEY: "XU-J5xNOtkaUKAoqWT7_VoT3zk2OTuoqKPBN3l0pOFg="
       FLASK_APP: flowauth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -484,7 +484,7 @@ jobs:
 
   run_flowkit_api_tests:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
         environment:
           FLOWAPI_IDENTIFIER: TEST_SERVER
     working_directory: /home/circleci/project/flowapi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- FlowMachine's docker container now uses Python 3.8
+- FlowAPI's docker container now uses Python 3.8
+- FlowAuth's docker container now uses Python 3.8
+- AutoFlow's docker container now uses Python 3.8
 
 ### Fixed
 

--- a/autoflow/Dockerfile
+++ b/autoflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.8-slim
 
 ARG SOURCE_VERSION=0+unknown
 ENV SOURCE_VERSION=${SOURCE_VERSION}

--- a/autoflow/Pipfile
+++ b/autoflow/Pipfile
@@ -35,4 +35,4 @@ sqlalchemy-utils = "*"
 testing-postgresql = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"

--- a/autoflow/Pipfile.lock
+++ b/autoflow/Pipfile.lock
@@ -35,7 +35,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "platform_system == 'Darwin'",
+            "markers": "sys_platform == 'darwin'",
             "version": "==0.1.0"
         },
         "async-generator": {
@@ -240,14 +240,6 @@
                 "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
             "version": "==2.9"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
         },
         "ipykernel": {
             "hashes": [
@@ -1111,7 +1103,7 @@
                 "sha256:c952975c8ba74f546ae6de2e226ab3cc3cc11ae47baf607459a6728585bb542a",
                 "sha256:c98232a3ac391f5faea6821b53db8db461157baa788f5d6222a193e9456e1740"
             ],
-            "markers": "python_version < '3.8'",
+            "markers": "python_version >= '3.8'",
             "version": "==6.0.4"
         },
         "tqdm": {
@@ -1207,13 +1199,6 @@
                 "sha256:8e2969797627c8a663575c2fc6fcb53a05e37cdb83ee65f341fc6e0c3d0ced16"
             ],
             "version": "==2.0.0"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "version": "==3.1.0"
         }
     },
     "develop": {
@@ -1222,7 +1207,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "platform_system == 'Darwin'",
+            "markers": "sys_platform == 'darwin'",
             "version": "==0.1.0"
         },
         "attrs": {
@@ -1389,14 +1374,6 @@
                 "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
             "version": "==2.9"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
         },
         "ipykernel": {
             "hashes": [
@@ -2037,7 +2014,7 @@
                 "sha256:c952975c8ba74f546ae6de2e226ab3cc3cc11ae47baf607459a6728585bb542a",
                 "sha256:c98232a3ac391f5faea6821b53db8db461157baa788f5d6222a193e9456e1740"
             ],
-            "markers": "python_version < '3.8'",
+            "markers": "python_version >= '3.8'",
             "version": "==6.0.4"
         },
         "traitlets": {
@@ -2088,13 +2065,6 @@
                 "sha256:8e2969797627c8a663575c2fc6fcb53a05e37cdb83ee65f341fc6e0c3d0ced16"
             ],
             "version": "==2.0.0"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "version": "==3.1.0"
         }
     }
 }

--- a/autoflow/Pipfile.lock
+++ b/autoflow/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e8d179cf1e9c0e473a79855d08ee00ff6a7f22a6865d8e639224e2fa68b7ec8c"
+            "sha256": "d9341a1b20ba6bcc75432ccdcfb0aaee13f6c6f90d5574ed1b19a7a9f5360371"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8"
         },
         "sources": [
             {

--- a/deployment/Pipfile
+++ b/deployment/Pipfile
@@ -10,4 +10,4 @@ passlib = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"

--- a/deployment/Pipfile.lock
+++ b/deployment/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2d98f2b1e77ca2e6ced9f164b77aa3a0590a8e24c426e825ea9ab21293d28df1"
+            "sha256": "a7ea5563189830598cbfce9b16afe9df34ee6024fc8abc924b0b7430d32f84fa"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8"
         },
         "sources": [
             {

--- a/docs/Pipfile
+++ b/docs/Pipfile
@@ -35,7 +35,7 @@ jupyterlab = "*"
 flowetl = {editable = true,path = "./../flowetl/flowetl"} # Working around version conflict caused by airflow's aggressive pinning
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"
 
 [scripts]
 build = "bash build.sh"

--- a/docs/Pipfile.lock
+++ b/docs/Pipfile.lock
@@ -59,7 +59,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "platform_system == 'Darwin'",
+            "markers": "sys_platform == 'darwin'",
             "version": "==0.1.0"
         },
         "asyncpg": {
@@ -416,14 +416,6 @@
                 "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"
             ],
             "version": "==1.2.0"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
         },
         "ipykernel": {
             "hashes": [
@@ -1451,13 +1443,6 @@
                 "sha256:e3d190a11d9307112ba23bbe60055604949b172143969c8f641318476a9b6f1d"
             ],
             "version": "==0.15.0"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "version": "==3.1.0"
         }
     },
     "develop": {
@@ -1489,7 +1474,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "platform_system == 'Darwin'",
+            "markers": "sys_platform == 'darwin'",
             "version": "==0.1.0"
         },
         "argcomplete": {
@@ -1751,14 +1736,6 @@
                 "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
             "version": "==2.9"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
         },
         "ipykernel": {
             "hashes": [
@@ -2393,14 +2370,6 @@
             ],
             "version": "==4.3.3"
         },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5",
-                "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae",
-                "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"
-            ],
-            "version": "==3.7.4.2"
-        },
         "tzlocal": {
             "hashes": [
                 "sha256:4ebeb848845ac898da6519b9b31879cf13b6626f7184c496037b818e238f2c4e"
@@ -2447,13 +2416,6 @@
                 "sha256:861a13b3ae521d6700dac3b2771970bd354a63ba7043ecc3a82b5288596a1972"
             ],
             "version": "==2.3.1"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "version": "==3.1.0"
         },
         "zope.deprecation": {
             "hashes": [

--- a/docs/Pipfile.lock
+++ b/docs/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b7e01a2bcc74613b70c6583fd64c1eaadd9c7bf52578f65f701b0d20ecaf3a74"
+            "sha256": "6676cb496054a44ba656ff261be505d3f1bd8bc26aa3155bb339b4a8092bf339"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -59,7 +59,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "sys_platform == 'darwin'",
+            "markers": "platform_system == 'Darwin'",
             "version": "==0.1.0"
         },
         "asyncpg": {
@@ -1489,7 +1489,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "sys_platform == 'darwin'",
+            "markers": "platform_system == 'Darwin'",
             "version": "==0.1.0"
         },
         "argcomplete": {

--- a/docs/Pipfile.lock
+++ b/docs/Pipfile.lock
@@ -531,10 +531,10 @@
                 "languages"
             ],
             "hashes": [
-                "sha256:1208622930c915a07e6f8e8640474357826bad48534c0f57969b6fca9bffc88e",
-                "sha256:7be69d7186f65784a4f2adf81e5c58efd6a9921aa95966babcb1f2f2ada75c20"
+                "sha256:aab3f489c4d4fab4c1294a257a30fec397db56f0a50273218ccc3efdbf01d6ca",
+                "sha256:c4fb063b98eff775dd638b3df380008ae85e6cb1d1a24d1cd81a10ef6391c26e"
             ],
-            "version": "==0.5.6"
+            "version": "==0.5.8"
         },
         "mapboxgl": {
             "hashes": [
@@ -639,11 +639,11 @@
         },
         "mkdocs": {
             "hashes": [
-                "sha256:1e385a70aea8a9dedb731aea4fd5f3704b2074801c4f96f06b2920999babda8a",
-                "sha256:9243291392f59e20b655e4e46210233453faf97787c2cf72176510e868143174"
+                "sha256:33d5843e17ce7f21c40a31e04550eac2826697d8417c5a3f3dd50b9c3953cd04",
+                "sha256:9fe57f2631ea39ebb50571af9998004a90f010cbc9cb9f24c4237ecad7211a96"
             ],
             "index": "pypi",
-            "version": "==1.1"
+            "version": "==1.1.1"
         },
         "mkdocs-material": {
             "hashes": [

--- a/flowapi/Dockerfile
+++ b/flowapi/Dockerfile
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 ARG SOURCE_VERSION=0+unknown
 ENV SOURCE_VERSION=${SOURCE_VERSION}

--- a/flowapi/Pipfile
+++ b/flowapi/Pipfile
@@ -26,4 +26,4 @@ black = "==19.10b0"
 flowkit-jwt-generator = {editable = true,path = "./../flowkit_jwt_generator"}
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"

--- a/flowapi/Pipfile.lock
+++ b/flowapi/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "11e286323f250fa305b21e2c61b328e67f7cd7bd06caa44d9cfa93c970dab645"
+            "sha256": "bed9672ba141d9f982c5d55f16af3b9732afff4787ab3b07cd45b6d1a8aa2bf5"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8"
         },
         "sources": [
             {

--- a/flowapi/Pipfile.lock
+++ b/flowapi/Pipfile.lock
@@ -203,14 +203,6 @@
             ],
             "version": "==2.9"
         },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
-        },
         "itsdangerous": {
             "hashes": [
                 "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
@@ -484,13 +476,6 @@
                 "sha256:e3d190a11d9307112ba23bbe60055604949b172143969c8f641318476a9b6f1d"
             ],
             "version": "==0.15.0"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "version": "==3.1.0"
         }
     },
     "develop": {
@@ -649,14 +634,6 @@
                 "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
             "version": "==2.9"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
         },
         "more-itertools": {
             "hashes": [
@@ -823,13 +800,6 @@
                 "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
             ],
             "version": "==0.1.9"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "version": "==3.1.0"
         }
     }
 }

--- a/flowapi/setup.py
+++ b/flowapi/setup.py
@@ -25,6 +25,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
+    python_requires=">=3.7",
     install_requires=[
         "quart",
         "pyzmq",

--- a/flowauth/Dockerfile
+++ b/flowauth/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install --production
 RUN PUBLIC_URL=/static npm run-script build
 
 
-FROM tiangolo/uwsgi-nginx-flask:python3.6-alpine3.8
+FROM tiangolo/uwsgi-nginx-flask:python3.8-alpine3.10
 COPY Pipfile .
 COPY Pipfile.lock .
 # Install dependencies required for argon crypto & psycopg2

--- a/flowauth/Dockerfile
+++ b/flowauth/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install --production
 RUN PUBLIC_URL=/static npm run-script build
 
 
-FROM tiangolo/uwsgi-nginx-flask:python3.8-alpine3.10
+FROM tiangolo/uwsgi-nginx-flask:python3.8-alpine
 COPY Pipfile .
 COPY Pipfile.lock .
 # Install dependencies required for argon crypto & psycopg2

--- a/flowauth/Pipfile
+++ b/flowauth/Pipfile
@@ -33,7 +33,7 @@ flowauth = {editable = true,path = "./backend"}
 flowkit-jwt-generator = {editable = true,path = "./../flowkit_jwt_generator"}
 
 [requires]
-python_version = "3.6"
+python_version = "3.8"
 
 [scripts]
 build-frontend = "bash start.sh build"

--- a/flowauth/Pipfile.lock
+++ b/flowauth/Pipfile.lock
@@ -639,14 +639,6 @@
             ],
             "version": "==2.9"
         },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
-        },
         "itsdangerous": {
             "hashes": [
                 "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
@@ -935,13 +927,6 @@
                 "sha256:861a13b3ae521d6700dac3b2771970bd354a63ba7043ecc3a82b5288596a1972"
             ],
             "version": "==2.3.1"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "version": "==3.1.0"
         },
         "zxcvbn": {
             "hashes": [

--- a/flowauth/Pipfile.lock
+++ b/flowauth/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3dc7aa680feb9bb59ed8a5dd569e89e6fc0f2fc8d46196a0008e53bf42024604"
+            "sha256": "63638f3438ce96b585c33598949cc343da7c6590a4af09dc5ad8bcd39cbe9eeb"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.8"
         },
         "sources": [
             {

--- a/flowauth/backend/setup.py
+++ b/flowauth/backend/setup.py
@@ -24,6 +24,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
+    python_requires=">=3.7",
     install_requires=[
         "flask",
         "flask-sqlalchemy",

--- a/flowclient/Pipfile
+++ b/flowclient/Pipfile
@@ -21,4 +21,4 @@ ipython = "*"
 ipdb = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"

--- a/flowclient/Pipfile.lock
+++ b/flowclient/Pipfile.lock
@@ -242,14 +242,6 @@
             ],
             "version": "==4.4.2"
         },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
-        },
         "ipdb": {
             "hashes": [
                 "sha256:77fb1c2a6fccdfee0136078c9ed6fe547ab00db00bebff181f1e8c9e13418d49"
@@ -474,13 +466,6 @@
                 "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
             ],
             "version": "==0.1.9"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "version": "==3.1.0"
         }
     }
 }

--- a/flowclient/Pipfile.lock
+++ b/flowclient/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9f0c5efc4b89aca5df70f7b758e5197add4b0b69da95d8139ce425ac92655c30"
+            "sha256": "8faa454fc6e20cbcd206b3c66af3f38b2e7717a1f952b8dedbe5810c003a3d38"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8"
         },
         "sources": [
             {

--- a/flowclient/setup.py
+++ b/flowclient/setup.py
@@ -55,6 +55,7 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.7",
         "Natural Language :: English",
         "Operating System :: MacOS :: MacOS X",

--- a/flowclient/setup.py
+++ b/flowclient/setup.py
@@ -38,6 +38,7 @@ setup(
     keywords="mobile telecommunications analysis",
     packages=["flowclient"],
     include_package_data=True,
+    python_requires=">=3.6",
     install_requires=[
         "pandas",
         "requests",

--- a/flowdb/testdata/synthetic_data/Pipfile.lock
+++ b/flowdb/testdata/synthetic_data/Pipfile.lock
@@ -32,10 +32,10 @@
         },
         "faker": {
             "hashes": [
-                "sha256:53bf2c8a2de8af271466e7b9cc2f08ecf83c4c947981680eb61080779a0adace",
-                "sha256:7292806948ed848f1bcea1e7b963bae6f398687d1da0ea096e156fea2787f454"
+                "sha256:103c46b9701a151299c5bffe6fefcd4fb5fb04c3b5d06bee4952d36255d44ea2",
+                "sha256:34ae397aef03a0a17910452f1e8430d57fa59e2d67b20e9b637218e8f7dd22b3"
             ],
-            "version": "==4.0.3"
+            "version": "==4.1.0"
         },
         "geojson": {
             "hashes": [

--- a/flowdb/testdata/test_data/Pipfile.lock
+++ b/flowdb/testdata/test_data/Pipfile.lock
@@ -32,10 +32,10 @@
         },
         "faker": {
             "hashes": [
-                "sha256:53bf2c8a2de8af271466e7b9cc2f08ecf83c4c947981680eb61080779a0adace",
-                "sha256:7292806948ed848f1bcea1e7b963bae6f398687d1da0ea096e156fea2787f454"
+                "sha256:103c46b9701a151299c5bffe6fefcd4fb5fb04c3b5d06bee4952d36255d44ea2",
+                "sha256:34ae397aef03a0a17910452f1e8430d57fa59e2d67b20e9b637218e8f7dd22b3"
             ],
-            "version": "==4.0.3"
+            "version": "==4.1.0"
         },
         "geoalchemy2": {
             "hashes": [

--- a/flowkit_jwt_generator/Pipfile
+++ b/flowkit_jwt_generator/Pipfile
@@ -17,4 +17,4 @@ flowkit-jwt-generator = {editable = true,path = "."}
 black = "==19.10b0"
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"

--- a/flowkit_jwt_generator/Pipfile.lock
+++ b/flowkit_jwt_generator/Pipfile.lock
@@ -110,14 +110,6 @@
             ],
             "version": "==2.9"
         },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
-        },
         "more-itertools": {
             "hashes": [
                 "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
@@ -204,13 +196,6 @@
                 "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
             ],
             "version": "==0.1.9"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "version": "==3.1.0"
         }
     },
     "develop": {
@@ -362,14 +347,6 @@
                 "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
             "version": "==2.9"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
         },
         "more-itertools": {
             "hashes": [
@@ -539,13 +516,6 @@
                 "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
             ],
             "version": "==0.1.9"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "version": "==3.1.0"
         }
     }
 }

--- a/flowkit_jwt_generator/Pipfile.lock
+++ b/flowkit_jwt_generator/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "48e10e61c4e0545699cda3722632148131bffb6954c7628a1b0c3751021f8b6c"
+            "sha256": "29cc6ed8c285ebc91ec580a127fd1ed7a0bbc59d91e4854b13b54fc67347d2ac"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8"
         },
         "sources": [
             {

--- a/flowkit_jwt_generator/setup.py
+++ b/flowkit_jwt_generator/setup.py
@@ -46,10 +46,12 @@ setup(
     extras_require={"test": test_requirements},
     tests_require=test_requirements,
     setup_requires=["pytest-runner"],
+    python_requires=">=3.6",
     platforms=["MacOS X", "Linux"],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.6",
         "Natural Language :: English",

--- a/flowmachine/Dockerfile
+++ b/flowmachine/Dockerfile
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-FROM python:3.7-slim
+FROM python:3.8-slim
 
 ARG SOURCE_VERSION=0+unknown
 ENV SOURCE_VERSION=${SOURCE_VERSION}

--- a/flowmachine/Pipfile
+++ b/flowmachine/Pipfile
@@ -44,4 +44,4 @@ watchdog = "*"
 ipdb = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"

--- a/flowmachine/Pipfile.lock
+++ b/flowmachine/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7d78fdaa1ac1cca66f1720215da150d549964ca6a5c94193be77db8c9d5e645e"
+            "sha256": "2f491d4cb9fc1b0d0ced8db66711dea17fb37dd713ce7e515f39d895d23a45ea"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -371,7 +371,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "platform_system == 'Darwin'",
+            "markers": "sys_platform == 'darwin'",
             "version": "==0.1.0"
         },
         "approvaltests": {

--- a/flowmachine/Pipfile.lock
+++ b/flowmachine/Pipfile.lock
@@ -371,7 +371,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "sys_platform == 'darwin'",
+            "markers": "platform_system == 'Darwin'",
             "version": "==0.1.0"
         },
         "approvaltests": {
@@ -565,14 +565,6 @@
                 "sha256:88ed90632023e52a6495749c6732e61e08ec9f4f04e95484a5c37b9caf40283c"
             ],
             "version": "==1.4.15"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
         },
         "ipdb": {
             "hashes": [
@@ -785,11 +777,11 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:979b53dab1af35063a483bfe13b0fcbbf1a2cf8c46b60e0a9a8d08e8269647a1",
-                "sha256:f3e85e68c6d1cbe7828d3471896f1b192cfcf1c4d83bf26e26beeb5941855257"
+                "sha256:5559e09afcac7808933951ffaf4ff9aac524f31efbc3f24d021540b6c579813c",
+                "sha256:703e2e34cbe0eedb0d319eff9f7b83e2022bb5a3ab5289a6a8841441076514d0"
             ],
             "index": "pypi",
-            "version": "==2.3.0"
+            "version": "==2.4.0"
         },
         "prompt-toolkit": {
             "hashes": [
@@ -1089,13 +1081,6 @@
                 "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
             ],
             "version": "==0.1.9"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "version": "==3.1.0"
         }
     }
 }

--- a/flowmachine/Pipfile.lock
+++ b/flowmachine/Pipfile.lock
@@ -371,7 +371,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "platform_system == 'Darwin'",
+            "markers": "sys_platform == 'darwin'",
             "version": "==0.1.0"
         },
         "approvaltests": {

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -15,7 +15,7 @@ from functools import partial
 
 from typing import TYPE_CHECKING, Tuple, List, Callable, Optional
 
-from psycopg2 import InternalError
+import psycopg2
 
 from redis import StrictRedis
 import psycopg2
@@ -230,7 +230,7 @@ def touch_cache(connection: "Connection", query_id: str) -> float:
     """
     try:
         return float(connection.fetch(f"SELECT touch_cache('{query_id}')")[0][0])
-    except (IndexError, InternalError):
+    except (IndexError, psycopg2.InternalError):
         raise ValueError(f"Query id '{query_id}' is not in cache on this connection.")
 
 
@@ -822,7 +822,7 @@ async def watch_and_shrink_cache(
                 ),
                 timeout=timeout,
             )
-        except TimeoutError:
+        except (TimeoutError, asyncio.exceptions.TimeoutError):
             logger.error(
                 f"Failed to complete cache shrink within {timeout}s. Trying again in {sleep_time}s."
             )

--- a/flowmachine/setup.py
+++ b/flowmachine/setup.py
@@ -100,6 +100,7 @@ setup(
     classifiers=[
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
         "Development Status :: 4 - Beta",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.7",
         "Natural Language :: English",
         "Operating System :: MacOS :: MacOS X",

--- a/flowmachine/tests/server/test_server_config.py
+++ b/flowmachine/tests/server/test_server_config.py
@@ -66,4 +66,4 @@ def test_get_server_config_defaults(monkeypatch):
     assert config.store_dependencies
     assert config.cache_pruning_timeout == 600
     assert config.cache_pruning_frequency == 86400
-    assert config.server_thread_pool._max_workers == (os.cpu_count() or 1) * 5
+    assert config.server_thread_pool._max_workers == min(32, os.cpu_count() + 4)

--- a/integration_tests/Pipfile
+++ b/integration_tests/Pipfile
@@ -18,7 +18,7 @@ flowkit-jwt-generator = {editable = true,path = "./../flowkit_jwt_generator"}
 geojson = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"
 
 [dev-packages]
 

--- a/integration_tests/Pipfile.lock
+++ b/integration_tests/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "90755a5c8ee21d68d4e90f99016820d0c694f4298e9e85dcedde9e3aae9ed0e7"
+            "sha256": "386d85cd0985f069367b93c522c188c1c63e21b30fdf449d5c757429a2d5c833"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -59,7 +59,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "sys_platform == 'darwin'",
+            "markers": "platform_system == 'Darwin'",
             "version": "==0.1.0"
         },
         "approvaltests": {

--- a/integration_tests/Pipfile.lock
+++ b/integration_tests/Pipfile.lock
@@ -475,14 +475,6 @@
             ],
             "version": "==2.9"
         },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
-        },
         "ipykernel": {
             "hashes": [
                 "sha256:003c9c1ab6ff87d11f531fee2b9ca59affab19676fc6b2c21da329aef6e73499",
@@ -1562,7 +1554,7 @@
                 "sha256:c952975c8ba74f546ae6de2e226ab3cc3cc11ae47baf607459a6728585bb542a",
                 "sha256:c98232a3ac391f5faea6821b53db8db461157baa788f5d6222a193e9456e1740"
             ],
-            "markers": "python_version < '3.8'",
+            "markers": "python_version >= '3.8'",
             "version": "==6.0.4"
         },
         "tqdm": {
@@ -1680,13 +1672,6 @@
                 "sha256:8e2969797627c8a663575c2fc6fcb53a05e37cdb83ee65f341fc6e0c3d0ced16"
             ],
             "version": "==2.0.0"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "version": "==3.1.0"
         }
     },
     "develop": {}


### PR DESCRIPTION
#1411

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Updates python to 3.8 for:

autoflow, flowmachine, flowauth, flowapi, flowclient, and most tests.

FlowETL remains at 3.7 because the upstream image for 3.8 isn't yet published, flowdb remains at 3.7 because debian.