### PR TITLE
Fix 'count duplicates' QA check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- The FlowETL 'count_duplicates' QA check now correctly counts the number of duplicate rows. [#2651](https://github.com/Flowminder/FlowKit/issues/2651)
 
 ### Removed
 

--- a/flowetl/flowetl/flowetl/qa_checks/qa_checks/count_duplicates.sql
+++ b/flowetl/flowetl/flowetl/qa_checks/qa_checks/count_duplicates.sql
@@ -32,4 +32,4 @@ SELECT COALESCE(sum(n_dupes), 0) FROM
         tac,
         operator_code,
         country_code
-    HAVING count(*) - 1 > 1) tableWithCount
+    HAVING count(*) > 1) tableWithCount


### PR DESCRIPTION
Closes #2651

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Fixes the FlowETL QA check 'count_duplicates.sql', which was previously only counting duplicates for rows that were duplicated at least twice (i.e. at least 3 identical rows).