### PR TITLE
Bump markdown to 3.3.3 to fix Nones in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
+## [1.14.1]
+
+### Fixed
+- Docs displaying None where they shouldn't
+
 ## [1.14.0]
 
 ### Added
@@ -840,7 +845,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 -   Added Python 3.6 support for FlowClient
 
-[unreleased]: https://github.com/Flowminder/FlowKit/compare/1.14.0...master
+[unreleased]: https://github.com/Flowminder/FlowKit/compare/1.14.1...master
+[1.14.1]: https://github.com/Flowminder/FlowKit/compare/1.14.0...1.14.1
 [1.14.0]: https://github.com/Flowminder/FlowKit/compare/1.13.0...1.14.0
 [1.13.0]: https://github.com/Flowminder/FlowKit/compare/1.12.1...1.13.0
 [1.12.0]: https://github.com/Flowminder/FlowKit/compare/1.11.1...1.12.0

--- a/docs/Pipfile
+++ b/docs/Pipfile
@@ -25,7 +25,7 @@ flowkit-jwt-generator = {editable = true,path = "./../flowkit_jwt_generator"}
 mktheapidocs = "*"
 mknotebooks = "*"
 mapboxgl = "*"
-markdown = "==3.3.2" # Working around version conflict caused by airflow's aggressive pinning
+markdown = "==3.3.3" # Working around version conflict caused by airflow's aggressive pinning
 chroma-py = "==0.1.0.dev1"
 ipywidgets = "*"
 

--- a/docs/Pipfile.lock
+++ b/docs/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "67c36a347958d0776c4270cb23ba2c1b074d88582b961436f46d0531d560d38b"
+            "sha256": "b721d9c4b4afac86c02ecf08a0e8710825faa5742ec5c4c6881498a957860c94"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -653,11 +653,11 @@
         },
         "markdown": {
             "hashes": [
-                "sha256:4b71fbd2db30c1dfb400f22b25f41cb823fc1db0aa8b7b67d120644f92cc1011",
-                "sha256:77b7bff443b1f97b4814fa438c181fd5882e31edb01b422856b3feca91475f3e"
+                "sha256:5d9f2b5ca24bc4c7a390d22323ca4bad200368612b5aaa7796babf971d2b2f18",
+                "sha256:c109c15b7dc20a9ac454c9e6025927d44460b85bd039da028d85e2b6d0bcc328"
             ],
             "index": "pypi",
-            "version": "==3.3.2"
+            "version": "==3.3.3"
         },
         "markupsafe": {
             "hashes": [
@@ -2335,11 +2335,11 @@
         },
         "markdown": {
             "hashes": [
-                "sha256:4b71fbd2db30c1dfb400f22b25f41cb823fc1db0aa8b7b67d120644f92cc1011",
-                "sha256:77b7bff443b1f97b4814fa438c181fd5882e31edb01b422856b3feca91475f3e"
+                "sha256:5d9f2b5ca24bc4c7a390d22323ca4bad200368612b5aaa7796babf971d2b2f18",
+                "sha256:c109c15b7dc20a9ac454c9e6025927d44460b85bd039da028d85e2b6d0bcc328"
             ],
             "index": "pypi",
-            "version": "==3.3.2"
+            "version": "==3.3.3"
         },
         "markupsafe": {
             "hashes": [


### PR DESCRIPTION
Subsuming #3214

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Version 3.3.2 of markdown spits out loads of Nones in the example notebooks. This is fixed in 3.3.3.