### PR TITLE
Fix FlowClient ignoring client certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- Fixed FlowClient ignoring custom SSL certificates [#3344](https://github.com/Flowminder/FlowKit/issues/3344)
 
 ### Removed
 

--- a/flowclient/flowclient/async_client.py
+++ b/flowclient/flowclient/async_client.py
@@ -23,7 +23,7 @@ async def connect_async(
     url: str,
     token: str,
     api_version: int = 0,
-    ssl_certificate: Union[str, None] = None,
+    ssl_certificate: Union[str, bool] = True,
 ) -> ASyncConnection:
     """
     Connect to a FlowKit API server and return the resulting Connection object.
@@ -36,9 +36,9 @@ async def connect_async(
         JSON Web Token for this API server
     api_version : int, default 0
         Version of the API to connect to
-    ssl_certificate: str or None
-        Provide a path to an ssl certificate to use, or None to use
-        default root certificates.
+    ssl_certificate: str or bool
+        Provide a path to an ssl certificate to use, True to use
+        default root certificates, or False to disable ssl verification.
 
     Returns
     -------

--- a/flowclient/flowclient/async_connection.py
+++ b/flowclient/flowclient/async_connection.py
@@ -44,9 +44,9 @@ class ASyncConnection:
         JSON Web Token for this API server
     api_version : int, default 0
         Version of the API to connect to
-    ssl_certificate: str or None
-        Provide a path to an ssl certificate to use, or None to use
-        default root certificates.
+    ssl_certificate: str or bool
+        Provide a path to an ssl certificate to use, True to use
+        default root certificates, or False to disable ssl verification.
     """
 
     url: str
@@ -60,7 +60,7 @@ class ASyncConnection:
         url: str,
         token: str,
         api_version: int = 0,
-        ssl_certificate: Union[str, None] = None,
+        ssl_certificate: Union[str, bool] = True,
     ) -> None:
         if not url.lower().startswith("https://"):
             warnings.warn(
@@ -69,10 +69,11 @@ class ASyncConnection:
         self.url = url
         self.api_version = api_version
         self.session = httpx.AsyncClient(
-            base_url=f"{self.url}/api/{self.api_version}/", timeout=None, http2=http2
+            base_url=f"{self.url}/api/{self.api_version}/",
+            timeout=None,
+            http2=http2,
+            verify=ssl_certificate,
         )
-        if ssl_certificate is not None:
-            self.session.verify = ssl_certificate
         self.update_token(token=token)
 
     def update_token(self, token: str) -> None:

--- a/flowclient/flowclient/client.py
+++ b/flowclient/flowclient/client.py
@@ -22,7 +22,7 @@ def connect(
     url: str,
     token: str,
     api_version: int = 0,
-    ssl_certificate: Union[str, None] = None,
+    ssl_certificate: Union[str, bool] = True,
 ) -> Connection:
     """
     Connect to a FlowKit API server and return the resulting Connection object.
@@ -35,9 +35,9 @@ def connect(
         JSON Web Token for this API server
     api_version : int, default 0
         Version of the API to connect to
-    ssl_certificate: str or None
-        Provide a path to an ssl certificate to use, or None to use
-        default root certificates.
+    ssl_certificate: str or bool
+        Provide a path to an ssl certificate to use, True to use
+        default root certificates, or False to disable ssl verification.
 
     Returns
     -------

--- a/flowclient/flowclient/connection.py
+++ b/flowclient/flowclient/connection.py
@@ -44,9 +44,9 @@ class Connection:
         JSON Web Token for this API server
     api_version : int, default 0
         Version of the API to connect to
-    ssl_certificate: str or None
-        Provide a path to an ssl certificate to use, or None to use
-        default root certificates.
+    ssl_certificate: str or bool
+        Provide a path to an ssl certificate to use, True to use
+        default root certificates, or False to disable ssl verification.
     """
 
     url: str
@@ -60,7 +60,7 @@ class Connection:
         url: str,
         token: str,
         api_version: int = 0,
-        ssl_certificate: Union[str, None] = None,
+        ssl_certificate: Union[str, bool] = True,
     ) -> None:
         if not url.lower().startswith("https://"):
             warnings.warn(
@@ -69,10 +69,11 @@ class Connection:
         self.url = url
         self.api_version = api_version
         self.session = httpx.Client(
-            base_url=f"{self.url}/api/{self.api_version}/", timeout=None, http2=http2
+            base_url=f"{self.url}/api/{self.api_version}/",
+            timeout=None,
+            http2=http2,
+            verify=ssl_certificate,
         )
-        if ssl_certificate is not None:
-            self.session.verify = ssl_certificate
         self.update_token(token=token)
 
     def update_token(self, token: str) -> None:

--- a/flowclient/tests/unit/test_login.py
+++ b/flowclient/tests/unit/test_login.py
@@ -38,17 +38,6 @@ def test_login(token):
     assert token == c.token
     assert "bar" == c.user
     assert "Authorization" in c.session.headers
-    assert False == getattr(
-        c.session, "verify", False
-    )  # Shouldn't be set if no ssl_certificate passed
-
-
-def test_ssl_cert_path_set(token):
-    """
-    Test that if a path to certificate is given it gets set on the session object.
-    """
-    c = Connection(url="foo", token=token, ssl_certificate="DUMMY_CERT_PATH")
-    assert "DUMMY_CERT_PATH" == c.session.verify
 
 
 def test_connection_repr(token):


### PR DESCRIPTION
Closes #3344

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Passes the provided ssl certificate file to the underlying httpx client at init instead of setting it as an attribute.