### PR TITLE
Union many

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Harmonised FlowAPI parameter names for start and end dates. They are now all `start_date` and `end_date`
 - Further improvements to token display in FlowAuth. [#1124](https://github.com/Flowminder/FlowKit/issues/1124)
 - Increased the FlowDB quickstart container's timeout to 15 minutes. [#782](https://github.com/Flowminder/FlowKit/issues/782)
+- `Union` and `Query.union` now accept a variable number of queries to concatenate. [#4565](https://github.com/Flowminder/FlowKit/issues/4565)
 
 ### Fixed
 - Autoflow's prefect version is now current. [#2544](https://github.com/Flowminder/FlowKit/issues/2544)

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -398,11 +398,11 @@ class Query(metaclass=ABCMeta):
         """
         return flowmachine.core.Table(self.fully_qualified_table_name)
 
-    def union(self, *other, all=True):
+    def union(self, *other: "Query", all: bool = True):
         """
-        Returns a Query representing a the union of the two queries.
-        This is simply the two tables concatenated. By passing the
-        argument all as true the duplicates are also removed.
+        Returns a Query representing a the union of queries.
+        This is simply the tables concatenated. By passing the
+        argument all as False the duplicates are also removed.
 
         Parameters
         ----------

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -398,7 +398,7 @@ class Query(metaclass=ABCMeta):
         """
         return flowmachine.core.Table(self.fully_qualified_table_name)
 
-    def union(self, other, all=True):
+    def union(self, *other, all=True):
         """
         Returns a Query representing a the union of the two queries.
         This is simply the two tables concatenated. By passing the
@@ -429,7 +429,7 @@ class Query(metaclass=ABCMeta):
 
         from .union import Union
 
-        return Union(self, other, all)
+        return Union(self, *other, all=all)
 
     def join(
         self,

--- a/flowmachine/flowmachine/core/union.py
+++ b/flowmachine/flowmachine/core/union.py
@@ -14,25 +14,26 @@ class Union(Query):
 
     Parameters
     ----------
-    top, bottom : flowmachine.Query object
-        First and second tables respectively
+    queries : flowmachine.Query object
+        Queries to union
+    all : bool, default: True
+        If True, queries will be deduped, if set to False, duplicate rows will be preserved.
     """
 
-    def __init__(self, top, bottom, all=True):
-        """"""
-
-        self.top = top
-        self.bottom = bottom
+    def __init__(self, *queries: Query, all: bool = True):
+        self.queries = queries
         self.all = all
+        column_set = set(tuple(query.column_names) for query in queries)
+        if len(column_set) > 1:
+            raise ValueError("Inconsistent columns.")
 
         super().__init__()
 
     @property
     def column_names(self) -> List[str]:
-        return list(self.top.column_names)
+        return list(self.queries[0].column_names)
 
     def _make_query(self):
-
-        return """({}) UNION {} ({})""".format(
-            self.top.get_query(), "ALL" if self.all else "", self.bottom.get_query()
+        return (" UNION ALL " if self.all else " UNION ").join(
+            f"({query.get_query()})" for query in self.queries
         )

--- a/flowmachine/flowmachine/core/union.py
+++ b/flowmachine/flowmachine/core/union.py
@@ -26,6 +26,8 @@ class Union(Query):
         column_set = set(tuple(query.column_names) for query in queries)
         if len(column_set) > 1:
             raise ValueError("Inconsistent columns.")
+        if len(queries) < 2:
+            raise ValueError("Union requires at least two queries.")
 
         super().__init__()
 

--- a/flowmachine/tests/test_query_union.py
+++ b/flowmachine/tests/test_query_union.py
@@ -5,6 +5,7 @@ import pytest
 
 from flowmachine.core import Table
 from flowmachine.core.custom_query import CustomQuery
+from flowmachine.core.union import Union
 
 
 def test_union_column_names():
@@ -35,7 +36,7 @@ def test_union(get_dataframe):
     assert len(single_id) == 2
 
 
-def test_union_raises():
+def test_union_raises_with_mismatched_columns():
     """
     Test that unioning queries with inconsistent column names raises an error.
     """
@@ -43,3 +44,11 @@ def test_union_raises():
         Table(schema="events", name="calls", columns=["msisdn"]).union(
             Table(schema="events", name="calls")
         )
+
+
+def test_union_raises_with_not_enough_queries():
+    """
+    Test that unioning less than two queries raises an error.
+    """
+    with pytest.raises(ValueError):
+        Union(Table(schema="events", name="calls"))

--- a/flowmachine/tests/test_query_union.py
+++ b/flowmachine/tests/test_query_union.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import pytest
 
 from flowmachine.core import Table
 from flowmachine.core.custom_query import CustomQuery
@@ -32,3 +33,13 @@ def test_union(get_dataframe):
     union_df = get_dataframe(union)
     single_id = union_df[union_df.id == "5wNJA-PdRJ4-jxEdG-yOXpZ"]
     assert len(single_id) == 2
+
+
+def test_union_raises():
+    """
+    Test that unioning queries with inconsistent column names raises an error.
+    """
+    with pytest.raises(ValueError):
+        Table(schema="events", name="calls", columns=["msisdn"]).union(
+            Table(schema="events", name="calls")
+        )


### PR DESCRIPTION
Closes #4565
### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Changes `Union` and `Query.union` such that they accept variable numbers of `Query` objects to union together.