### PR TITLE
Default ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 -   The issuer name can now be set for FlowAuth's 2factor authentication using the `FLOWAUTH_TWO_FACTOR_ISSUER` environment variable.
 -   FlowAPI's internal port can now be set using the `FLOWAPI_PORT` environment variable, but continues to default to `9090`. [#2723](https://github.com/Flowminder/FlowKit/issues/2723)
+
+    With thanks to [JIPS](https://www.jips.org) for supporting this work.
 -   FlowETL's default port can now be set using the `FLOWETL_PORT` environment variable, but continues to default to `8080`. [#2724](https://github.com/Flowminder/FlowKit/issues/2724)
+
+    With thanks to [JIPS](https://www.jips.org) for supporting this work.
 
 ### Changed
 - Test and synthetic DFS data now uses the same pool of subscribers as CDR data. [#2713](https://github.com/Flowminder/FlowKit/issues/2713)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Added 
-- The issuer name can now be set for FlowAuth's 2factor authentication using the `FLOWAUTH_TWO_FACTOR_ISSUER` environment variable. 
+### Added
+
+-   The issuer name can now be set for FlowAuth's 2factor authentication using the `FLOWAUTH_TWO_FACTOR_ISSUER` environment variable.
+-   FlowAPI's internal port can now be set using the `FLOWAPI_PORT` environment variable, but continues to default to `9090`. [#2723](https://github.com/Flowminder/FlowKit/issues/2723)
+-   FlowETL's default port can now be set using the `FLOWETL_PORT` environment variable, but continues to default to `8080`. [#2724](https://github.com/Flowminder/FlowKit/issues/2724)
 
 ### Changed
 - Test and synthetic DFS data now uses the same pool of subscribers as CDR data. [#2713](https://github.com/Flowminder/FlowKit/issues/2713)
@@ -20,61 +23,75 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.11.1]
 
-### Added 
+### Added
 
-- FlowDB's SQL synthetic data generator now uses the [WorldPop project](https://www.worldpop.org)'s [2016 population raster](https://www.worldpop.org/doi/10.5258/SOTON/WP00647) for the country chosen as the basis for generating data.
+-   FlowDB's SQL synthetic data generator now uses the [WorldPop project](https://www.worldpop.org)'s [2016 population raster](https://www.worldpop.org/doi/10.5258/SOTON/WP00647) for the country chosen as the basis for generating data.
 
 ## [1.11.0]
 
-### Added 
-- Queries run through FlowAPI can now be run on only a subset of the available CDR types, by supplying an `event_types` parameter. [#2631](https://github.com/Flowminder/FlowKit/issues/2631)
-- FlowETL now includes QA checks for the earliest and latest timestamps in the ingested data. [#2627](https://github.com/Flowminder/FlowKit/issues/2627)
+### Added
+
+-   Queries run through FlowAPI can now be run on only a subset of the available CDR types, by supplying an `event_types` parameter. [#2631](https://github.com/Flowminder/FlowKit/issues/2631)
+-   FlowETL now includes QA checks for the earliest and latest timestamps in the ingested data. [#2627](https://github.com/Flowminder/FlowKit/issues/2627)
 
 ### Fixed
-- The FlowETL 'count_duplicates' QA check now correctly counts the number of duplicate rows. [#2651](https://github.com/Flowminder/FlowKit/issues/2651)
+
+-   The FlowETL 'count_duplicates' QA check now correctly counts the number of duplicate rows. [#2651](https://github.com/Flowminder/FlowKit/issues/2651)
 
 ## [1.10.0]
 
 ### Added
-- FlowDB's SQL synthetic data generator can now generate events for any country, not just Nepal.
-  
-  To generate synthetic data for a different country, supply the `COUNTRY` environment variable when starting the container, and a valid GADM GID code for the region to simulate a disaster. 
+
+-   FlowDB's SQL synthetic data generator can now generate events for any country, not just Nepal.
+
+    To generate synthetic data for a different country, supply the `COUNTRY` environment variable when starting the container, and a valid GADM GID code for the region to simulate a disaster.
 
 ### Changed
-- FlowMachine's docker container now uses Python 3.8
-- FlowAPI's docker container now uses Python 3.8
-- FlowAuth's docker container now uses Python 3.8
-- AutoFlow's docker container now uses Python 3.8
-- FlowDB's SQL synthetic data generator now uses [GADM 3.6](https://gadm.org) boundaries.
-- FlowAuth and FlowAPI now exchange tokens with compressed claims. [#2625](https://github.com/Flowminder/FlowKit/issues/2625)
+
+-   FlowMachine's docker container now uses Python 3.8
+-   FlowAPI's docker container now uses Python 3.8
+-   FlowAuth's docker container now uses Python 3.8
+-   AutoFlow's docker container now uses Python 3.8
+-   FlowDB's SQL synthetic data generator now uses [GADM 3.6](https://gadm.org) boundaries.
+-   FlowAuth and FlowAPI now exchange tokens with compressed claims. [#2625](https://github.com/Flowminder/FlowKit/issues/2625)
 
 ### Fixed
-- FlowAuth will no longer fail to start if there are directories with names the same as the SSL certificate secrets.
+
+-   FlowAuth will no longer fail to start if there are directories with names the same as the SSL certificate secrets.
 
 ## [1.9.4]
+
 ## Changed
-- `JoinToLocation` is cacheable only if the joined query is also cacheable.
+
+-   `JoinToLocation` is cacheable only if the joined query is also cacheable.
 
 ## [1.9.3]
+
 ### Changed
-- `SubscriberLocations` are no longer cacheable using FlowMachine.
+
+-   `SubscriberLocations` are no longer cacheable using FlowMachine.
 
 ### Fixed
-- Fixed cache shrinking failing when large numbers of tables have been written. [#2462](https://github.com/Flowminder/FlowKit/issues/2462)
-- Fixed FlowAuth's MySQL support.
+
+-   Fixed cache shrinking failing when large numbers of tables have been written. [#2462](https://github.com/Flowminder/FlowKit/issues/2462)
+-   Fixed FlowAuth's MySQL support.
 
 ## [1.9.2]
+
 ### Fixed
-- Added missing bridge table arguments to Several FlowClient methods.
+
+-   Added missing bridge table arguments to Several FlowClient methods.
 
 ## [1.9.1]
+
 ### Added
-- FlowAuth now supports MySQL as a database backend.
-- FlowKit now allows the use of bridge tables to manually specify linkages between cells and geometries. 
+
+-   FlowAuth now supports MySQL as a database backend.
+-   FlowKit now allows the use of bridge tables to manually specify linkages between cells and geometries.
 
 ### Fixed
-- FlowAuth no longer errors after a period of inactivity due to timed out database connections. [#2382](https://github.com/Flowminder/FlowKit/issues/2382)
 
+-   FlowAuth no longer errors after a period of inactivity due to timed out database connections. [#2382](https://github.com/Flowminder/FlowKit/issues/2382)
 
 ## [1.9.0]
 
@@ -87,6 +104,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   FlowClient now has an asyncio API. Use `connect_async` instead of `connect` to create an `ASyncConnection`, and `await` methods on `APIQuery` objects. [#2199](https://github.com/Flowminder/FlowKit/issues/2199)
 
 ### Fixed
+
 -   Fixed FlowMachine server becoming deadlocked under load. [#2390](https://github.com/Flowminder/FlowKit/issues/2390)
 
 ## [1.8.0]

--- a/flowapi.Dockerfile
+++ b/flowapi.Dockerfile
@@ -19,4 +19,5 @@ ENV QUART_ENV=production
 ENV FLOWAPI_PORT=9090
 EXPOSE 80
 EXPOSE 443
+EXPOSE 9090
 CMD ["pipenv", "run", "./start.sh"]

--- a/flowapi.Dockerfile
+++ b/flowapi.Dockerfile
@@ -16,4 +16,7 @@ RUN apk update && apk add libzmq && apk add --virtual build-dependencies build-b
 COPY . /${SOURCE_TREE}/
 RUN pipenv run python setup.py install
 ENV QUART_ENV=production
+ENV FLOWAPI_PORT=9090
+EXPOSE 80
+EXPOSE 443
 CMD ["pipenv", "run", "./start.sh"]

--- a/flowapi/start.sh
+++ b/flowapi/start.sh
@@ -7,8 +7,8 @@
 
 if [ -f /run/secrets/cert-flowkit.pem ] && [ -f /run/secrets/key-flowkit.pem ];
 then
-    hypercorn --bind 0.0.0.0:9090 --certfile /run/secrets/cert-flowkit.pem --keyfile /run/secrets/key-flowkit.pem "flowapi.main:create_app()"
+    hypercorn --bind 0.0.0.0:${FLOWAPI_PORT:-443} --certfile /run/secrets/cert-flowkit.pem --keyfile /run/secrets/key-flowkit.pem "flowapi.main:create_app()"
 else
     echo "WARNING: No certificate file provided. Communications with the API server will NOT BE SECURE."
-    hypercorn --bind 0.0.0.0:9090 "flowapi.main:create_app()"
+    hypercorn --bind 0.0.0.0:${FLOWAPI_PORT:-80} "flowapi.main:create_app()"
 fi

--- a/flowetl.Dockerfile
+++ b/flowetl.Dockerfile
@@ -69,6 +69,7 @@ WORKDIR ${AIRFLOW_HOME}
 ENTRYPOINT ["/entrypoint.sh"]
 # set default arg for entrypoint
 EXPOSE 80
+EXPOSE 8080
 ENV FLOWETL_PORT=8080
 
 CMD ["webserver"]

--- a/flowetl.Dockerfile
+++ b/flowetl.Dockerfile
@@ -62,6 +62,12 @@ RUN ln -s /opt/airflow /usr/local/airflow
 #
 # When possible, this will get changed to 700 at runtime (uid 0)
 RUN chmod -R 777 ${AIRFLOW_HOME}
+RUN  apt-get update && \
+        apt-get install -y --no-install-recommends authbind && \
+        touch /etc/authbind/byport/80  && \
+        chmod 500 /etc/authbind/byport/80 && \
+        chown airflow /etc/authbind/byport/80 && \
+        rm -rf /var/lib/apt/lists/*
 
 USER airflow
 

--- a/flowetl.Dockerfile
+++ b/flowetl.Dockerfile
@@ -68,6 +68,9 @@ USER airflow
 WORKDIR ${AIRFLOW_HOME}
 ENTRYPOINT ["/entrypoint.sh"]
 # set default arg for entrypoint
+EXPOSE 80
+ENV FLOWETL_PORT=8080
+
 CMD ["webserver"]
 
 

--- a/flowetl.Dockerfile
+++ b/flowetl.Dockerfile
@@ -65,7 +65,7 @@ RUN chmod -R 777 ${AIRFLOW_HOME}
 RUN  apt-get update && \
         apt-get install -y --no-install-recommends authbind && \
         touch /etc/authbind/byport/80  && \
-        chmod 500 /etc/authbind/byport/80 && \
+        chmod 777 /etc/authbind/byport/80 && \
         chown airflow /etc/authbind/byport/80 && \
         rm -rf /var/lib/apt/lists/*
 

--- a/flowetl/entrypoint.sh
+++ b/flowetl/entrypoint.sh
@@ -126,7 +126,7 @@ case "$1" in
       # With the "Local" and "Sequential" executors it should all run in one container.
       airflow scheduler &
     fi
-    exec airflow webserver
+    exec airflow webserver -p ${FLOWETL_PORT}
     ;;
   worker|scheduler)
     # To give the webserver time to run initdb.

--- a/flowetl/entrypoint.sh
+++ b/flowetl/entrypoint.sh
@@ -9,6 +9,9 @@ set -euo pipefail
 # Used to fake a user and group when passed to docker and does not already exist
 # https://cwrap.org/nss_wrapper.html
 
+chown $(id -u) /etc/authbind/byport/80
+chmod 500 /etc/authbind/byport/80
+
 # allow the container to be started with `--user`
 if [ "$1" = 'webserver' ] && [ "$(id -u)" = '0' ]; then
 	  chown -R airflow "$AIRFLOW_HOME"
@@ -27,7 +30,6 @@ if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ];
     export NSS_WRAPPER_GROUP="$(mktemp)"
 		echo "airflow:x:$(id -u):$(id -g):Airflow:$HOME:/bin/false" > "$NSS_WRAPPER_PASSWD"
 		echo "airflow:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-    chown $(id -u) /etc/authbind/byport/80
 fi
 
 

--- a/flowetl/entrypoint.sh
+++ b/flowetl/entrypoint.sh
@@ -27,6 +27,7 @@ if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ];
     export NSS_WRAPPER_GROUP="$(mktemp)"
 		echo "airflow:x:$(id -u):$(id -g):Airflow:$HOME:/bin/false" > "$NSS_WRAPPER_PASSWD"
 		echo "airflow:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+    chown $(id -u) /etc/authbind/byport/80
 fi
 
 

--- a/flowetl/entrypoint.sh
+++ b/flowetl/entrypoint.sh
@@ -9,9 +9,6 @@ set -euo pipefail
 # Used to fake a user and group when passed to docker and does not already exist
 # https://cwrap.org/nss_wrapper.html
 
-chown $(id -u) /etc/authbind/byport/80
-chmod 500 /etc/authbind/byport/80
-
 # allow the container to be started with `--user`
 if [ "$1" = 'webserver' ] && [ "$(id -u)" = '0' ]; then
 	  chown -R airflow "$AIRFLOW_HOME"

--- a/flowetl/entrypoint.sh
+++ b/flowetl/entrypoint.sh
@@ -126,7 +126,7 @@ case "$1" in
       # With the "Local" and "Sequential" executors it should all run in one container.
       airflow scheduler &
     fi
-    exec airflow webserver -p ${FLOWETL_PORT}
+    exec authbind --deep airflow webserver -p ${FLOWETL_PORT}
     ;;
   worker|scheduler)
     # To give the webserver time to run initdb.


### PR DESCRIPTION
Closes #2723 closes #2724

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Adds two new env vars: `FLOWAPI_PORT` and `FLOWETL_PORT` which control the _internal_ port these containers listen on.  Additionally exposes standard http and https ports on the flowapi container.