### PR TITLE
Disable travis requirement for mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,6 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - label=ready-to-merge
       - status-success=run_build_pipeline
-      - status-success=Travis CI - Pull Request
     actions:
       merge:
         method: merge
@@ -13,7 +12,6 @@ pull_request_rules:
   - name: automatic merge for Dependabot pull requests on master
     conditions:
       - author=dependabot[bot]
-      - status-success=Travis CI - Pull Request
       - status-success=run_build_pipeline
       - base=master
     actions:


### PR DESCRIPTION
Travis have radically limited their OSS offering, and given we already pay for CircleCI we aren't going to pay for travis as well.
