### PR TITLE
Fix broken rendering of some qa checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- FlowETL QA checks with template sections conditional on the `cdr_type` argument now render correctly. [#3479](https://github.com/Flowminder/FlowKit/issues/3479)
 
 ### Removed
 

--- a/flowetl/flowetl/flowetl/mixins/table_name_macros_mixin.py
+++ b/flowetl/flowetl/flowetl/mixins/table_name_macros_mixin.py
@@ -34,6 +34,7 @@ class TableNameMacrosMixin:
             final_table=final_table,
             extract_table=extract_table,
             staging_table=staging_table,
+            cdr_type=cdr_type,
             **context,
         )
         super().render_template_fields(context, jinja_env=jinja_env)

--- a/flowetl/tests/unit/test_table_name_macros.py
+++ b/flowetl/tests/unit/test_table_name_macros.py
@@ -26,5 +26,6 @@ def test_macros():
         final_table="events.TEST_TYPE_DATE_STAMP",
         extract_table="etl.extract_TEST_TYPE_DATE_STAMP",
         staging_table="etl.stg_TEST_TYPE_DATE_STAMP",
+        cdr_type="TEST_TYPE",
         **test_context,
     )


### PR DESCRIPTION
Closes #3479

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Adds a `cdr_type` macro available on flowetl templates