### PR TITLE
Optional file flux check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- When creating a file-based DAG using `create_dag`, you can now use the slower, table based method of checking whether the file is being written. [#2857](https://github.com/Flowminder/FlowKit/issues/2857)
 
 ### Fixed
 

--- a/flowetl/flowetl/flowetl/util.py
+++ b/flowetl/flowetl/flowetl/util.py
@@ -94,6 +94,7 @@ def create_dag(
     quote: str = '"',
     escape: str = '"',
     encoding: Optional[str] = None,
+    use_file_flux_sensor: bool = True,
     **kwargs,
 ) -> "DAG":
     """
@@ -161,6 +162,10 @@ def create_dag(
         When loading from files, you may specify the escape character
     encoding : str or None
         Optionally specify file encoding when loading from files.
+    use_file_flux_sensor : bool, default True
+        When set to True, uses a check on the last modification time of the file to determine
+        whether the file is in flux.  Set to False to perform a slower check based on the
+        number of rows in the mounted table.
 
     Returns
     -------
@@ -243,7 +248,7 @@ def create_dag(
             poke_interval=data_present_poke_interval,
             timeout=data_present_timeout,
         )
-        if filename is not None:
+        if filename is not None and use_file_flux_sensor:
             check_not_in_flux = FileFluxSensor(
                 task_id="check_not_in_flux",
                 filename=filename,


### PR DESCRIPTION
Closes #2857

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Allows passing `use_file_flux_sensor=False` to `create_dag` to disable the fast modification time based method of checking for flux.