### PR TITLE
Flowauth issuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added 
+- The issuer name can now be set for FlowAuth's 2factor authentication using the `FLOWAUTH_TWO_FACTOR_ISSUER` environment variable. 
 
 ### Changed
 

--- a/flowauth/backend/flowauth/config.py
+++ b/flowauth/backend/flowauth/config.py
@@ -111,6 +111,7 @@ def get_config():
             RESET_DB=True if getenv("RESET_FLOWAUTH_DB") is not None else False,
             DB_IS_SET_UP=Event(),
             CACHE_BACKEND=get_cache_backend(),
+            FLOWAUTH_TWO_FACTOR_ISSUER=getenv("FLOWAUTH_TWO_FACTOR_ISSUER", "FlowAuth"),
         )
     except KeyError as e:
         raise UndefinedConfigOption(

--- a/flowauth/backend/flowauth/user_settings.py
+++ b/flowauth/backend/flowauth/user_settings.py
@@ -71,7 +71,8 @@ def enable_two_factor():
     """
     secret = pyotp.random_base32()
     provisioning_url = pyotp.totp.TOTP(secret).provisioning_uri(
-        current_user.username, issuer_name="FlowAuth"
+        current_user.username,
+        issuer_name=current_app.config["FLOWAUTH_TWO_FACTOR_ISSUER"],
     )
     signed_secret = TimestampSigner(current_app.config["SECRET_KEY"]).sign(secret)
     backup_codes = generate_backup_codes()
@@ -83,7 +84,7 @@ def enable_two_factor():
             {
                 "provisioning_url": provisioning_url,
                 "secret": signed_secret.decode(),
-                "issuer": "FlowAuth",
+                "issuer": current_app.config["FLOWAUTH_TWO_FACTOR_ISSUER"],
                 "backup_codes": backup_codes,
                 "backup_codes_signature": serialised_codes,
             }


### PR DESCRIPTION
### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Allows one to control the issuer name for flowauth 2factor codes (so when working with multiple flowauths you don't have to guess which code is right)