### PR TITLE
Support validity window for Flowauth 2factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Previously run, or currently running queries can now be referenced as a subscriber subset via FlowAPI. [#1009](https://github.com/Flowminder/FlowKit/issues/1009)
 - total_network_objects, location_introversion, and unique_subscriber_counts now also accept subscriber subsets.
+- The validity window for FlowAuth 2factor codes can now be configured using the `TWO_FACTOR_VALID_WINDOW` env variable. [#3203](https://github.com/Flowminder/FlowKit/issues/3203)
 
 ### Changed
 - `get_cached_query_objects_ordered_by_score` is now a generator. [#3116](https://github.com/Flowminder/FlowKit/issues/3116)

--- a/flowauth/backend/flowauth/config.py
+++ b/flowauth/backend/flowauth/config.py
@@ -112,6 +112,7 @@ def get_config():
             DB_IS_SET_UP=Event(),
             CACHE_BACKEND=get_cache_backend(),
             FLOWAUTH_TWO_FACTOR_ISSUER=getenv("FLOWAUTH_TWO_FACTOR_ISSUER", "FlowAuth"),
+            TWO_FACTOR_VALID_WINDOW=int(getenv("TWO_FACTOR_VALID_WINDOW", 0)),
         )
     except KeyError as e:
         raise UndefinedConfigOption(

--- a/flowauth/backend/flowauth/models.py
+++ b/flowauth/backend/flowauth/models.py
@@ -211,7 +211,9 @@ class TwoFactorAuth(db.Model):
         current_app.logger.debug(
             "Verifying 2factor code", code=code, secret_key=self.decrypted_secret_key
         )
-        is_valid = pyotp.totp.TOTP(self.decrypted_secret_key).verify(code)
+        is_valid = pyotp.totp.TOTP(self.decrypted_secret_key).verify(
+            code, valid_window=current_app.config["TWO_FACTOR_VALID_WINDOW"]
+        )
         if is_valid:
             if (
                 current_app.config["CACHE_BACKEND"].get(


### PR DESCRIPTION
Closes #3203

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Allows setting the validity window for two factor code verification in Flowauth using `TWO_FACTOR_VALID_WINDOW` env var.