### PR TITLE
Fix cannot uncache novel objs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Autoflow's prefect version is now current. [#2544](https://github.com/Flowminder/FlowKit/issues/2544)
+- FlowMachine server will now successfully remove cache for queries defined in an interactive flowmachine session during cleanup. [#4008](https://github.com/Flowminder/FlowKit/issues/4008)   
 
 ### Removed
 

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -36,7 +36,26 @@ import structlog
 logger = structlog.get_logger("flowmachine.debug", submodule=__name__)
 
 
-def get_obj_or_stub(connection, query_id):
+def get_obj_or_stub(connection: "Connection", query_id: str):
+    """
+    Get a query object by ID if the object can be recreated. If it cannot
+    then get a stub which keeps the query's dependency relationships as recorded
+    in the database.
+
+    Parameters
+    ----------
+    connection : Connection
+        DB connection to get the object from
+    query_id : str
+        Unique identifier of the query
+
+    Returns
+    -------
+    Query
+        The query object if it can be recreated, or a 'stub' class which records
+        the dependencies it had if not.
+
+    """
     from flowmachine.core.query import Query
 
     class QStub(Query):

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -36,6 +36,33 @@ import structlog
 logger = structlog.get_logger("flowmachine.debug", submodule=__name__)
 
 
+def get_obj_or_stub(connection, query_id):
+    from flowmachine.core.query import Query
+
+    class QStub(Query):
+        def __init__(self, deps, qid):
+            self.deps = deps
+            self._md5 = qid
+            super().__init__()
+
+        def _make_query(self):
+            pass
+
+        @property
+        def column_names(self):
+            pass
+
+    try:
+        return get_query_object_by_id(connection, query_id)
+    except EOFError:
+        logger.debug("Can't unpickle, creating stub.", query_id=query_id)
+        qry = f"SELECT depends_on FROM cache.dependencies WHERE query_id='{query_id}'"
+        return QStub(
+            deps=[get_obj_or_stub(connection, res[0]) for res in connection.fetch(qry)],
+            qid=query_id,
+        )
+
+
 def write_query_to_cache(
     *,
     name: str,
@@ -395,14 +422,15 @@ def get_cached_query_objects_ordered_by_score(
         if protected_period is not None
         else " AND NOW()-created > (cache_protected_period()*INTERVAL '1 seconds')"
     )
-    qry = f"""SELECT obj, table_size(tablename, schema) as table_size
+    qry = f"""SELECT query_id, table_size(tablename, schema) as table_size
         FROM cache.cached
         WHERE cached.class!='Table' AND cached.class!='GeoTable'
         {protected_period_clause}
         ORDER BY cache_score(cache_score_multiplier, compute_time, table_size(tablename, schema)) ASC
         """
     cache_queries = connection.fetch(qry)
-    yield from ((pickle.loads(obj), table_size) for obj, table_size in cache_queries)
+    for query_id, table_size in cache_queries:
+        yield get_obj_or_stub(connection, query_id)
 
 
 def shrink_one(

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -73,7 +73,13 @@ def get_obj_or_stub(connection: "Connection", query_id: str):
 
     try:
         return get_query_object_by_id(connection, query_id)
-    except (EOFError, ModuleNotFoundError, AttributeError) as exc:
+    except (
+        EOFError,
+        ModuleNotFoundError,
+        AttributeError,
+        pickle.UnpicklingError,
+        IndexError
+    ) as exc:
         logger.debug("Can't unpickle, creating stub.", query_id=query_id, exception=exc)
         qry = f"SELECT depends_on FROM cache.dependencies WHERE query_id='{query_id}'"
         return QStub(

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -449,7 +449,7 @@ def get_cached_query_objects_ordered_by_score(
         """
     cache_queries = connection.fetch(qry)
     for query_id, table_size in cache_queries:
-        yield get_obj_or_stub(connection, query_id)
+        yield get_obj_or_stub(connection, query_id), table_size
 
 
 def shrink_one(

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -78,7 +78,7 @@ def get_obj_or_stub(connection: "Connection", query_id: str):
         ModuleNotFoundError,
         AttributeError,
         pickle.UnpicklingError,
-        IndexError
+        IndexError,
     ) as exc:
         logger.debug("Can't unpickle, creating stub.", query_id=query_id, exception=exc)
         qry = f"SELECT depends_on FROM cache.dependencies WHERE query_id='{query_id}'"

--- a/flowmachine/flowmachine/core/cache.py
+++ b/flowmachine/flowmachine/core/cache.py
@@ -73,8 +73,8 @@ def get_obj_or_stub(connection: "Connection", query_id: str):
 
     try:
         return get_query_object_by_id(connection, query_id)
-    except EOFError:
-        logger.debug("Can't unpickle, creating stub.", query_id=query_id)
+    except (EOFError, ModuleNotFoundError, AttributeError) as exc:
+        logger.debug("Can't unpickle, creating stub.", query_id=query_id, exception=exc)
         qry = f"SELECT depends_on FROM cache.dependencies WHERE query_id='{query_id}'"
         return QStub(
             deps=[get_obj_or_stub(connection, res[0]) for res in connection.fetch(qry)],

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -27,7 +27,7 @@ from hashlib import md5
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import ResourceClosedError
 
-from flowmachine.core.cache import touch_cache
+from flowmachine.core.cache import touch_cache, get_obj_or_stub
 from flowmachine.core.context import (
     get_db,
     get_redis,
@@ -848,13 +848,12 @@ class Query(metaclass=ABCMeta):
             except NotImplementedError:
                 pass  # Not a storable by default table
             try:
-                deps = get_db().fetch(
-                    """SELECT obj FROM cache.cached LEFT JOIN cache.dependencies
-                    ON cache.cached.query_id=cache.dependencies.query_id
-                    WHERE depends_on='{}'""".format(
-                        self.query_id
+                dep_ids = [
+                    rec[0]
+                    for rec in get_db().fetch(
+                        f"SELECT query_id FROM cache.dependencies WHERE depends_on='{self.query_id}'"
                     )
-                )
+                ]
                 with con.begin():
                     con.execute(
                         "DELETE FROM cache.cached WHERE query_id=%s", (self.query_id,)
@@ -869,8 +868,8 @@ class Query(metaclass=ABCMeta):
                         log("Dropped cache table.")
 
                 if cascade:
-                    for rec in deps:
-                        dep = pickle.loads(rec[0])
+                    for dep_id in dep_ids:
+                        dep = get_obj_or_stub(get_db(), dep_id)
                         log(
                             "Cascading to dependent.",
                             dependency=dep.fully_qualified_table_name,
@@ -981,22 +980,17 @@ class Query(metaclass=ABCMeta):
         self._cache = False
 
     @classmethod
-    def get_stored(cls):
+    def get_stored(cls) -> "Query":
         """
-        Get a list of stored query objects of this type
+        Get a generator of stored query objects of this type
 
-        Returns
-        -------
-        list
+        Yields
+        ------
+        Query
             All cached instances of this Query type, or any if called with
             Query.
 
         """
-        try:
-            get_db()
-        except:
-            raise NotConnectedError()
-
         if cls is Query:
             qry = "SELECT obj FROM cache.cached"
         else:

--- a/flowmachine/tests/test_cache.py
+++ b/flowmachine/tests/test_cache.py
@@ -272,7 +272,7 @@ def create_and_store_novel_query():
 
 
 def test_retrieve_novel_query(create_and_store_novel_query, flowmachine_connect):
-    """ Test that a runtime defined query can be pulled from cache and invalidated. """
+    """Test that a runtime defined query can be pulled from cache and invalidated."""
     from_cache = get_obj_or_stub(get_db(), create_and_store_novel_query)
     assert from_cache.query_id == create_and_store_novel_query
     assert from_cache.is_stored
@@ -315,7 +315,7 @@ def create_and_store_novel_query_with_dependency():
 def test_retrieve_novel_query_with_dependency(
     create_and_store_novel_query_with_dependency, flowmachine_connect
 ):
-    """ Test that a runtime defined query composed of others can be pulled from cache and invalidated. """
+    """Test that a runtime defined query composed of others can be pulled from cache and invalidated."""
     qid, nested_id = create_and_store_novel_query_with_dependency
     from_cache = get_obj_or_stub(get_db(), qid)
     assert from_cache.query_id == qid

--- a/flowmachine/tests/test_cache.py
+++ b/flowmachine/tests/test_cache.py
@@ -8,7 +8,11 @@ Tests for query caching functions.
 
 import pytest
 
-from flowmachine.core.cache import cache_table_exists, write_cache_metadata
+from flowmachine.core.cache import (
+    cache_table_exists,
+    write_cache_metadata,
+    get_obj_or_stub,
+)
 from flowmachine.core.context import get_db
 from flowmachine.core.query import Query
 from flowmachine.features import daily_location, ModalLocation, Flows
@@ -267,14 +271,10 @@ def create_and_store_novel_query():
     yield q_id
 
 
-def test_retrieve_novel_query(create_and_store_novel_query):
+def test_retrieve_novel_query(create_and_store_novel_query, flowmachine_connect):
     """ Test that a runtime defined query can be pulled from cache and invalidated. """
-    from_cache = {x.query_id: x for x in Query.get_stored()}
-    assert create_and_store_novel_query in from_cache
-    from_cache[create_and_store_novel_query].invalidate_db_cache()
-    assert create_and_store_novel_query not in {
-        x.query_id: x for x in Query.get_stored()
-    }
+    from_cache = get_obj_or_stub(get_db(), create_and_store_novel_query)
+    from_cache.invalidate_db_cache()
 
 
 def test_df_not_pickled():


### PR DESCRIPTION
Closes #4008 

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Deals with queries which were defined outside the server process (e.g. interactive session, defined in an imported module in an interactive session) being un-invalidatable outside the defining session by unpickling them to a stub class which does nothing but preserve their dependency links and query id.

I was hoping to deal with this by pickling them using dill, but that can't pickle them either outside of a `__main__`. One could also pickle to a stub where not pickleable, but I think this is marginally more robust because it doesn't rely on everyone immediately using an up to date FlowMachine.