### PR TITLE
Fix misleading error with empty table list 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fixed a potential deadlock when using a small connection pool and `store`-ing queries
 - AutoFlow can now be run in a docker container with non-default user. [#5574](https://github.com/Flowminder/FlowKit/issues/5574)
+- Passing an empty list of events tables when creating a query now raises `ValueError: Empty tables list.` instead of a `MissingDateError`. [#436](https://github.com/Flowminder/FlowKit/issues/436)
 
 ### Removed
 

--- a/flowmachine/flowmachine/features/utilities/events_tables_union.py
+++ b/flowmachine/flowmachine/features/utilities/events_tables_union.py
@@ -84,8 +84,16 @@ class EventsTablesUnion(Query):
     def _parse_tables(self, tables):
         if tables is None:
             return [f"events.{t}" for t in get_db().subscriber_tables]
-        elif isinstance(tables, str):
+        elif isinstance(tables, str) and len(tables) > 0:
             return [tables]
+        elif isinstance(tables, str):
+            raise ValueError("Empty table name.")
+        elif not isinstance(tables, list) or not all(
+            [isinstance(tbl, str) for tbl in tables]
+        ):
+            raise ValueError("Tables must be a string or list of strings.")
+        elif len(tables) == 0:
+            raise ValueError("Empty tables list.")
         else:
             return tables
 

--- a/flowmachine/tests/test_events_table_union.py
+++ b/flowmachine/tests/test_events_table_union.py
@@ -62,6 +62,29 @@ def test_get_only_sms(get_length):
     assert get_length(etu) == 1246
 
 
+@pytest.mark.parametrize(
+    "arg,error_type,error_message",
+    [
+        ("", ValueError, "Empty table name."),
+        (0, ValueError, "Tables must be a string or list of strings."),
+        ([0, "a"], ValueError, "Tables must be a string or list of strings."),
+        ([], ValueError, "Empty tables list."),
+    ],
+)
+def test_bad_table_arguments(arg, error_type, error_message):
+    """
+    Test that an appropriate error is raised for bad tables arguments.
+    """
+
+    with pytest.raises(expected_exception=error_type, match=error_message):
+        EventsTablesUnion(
+            "2016-01-01",
+            "2016-01-02",
+            columns=["msisdn"],
+            tables=arg,
+        )
+
+
 def test_get_list_of_tables(get_length):
     """
     Test that we can get only sms


### PR DESCRIPTION
Closes #436

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [ ] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Fixes the misleading missing dates error raised when passing an empty list of tables to `EventsTablesUnion`. Instead it will now raise a `ValueError` stating that the list must have table names in it, also raises sensible errors for empty strings, and things which are not strings.