### PR TITLE
Close tags to fix formatting

### DIFF
--- a/docs/source/developer/index.md
+++ b/docs/source/developer/index.md
@@ -37,8 +37,8 @@ FlowETL details are found [here](#flowetl).
 -   Individual level API
 
 <a name="contrib"></a>
-<p>
-<p>
+<p></p>
+<p></p>
 
 ## Contributing
 


### PR DESCRIPTION
Closes #3335

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Closes the two open `<p>` tags.