### PR TITLE
Add db name to last used totp check

### DIFF
--- a/autoflow/Pipfile.lock
+++ b/autoflow/Pipfile.lock
@@ -243,11 +243,11 @@
         },
         "ipykernel": {
             "hashes": [
-                "sha256:003c9c1ab6ff87d11f531fee2b9ca59affab19676fc6b2c21da329aef6e73499",
-                "sha256:2937373c356fa5b634edb175c5ea0e4b25de8008f7c194f2d49cfbd1f9c970a8"
+                "sha256:731adb3f2c4ebcaff52e10a855ddc87670359a89c9c784d711e62d66fccdafae",
+                "sha256:a8362e3ae365023ca458effe93b026b8cdadc0b73ff3031472128dd8a2cf0289"
             ],
             "index": "pypi",
-            "version": "==5.2.1"
+            "version": "==5.3.0"
         },
         "ipython": {
             "hashes": [
@@ -408,10 +408,10 @@
         },
         "merge-args": {
             "hashes": [
-                "sha256:8ef3d1887aefb8eaf5eb7431c34f3c82c4049e13768aecc24d7447abf39ff60d",
-                "sha256:ec1455e8c1663f04951be4d4a38df1ab74014fd8d042038f2d02b942a25d0a22"
+                "sha256:79b01449801757f6ef2a24520b90fa270bc1a5296adf731a899afa950e6f1545",
+                "sha256:96b76d7141dda4bb2571f571a5794701a1ff0c3b1a09c0bc69fa8764ee1858c3"
             ],
-            "version": "==0.1.3"
+            "version": "==0.1.4"
         },
         "mistune": {
             "hashes": [
@@ -1386,11 +1386,11 @@
         },
         "ipykernel": {
             "hashes": [
-                "sha256:003c9c1ab6ff87d11f531fee2b9ca59affab19676fc6b2c21da329aef6e73499",
-                "sha256:2937373c356fa5b634edb175c5ea0e4b25de8008f7c194f2d49cfbd1f9c970a8"
+                "sha256:731adb3f2c4ebcaff52e10a855ddc87670359a89c9c784d711e62d66fccdafae",
+                "sha256:a8362e3ae365023ca458effe93b026b8cdadc0b73ff3031472128dd8a2cf0289"
             ],
             "index": "pypi",
-            "version": "==5.2.1"
+            "version": "==5.3.0"
         },
         "ipython": {
             "hashes": [

--- a/docs/Pipfile.lock
+++ b/docs/Pipfile.lock
@@ -59,7 +59,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "platform_system == 'Darwin'",
+            "markers": "sys_platform == 'darwin'",
             "version": "==0.1.0"
         },
         "asyncpg": {
@@ -419,11 +419,11 @@
         },
         "ipykernel": {
             "hashes": [
-                "sha256:003c9c1ab6ff87d11f531fee2b9ca59affab19676fc6b2c21da329aef6e73499",
-                "sha256:2937373c356fa5b634edb175c5ea0e4b25de8008f7c194f2d49cfbd1f9c970a8"
+                "sha256:731adb3f2c4ebcaff52e10a855ddc87670359a89c9c784d711e62d66fccdafae",
+                "sha256:a8362e3ae365023ca458effe93b026b8cdadc0b73ff3031472128dd8a2cf0289"
             ],
             "index": "pypi",
-            "version": "==5.2.1"
+            "version": "==5.3.0"
         },
         "ipython": {
             "hashes": [
@@ -625,10 +625,10 @@
         },
         "merge-args": {
             "hashes": [
-                "sha256:8ef3d1887aefb8eaf5eb7431c34f3c82c4049e13768aecc24d7447abf39ff60d",
-                "sha256:ec1455e8c1663f04951be4d4a38df1ab74014fd8d042038f2d02b942a25d0a22"
+                "sha256:79b01449801757f6ef2a24520b90fa270bc1a5296adf731a899afa950e6f1545",
+                "sha256:96b76d7141dda4bb2571f571a5794701a1ff0c3b1a09c0bc69fa8764ee1858c3"
             ],
-            "version": "==0.1.3"
+            "version": "==0.1.4"
         },
         "mistune": {
             "hashes": [
@@ -1490,7 +1490,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "platform_system == 'Darwin'",
+            "markers": "sys_platform == 'darwin'",
             "version": "==0.1.0"
         },
         "argcomplete": {
@@ -1755,11 +1755,11 @@
         },
         "ipykernel": {
             "hashes": [
-                "sha256:003c9c1ab6ff87d11f531fee2b9ca59affab19676fc6b2c21da329aef6e73499",
-                "sha256:2937373c356fa5b634edb175c5ea0e4b25de8008f7c194f2d49cfbd1f9c970a8"
+                "sha256:731adb3f2c4ebcaff52e10a855ddc87670359a89c9c784d711e62d66fccdafae",
+                "sha256:a8362e3ae365023ca458effe93b026b8cdadc0b73ff3031472128dd8a2cf0289"
             ],
             "index": "pypi",
-            "version": "==5.2.1"
+            "version": "==5.3.0"
         },
         "ipython": {
             "hashes": [

--- a/flowauth/backend/flowauth/models.py
+++ b/flowauth/backend/flowauth/models.py
@@ -214,13 +214,15 @@ class TwoFactorAuth(db.Model):
         is_valid = pyotp.totp.TOTP(self.decrypted_secret_key).verify(code)
         if is_valid:
             if (
-                current_app.config["CACHE_BACKEND"].get(f"{self.user_id}".encode())
+                current_app.config["CACHE_BACKEND"].get(
+                    f"{self.user_id}-{db.engine.url.database}".encode()
+                )
                 == code
             ):  # Reject if the code is being reused
                 raise Unauthorized("Code not valid.")
             else:
                 current_app.config["CACHE_BACKEND"].set(
-                    f"{self.user_id}".encode(), code
+                    f"{self.user_id}-{db.engine.url.database}".encode(), code
                 )
             return True
         else:

--- a/flowclient/Pipfile.lock
+++ b/flowclient/Pipfile.lock
@@ -154,6 +154,14 @@
             ],
             "version": "==1.4.4"
         },
+        "appnope": {
+            "hashes": [
+                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
+                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.0"
+        },
         "asynctest": {
             "hashes": [
                 "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676",

--- a/flowmachine/Pipfile.lock
+++ b/flowmachine/Pipfile.lock
@@ -375,6 +375,14 @@
             ],
             "version": "==1.4.4"
         },
+        "appnope": {
+            "hashes": [
+                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
+                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.0"
+        },
         "approvaltests": {
             "hashes": [
                 "sha256:77bcfa60f975a48a378c96f61749d7943ecc27d486394896aa8536d93105d556"

--- a/integration_tests/Pipfile.lock
+++ b/integration_tests/Pipfile.lock
@@ -59,7 +59,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "platform_system == 'Darwin'",
+            "markers": "sys_platform == 'darwin'",
             "version": "==0.1.0"
         },
         "approvaltests": {
@@ -477,10 +477,10 @@
         },
         "ipykernel": {
             "hashes": [
-                "sha256:003c9c1ab6ff87d11f531fee2b9ca59affab19676fc6b2c21da329aef6e73499",
-                "sha256:2937373c356fa5b634edb175c5ea0e4b25de8008f7c194f2d49cfbd1f9c970a8"
+                "sha256:731adb3f2c4ebcaff52e10a855ddc87670359a89c9c784d711e62d66fccdafae",
+                "sha256:a8362e3ae365023ca458effe93b026b8cdadc0b73ff3031472128dd8a2cf0289"
             ],
-            "version": "==5.2.1"
+            "version": "==5.3.0"
         },
         "ipython": {
             "hashes": [
@@ -653,10 +653,10 @@
         },
         "merge-args": {
             "hashes": [
-                "sha256:8ef3d1887aefb8eaf5eb7431c34f3c82c4049e13768aecc24d7447abf39ff60d",
-                "sha256:ec1455e8c1663f04951be4d4a38df1ab74014fd8d042038f2d02b942a25d0a22"
+                "sha256:79b01449801757f6ef2a24520b90fa270bc1a5296adf731a899afa950e6f1545",
+                "sha256:96b76d7141dda4bb2571f571a5794701a1ff0c3b1a09c0bc69fa8764ee1858c3"
             ],
-            "version": "==0.1.3"
+            "version": "==0.1.4"
         },
         "mistune": {
             "hashes": [


### PR DESCRIPTION
This allows multiple flowauth instances using separate dbs on the same server to share a single redis instance without risking collisions.