### PR TITLE
Faster cache shrink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- `get_cached_query_objects_ordered_by_score` is now a generator. [#3116](https://github.com/Flowminder/FlowKit/issues/3116)
 
 ### Fixed
 - FlowAPI now correctly logs all query run, poll, and retrieval requests for matching with FlowMachine. [#3071](https://github.com/Flowminder/FlowKit/issues/3071)

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -404,7 +404,7 @@ def get_cached_query_objects_ordered_by_score(
         ORDER BY cache_score(cache_score_multiplier, compute_time, table_size(tablename, schema)) ASC
         """
     cache_queries = connection.fetch(qry)
-    return ((pickle.loads(obj), table_size) for obj, table_size in cache_queries)
+    yield from ((pickle.loads(obj), table_size) for obj, table_size in cache_queries)
 
 
 def shrink_one(

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -374,7 +374,7 @@ def get_query_object_by_id(connection: "Connection", query_id: str) -> "Query":
 def get_cached_query_objects_ordered_by_score(
     connection: "Connection",
     protected_period: Optional[int] = None,
-) -> List[Tuple["Query", int]]:
+) -> Tuple["Query", int]:
     """
     Get all cached query objects in ascending cache score order.
 
@@ -386,9 +386,9 @@ def get_cached_query_objects_ordered_by_score(
         the value stored in cache.cache_config will be used.Set to a negative number to ignore cache protection
         completely.
 
-    Returns
+    Yields
     -------
-    list of tuples
+    tuples
         Returns a list of cached Query objects with their on disk sizes
 
     """
@@ -404,7 +404,7 @@ def get_cached_query_objects_ordered_by_score(
         ORDER BY cache_score(cache_score_multiplier, compute_time, table_size(tablename, schema)) ASC
         """
     cache_queries = connection.fetch(qry)
-    return [(pickle.loads(obj), table_size) for obj, table_size in cache_queries]
+    return ((pickle.loads(obj), table_size) for obj, table_size in cache_queries)
 
 
 def shrink_one(
@@ -431,9 +431,11 @@ def shrink_one(
     tuple of "Query", int
         The "Query" object that was removed from cache and the size of it
     """
-    obj_to_remove, obj_size = get_cached_query_objects_ordered_by_score(
-        connection, protected_period=protected_period
-    )[0]
+    obj_to_remove, obj_size = next(
+        get_cached_query_objects_ordered_by_score(
+            connection, protected_period=protected_period
+        )
+    )
 
     logger.info(
         f"{'Would' if dry_run else 'Will'} remove cache record for {obj_to_remove.query_id} of type {obj_to_remove.__class__}"
@@ -485,10 +487,8 @@ def shrink_below_size(
     )
 
     if dry_run:
-        cached_queries = iter(
-            get_cached_query_objects_ordered_by_score(
-                connection, protected_period=protected_period
-            )
+        cached_queries = get_cached_query_objects_ordered_by_score(
+            connection, protected_period=protected_period
         )
 
         def dry_run_shrink(connection, protected_period):

--- a/flowmachine/tests/test_cache_utils.py
+++ b/flowmachine/tests/test_cache_utils.py
@@ -159,8 +159,8 @@ def test_get_cached_query_objects_ordered_by_score(flowmachine_connect):
     table = dl.get_table()
 
     # Should prefer the larger, but slower to calculate and more used dl over the aggregation
-    cached_queries = get_cached_query_objects_ordered_by_score(
-        get_db(), protected_period=-1
+    cached_queries = list(
+        get_cached_query_objects_ordered_by_score(get_db(), protected_period=-1)
     )
     assert 2 == len(cached_queries)
     assert dl_agg.query_id == cached_queries[0][0].query_id
@@ -176,15 +176,15 @@ def test_get_cached_query_objects_protected_period(flowmachine_connect):
     dl_agg = dl.aggregate().store().result()
     table = dl.get_table()
 
-    cached_queries = get_cached_query_objects_ordered_by_score(
-        get_db(), protected_period=-1
+    cached_queries = list(
+        get_cached_query_objects_ordered_by_score(get_db(), protected_period=-1)
     )
     assert 2 == len(cached_queries)
     assert dl_agg.query_id == cached_queries[0][0].query_id
     assert dl.query_id == cached_queries[1][0].query_id
     assert 2 == len(cached_queries[0])
-    cached_queries = get_cached_query_objects_ordered_by_score(
-        get_db(), protected_period=10
+    cached_queries = list(
+        get_cached_query_objects_ordered_by_score(get_db(), protected_period=10)
     )
     assert 0 == len(cached_queries)
 


### PR DESCRIPTION
…npickling queries repeatedly.


Closes #3116

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Makes `get_cached_query_objects_ordered_by_score` a generator instead of unpickling every query object every time.