### PR TITLE
Reworking mergify.yml to use a single queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,10 @@
+queue_rules:
+  - name: default
+    conditions:
+      - status-success=run_build_pipeline
+      - base=master
+
+
 pull_request_rules:
   - name: Automatic merge for approved PRs labelled as ready
     conditions:
@@ -6,17 +13,20 @@ pull_request_rules:
       - label=ready-to-merge
       - status-success=run_build_pipeline
     actions:
-      merge:
+      queue:
+        name: default
         method: merge
-        strict: smart
+
   - name: automatic merge for Dependabot pull requests on master
     conditions:
       - author=dependabot[bot]
       - status-success=run_build_pipeline
       - base=master
     actions:
-      merge:
+      queue:
+        name: default
         method: merge
+
   - name: automatic bump for Dependabot pull requests on master
     conditions:
       - author=dependabot[bot]
@@ -24,6 +34,7 @@ pull_request_rules:
     actions:
       comment:
         message: "@dependabot rebase"
+
   - name: Delete branch after merge
     actions:
       delete_head_branch: {}


### PR DESCRIPTION
Closes #4667 

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [ ] Brought the branch up to date with master
- [ ] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Rewrites mergify rules to use a default queue.
At present, assuming everything needs to fall into one queue, and the pre-queue checks (previously know as the merge checks) are sufficient to keep the master branch clean.