### PR TITLE
Per subscriber aggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `CombineFirst` and `CoalescedLocation` queries. [#4524](https://github.com/Flowminder/FlowKit/issues/4524)
 - Added `MajorityLocation` query. [#4522](https://github.com/Flowminder/FlowKit/issues/4522)
 - Added `join_type` param to `Flows` class. [#4539](https://github.com/Flowminder/FlowKit/issues/4539)
+- Added `PerSubscriberAggregate` query. [#4559](https://github.com/Flowminder/FlowKit/issues/4559)
 
 ### Changed
 - Harmonised FlowAPI parameter names for start and end dates. They are now all `start_date` and `end_date`

--- a/flowmachine/flowmachine/features/subscriber/per_subscriber_aggregate.py
+++ b/flowmachine/flowmachine/features/subscriber/per_subscriber_aggregate.py
@@ -15,9 +15,9 @@ class PerSubscriberAggregate(SubscriberFeature):
         if "subscriber" not in subscriber_query.column_names:
             raise ValueError("'subscriber' column not in subscriber_query")
         if agg_column not in subscriber_query.column_names:
-            raise ValueError(f"{agg_column} not in subscriber_query")
+            raise ValueError(f"'{agg_column}' column not in subscriber_query")
         if agg_method not in agg_methods:
-            raise ValueError(f"{agg_method} not in {agg_methods}")
+            raise ValueError(f"agg_method must be one of {agg_methods}, not '{agg_method}'")
 
         self.subscriber_query = subscriber_query
         self.agg_column = agg_column

--- a/flowmachine/flowmachine/features/subscriber/per_subscriber_aggregate.py
+++ b/flowmachine/flowmachine/features/subscriber/per_subscriber_aggregate.py
@@ -1,6 +1,8 @@
 from typing import List
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 
+agg_methods = {"count", "sum", "avg", "max", "min", "median", "stddev", "variance"}
+
 
 class PerSubscriberAggregate(SubscriberFeature):
     def __init__(
@@ -10,6 +12,13 @@ class PerSubscriberAggregate(SubscriberFeature):
         agg_column: str,
         agg_method: str = "avg",
     ):
+        if "subscriber" not in subscriber_query.column_names:
+            raise ValueError("'subscriber' column not in subscriber_query")
+        if agg_column not in subscriber_query:
+            raise ValueError(f"{agg_column} not in subscriber_query")
+        if agg_method not in agg_methods:
+            raise ValueError(f"{agg_method} not in {agg_methods}")
+
         self.subscriber_query = subscriber_query
         self.agg_column = agg_column
         self.agg_method = agg_method

--- a/flowmachine/flowmachine/features/subscriber/per_subscriber_aggregate.py
+++ b/flowmachine/flowmachine/features/subscriber/per_subscriber_aggregate.py
@@ -1,3 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# -*- coding: utf-8 -*-
+
 from typing import List
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 
@@ -5,6 +11,45 @@ agg_methods = {"count", "sum", "avg", "max", "min", "median", "stddev", "varianc
 
 
 class PerSubscriberAggregate(SubscriberFeature):
+    """
+        Query that performs per-subscriber aggregation of a column. Returns a column
+        'subscriber' containing unique subscribers and a column 'value' containing the
+        aggregration.
+
+        Parameters
+        ----------
+        subscriber_query: SubscriberFeature
+            A query with a `subscriber` column
+        agg_column: str
+            The name of the column in `subscriber_query` to aggregate. Cannot be 'subscriber'.
+        agg_method: {"count", "sum", "avg", "max", "min", "median", "stddev", "variance"} default "avg"
+            The method of aggregation to perform
+
+        Examples
+        --------
+        Gets the maximum call duration of each subscriber on 2016-01-01.
+        >>>     per_location_query = PerLocationSubscriberCallDurations("2016-01-01", "2016-01-02")
+        >>>     max_psa = PerSubscriberAggregate(
+        ...         subscriber_query=per_location_query, agg_column="value", agg_method="max"
+        ...     )
+
+                   subscriber   value
+        0    038OVABN11Ak4W5P  4641.0
+        1    0Gl95NRLjW2aw8pW   876.0
+        2    0gmvwzMAYbz5We1E  2214.0
+        3    0MQ4RYeKn7lryxGa  3964.0
+        4    0Ze1l70j0LNgyY4w  3368.0
+        ..                ...     ...
+        350  ZmPRjkQ74Xeql71V  2385.0
+        351  ZQG8glazmxYa1K62  4238.0
+        352  Zv4W9eak2QN1M5A7   337.0
+        353  zvaOknzKbEVD2eME  2171.0
+        354  ZYPxqVGLzlQy6l7n  4602.0
+
+    [355 rows x 2 columns]
+
+    """
+
     def __init__(
         self,
         *,
@@ -16,8 +61,12 @@ class PerSubscriberAggregate(SubscriberFeature):
             raise ValueError("'subscriber' column not in subscriber_query")
         if agg_column not in subscriber_query.column_names:
             raise ValueError(f"'{agg_column}' column not in subscriber_query")
+        if agg_column == "subscriber":
+            raise ValueError(f"'agg_column' cannot be 'subscriber'")
         if agg_method not in agg_methods:
-            raise ValueError(f"agg_method must be one of {agg_methods}, not '{agg_method}'")
+            raise ValueError(
+                f"agg_method must be one of {agg_methods}, not '{agg_method}'"
+            )
 
         self.subscriber_query = subscriber_query
         self.agg_column = agg_column

--- a/flowmachine/flowmachine/features/subscriber/per_subscriber_aggregate.py
+++ b/flowmachine/flowmachine/features/subscriber/per_subscriber_aggregate.py
@@ -14,7 +14,7 @@ class PerSubscriberAggregate(SubscriberFeature):
     ):
         if "subscriber" not in subscriber_query.column_names:
             raise ValueError("'subscriber' column not in subscriber_query")
-        if agg_column not in subscriber_query:
+        if agg_column not in subscriber_query.column_names:
             raise ValueError(f"{agg_column} not in subscriber_query")
         if agg_method not in agg_methods:
             raise ValueError(f"{agg_method} not in {agg_methods}")

--- a/flowmachine/flowmachine/features/subscriber/per_subscriber_aggregate.py
+++ b/flowmachine/flowmachine/features/subscriber/per_subscriber_aggregate.py
@@ -1,0 +1,26 @@
+from typing import List
+from flowmachine.features.subscriber.metaclasses import SubscriberFeature
+
+
+class PerSubscriberAggregate(SubscriberFeature):
+    def __init__(
+        self,
+        subscriber_query: SubscriberFeature,
+        agg_column: str,
+        agg_method: str = "mean",
+    ):
+        self.subscriber_query = subscriber_query
+        self.agg_column = agg_column
+        self.agg_method = agg_method
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "value"]
+
+    def _make_query(self):
+        sql = f"""
+SELECT subscriber, {self.agg_method} AS value
+FROM ({self.subscriber_query.get_query()}) AS sub_table
+GROUP BY subscriber
+"""
+        return sql

--- a/flowmachine/flowmachine/features/subscriber/per_subscriber_aggregate.py
+++ b/flowmachine/flowmachine/features/subscriber/per_subscriber_aggregate.py
@@ -5,9 +5,10 @@ from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 class PerSubscriberAggregate(SubscriberFeature):
     def __init__(
         self,
+        *,
         subscriber_query: SubscriberFeature,
         agg_column: str,
-        agg_method: str = "mean",
+        agg_method: str = "avg",
     ):
         self.subscriber_query = subscriber_query
         self.agg_column = agg_column
@@ -19,7 +20,7 @@ class PerSubscriberAggregate(SubscriberFeature):
 
     def _make_query(self):
         sql = f"""
-SELECT subscriber, {self.agg_method} AS value
+SELECT subscriber, {self.agg_method}({self.agg_column}) AS value
 FROM ({self.subscriber_query.get_query()}) AS sub_table
 GROUP BY subscriber
 """

--- a/flowmachine/tests/test_per_subscriber_aggregate.py
+++ b/flowmachine/tests/test_per_subscriber_aggregate.py
@@ -51,7 +51,7 @@ def test_agg_method(get_dataframe, per_location_query):
     )
     max_df = get_dataframe(max_psa)
     min_df = get_dataframe(min_psa)
-    assert (max_df.value >= min_df.value).all()
+    assert (max_df.value > min_df.value).any()
 
 
 def test_agg_column_validation(per_location_query):

--- a/flowmachine/tests/test_per_subscriber_aggregate.py
+++ b/flowmachine/tests/test_per_subscriber_aggregate.py
@@ -1,15 +1,63 @@
 from flowmachine.features.subscriber.per_subscriber_aggregate import (
     PerSubscriberAggregate,
+    agg_methods,
 )
 from flowmachine.features.subscriber.subscriber_call_durations import (
     PerLocationSubscriberCallDurations,
 )
+from flowmachine.core.dummy_query import DummyQuery
+
+import pytest
 
 
-def test_per_subscriber_aggregate(get_dataframe):
+@pytest.fixture()
+def per_location_query(flowmachine_connect):
+    sq = PerLocationSubscriberCallDurations("2016-01-01", "2016-01-02")
+    yield sq
+
+
+class NonSubQuery(DummyQuery):
+    @property
+    def column_names(self):
+        return ["value"]
+
+
+@pytest.mark.parametrize("agg_method", agg_methods)
+def test_aggregates(get_dataframe, agg_method, per_location_query):
+
     psa = PerSubscriberAggregate(
-        subscriber_query=PerLocationSubscriberCallDurations("2016-01-01", "2016-01-02"),
+        subscriber_query=per_location_query,
         agg_column="value",
-        agg_method="avg",
+        agg_method=agg_method,
     )
-    assert len(get_dataframe(psa)) >= 0
+    # per_location_query is 608 rows
+    assert (
+        len(get_dataframe(psa))
+        == get_dataframe(per_location_query).subscriber.nunique()
+    )
+
+
+def test_agg_column_validation(per_location_query):
+    with pytest.raises(ValueError):
+        psa = PerSubscriberAggregate(
+            subscriber_query=per_location_query,
+            agg_column="nonexistant",
+            agg_method="avg",
+        )
+
+
+def test_agg_method_validation(per_location_query):
+    with pytest.raises(ValueError):
+        psa = PerSubscriberAggregate(
+            subscriber_query=per_location_query,
+            agg_column="value",
+            agg_method="bogosort",
+        )
+
+
+def test_subscriber_column_validation():
+    dq = NonSubQuery(dummy_param="foo")
+    with pytest.raises(ValueError):
+        psa = PerSubscriberAggregate(
+            subscriber_query=dq, agg_column="value", agg_method="avg"
+        )

--- a/flowmachine/tests/test_per_subscriber_aggregate.py
+++ b/flowmachine/tests/test_per_subscriber_aggregate.py
@@ -30,11 +30,22 @@ def test_aggregates(get_dataframe, agg_method, per_location_query):
         agg_column="value",
         agg_method=agg_method,
     )
-    # per_location_query is 608 rows
     assert (
         len(get_dataframe(psa))
         == get_dataframe(per_location_query).subscriber.nunique()
     )
+
+
+def test_agg_method(get_dataframe, per_location_query):
+    max_psa = PerSubscriberAggregate(
+        subscriber_query=per_location_query, agg_column="value", agg_method="max"
+    )
+    min_psa = PerSubscriberAggregate(
+        subscriber_query=per_location_query, agg_column="value", agg_method="min"
+    )
+    max_df = get_dataframe(max_psa)
+    min_df = get_dataframe(min_psa)
+    assert (max_df.value >= min_df.value).all()
 
 
 def test_agg_column_validation(per_location_query):

--- a/flowmachine/tests/test_per_subscriber_aggregate.py
+++ b/flowmachine/tests/test_per_subscriber_aggregate.py
@@ -38,7 +38,7 @@ def test_aggregates(get_dataframe, agg_method, per_location_query):
 
 
 def test_agg_column_validation(per_location_query):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'nonexistant'"):
         psa = PerSubscriberAggregate(
             subscriber_query=per_location_query,
             agg_column="nonexistant",
@@ -47,7 +47,7 @@ def test_agg_column_validation(per_location_query):
 
 
 def test_agg_method_validation(per_location_query):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'bogosort'"):
         psa = PerSubscriberAggregate(
             subscriber_query=per_location_query,
             agg_column="value",
@@ -57,7 +57,7 @@ def test_agg_method_validation(per_location_query):
 
 def test_subscriber_column_validation():
     dq = NonSubQuery(dummy_param="foo")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'subscriber'"):
         psa = PerSubscriberAggregate(
             subscriber_query=dq, agg_column="value", agg_method="avg"
         )

--- a/flowmachine/tests/test_per_subscriber_aggregate.py
+++ b/flowmachine/tests/test_per_subscriber_aggregate.py
@@ -1,3 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# -*- coding: utf-8 -*-
+
 from flowmachine.features.subscriber.per_subscriber_aggregate import (
     PerSubscriberAggregate,
     agg_methods,
@@ -71,4 +77,13 @@ def test_subscriber_column_validation():
     with pytest.raises(ValueError, match="'subscriber'"):
         psa = PerSubscriberAggregate(
             subscriber_query=dq, agg_column="value", agg_method="avg"
+        )
+
+
+def test_not_subscriber_validation(per_location_query):
+    with pytest.raises(ValueError, match="'agg_column' cannot be 'subscriber'"):
+        psa = PerSubscriberAggregate(
+            subscriber_query=per_location_query,
+            agg_column="subscriber",
+            agg_method="avg",
         )

--- a/flowmachine/tests/test_per_subscriber_aggregate.py
+++ b/flowmachine/tests/test_per_subscriber_aggregate.py
@@ -51,6 +51,7 @@ def test_agg_method(get_dataframe, per_location_query):
     )
     max_df = get_dataframe(max_psa)
     min_df = get_dataframe(min_psa)
+    assert (max_df.value >= min_df.value).all()
     assert (max_df.value > min_df.value).any()
 
 

--- a/flowmachine/tests/test_per_subscriber_aggregate.py
+++ b/flowmachine/tests/test_per_subscriber_aggregate.py
@@ -12,4 +12,4 @@ def test_per_subscriber_aggregate(get_dataframe):
         agg_column="value",
         agg_method="avg",
     )
-    assert len(psa) >= 0
+    assert len(get_dataframe(psa)) >= 0

--- a/flowmachine/tests/test_per_subscriber_aggregate.py
+++ b/flowmachine/tests/test_per_subscriber_aggregate.py
@@ -1,0 +1,15 @@
+from flowmachine.features.subscriber.per_subscriber_aggregate import (
+    PerSubscriberAggregate,
+)
+from flowmachine.features.subscriber.subscriber_call_durations import (
+    PerLocationSubscriberCallDurations,
+)
+
+
+def test_per_subscriber_aggregate(get_dataframe):
+    psa = PerSubscriberAggregate(
+        subscriber_query=PerLocationSubscriberCallDurations("2016-01-01", "2016-01-02"),
+        agg_column="value",
+        agg_method="avg",
+    )
+    assert len(psa) >= 0


### PR DESCRIPTION
Closes #4559

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [x] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Implements a `PerSubscriberAggregate` class that takes a query with a `subscriber` column, and performs one of a set of aggregate functions over a specified column per subscriber.