### PR TITLE
Fix using default secret key in flowetl ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Reinstated tabs navigation in the docs [#3238](https://github.com/Flowminder/FlowKit/issues/3238)
 - Removed `$` from code snippets in developer docs [#3224](https://github.com/Flowminder/FlowKit/issues/3224)
+- FlowETL now randomly generates a secret ley to secure sessions with the web interface if one is not explicitly provided using `AIRFLOW__WEBSERVER__SECRET_KEY`. [#3244](https://github.com/Flowminder/FlowKit/issues/3244)
 
 ### Removed
 

--- a/flowetl/entrypoint.sh
+++ b/flowetl/entrypoint.sh
@@ -67,6 +67,7 @@ TRY_LOOP="20"
 : "${AIRFLOW_HOME:="/opt/airflow"}"
 : "${AIRFLOW__CORE__FERNET_KEY:=${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")}}"
 : "${AIRFLOW__CORE__EXECUTOR:=${EXECUTOR:-Sequential}Executor}"
+: "${AIRFLOW__WEBSERVER__SECRET_KEY:=${AIRFLOW__WEBSERVER__SECRET_KEY:=$(python -c "import os; print(os.urandom(16))")}}"
 
 export \
   AIRFLOW_HOME \


### PR DESCRIPTION
Closes #3244

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Generate a random key for flowetl web ui cookies if one not provided.