### PR TITLE
Adding join_type param to flows + test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added mixin for exposing start_date and end_date internally as datetime objects [#4497](https://github.com/Flowminder/FlowKit/issues/4497)
 - Added `CombineFirst` and `CoalescedLocation` queries. [#4524](https://github.com/Flowminder/FlowKit/issues/4524)
 - Added `MajorityLocation` query. [#4522](https://github.com/Flowminder/FlowKit/issues/4522)
+- Added `join_type` param to `Flows` class. [#4539](https://github.com/Flowminder/FlowKit/issues/4539)
 
 ### Changed
 - Harmonised FlowAPI parameter names for start and end dates. They are now all `start_date` and `end_date`

--- a/flowmachine/flowmachine/features/location/flows.py
+++ b/flowmachine/flowmachine/features/location/flows.py
@@ -121,7 +121,7 @@ class Flows(FlowLike, Query):
         As above for the second period
     """
 
-    def __init__(self, loc1, loc2):
+    def __init__(self, loc1, loc2, join_type="inner"):
         if loc1.spatial_unit != loc2.spatial_unit:
             raise InvalidSpatialUnitError(
                 "You cannot compute flows for locations on different spatial units"
@@ -129,7 +129,11 @@ class Flows(FlowLike, Query):
 
         self.spatial_unit = loc1.spatial_unit
         self.joined = loc1.join(
-            loc2, on_left="subscriber", left_append="_from", right_append="_to"
+            loc2,
+            on_left="subscriber",
+            left_append="_from",
+            right_append="_to",
+            how=join_type,
         )
         logger.info(
             "{} locations are pre-calculated.".format(loc1.is_stored + loc2.is_stored)

--- a/flowmachine/flowmachine/features/location/flows.py
+++ b/flowmachine/flowmachine/features/location/flows.py
@@ -119,6 +119,8 @@ class Flows(FlowLike, Query):
         first time frame of interest
     loc2 : daily_location, or ModalLocation object
         As above for the second period
+    join_type : {"inner", "full outer", "left", "right", "left outer", "right outer"} default "inner"
+        Join type of the join between loc_1 and loc_2
     """
 
     def __init__(self, loc1, loc2, join_type="inner"):

--- a/flowmachine/tests/test_flows.py
+++ b/flowmachine/tests/test_flows.py
@@ -151,3 +151,17 @@ def test_flows_geojson(get_dataframe):
         ].set_index("admin2name_to")
         for dest, tot in outflows.items():
             assert tot == df_src.loc[dest]["value"]
+
+
+def test_flows_outer_join(get_dataframe):
+    """
+    Test that outer_join returns appropriate pieces
+    """
+    flow = Flows(
+        daily_location("2016-01-01", spatial_unit=make_spatial_unit("admin", level=3)),
+        daily_location("2016-01-02", spatial_unit=make_spatial_unit("admin", level=3)),
+        join_type="left outer",
+    )
+    out = get_dataframe(flow)
+    assert out.pcod_to.isna().any()
+    assert not out.pcod_from.isna().any()


### PR DESCRIPTION
Closes #4539 

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Adds a `join_type` param to `Flows` that is passed straight to the internal `join` object. Defaults to `inner`.