### PR TITLE
Use Union's ability to take variadic args

### DIFF
--- a/flowmachine/flowmachine/core/union.py
+++ b/flowmachine/flowmachine/core/union.py
@@ -26,8 +26,8 @@ class Union(Query):
         column_set = set(tuple(query.column_names) for query in queries)
         if len(column_set) > 1:
             raise ValueError("Inconsistent columns.")
-        if len(queries) < 2:
-            raise ValueError("Union requires at least two queries.")
+        if len(queries) < 1:
+            raise ValueError("Union requires at least one query.")
 
         super().__init__()
 

--- a/flowmachine/flowmachine/core/union.py
+++ b/flowmachine/flowmachine/core/union.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import warnings
 
 from typing import List
 
@@ -17,7 +18,7 @@ class Union(Query):
     queries : flowmachine.Query object
         Queries to union
     all : bool, default: True
-        If True, queries will be deduped, if set to False, duplicate rows will be preserved.
+        If False, queries will be deduped, if set to True, duplicate rows will be preserved.
     """
 
     def __init__(self, *queries: Query, all: bool = True):
@@ -28,6 +29,8 @@ class Union(Query):
             raise ValueError("Inconsistent columns.")
         if len(queries) < 1:
             raise ValueError("Union requires at least one query.")
+        if (len(queries) == 1) and (not all):
+            warnings.warn("Single queries are not deduped by Union.")
 
         super().__init__()
 

--- a/flowmachine/flowmachine/features/subscriber/day_trajectories.py
+++ b/flowmachine/flowmachine/features/subscriber/day_trajectories.py
@@ -11,12 +11,12 @@ of events see feature subscriber_locations.
 
 """
 
-from functools import reduce
 from typing import List
 
 from flowmachine.core import Query
 from flowmachine.features.utilities.subscriber_locations import BaseLocation
 from ..utilities.multilocation import MultiLocation
+from flowmachine.core.union import Union
 
 
 class DayTrajectories(MultiLocation, BaseLocation, Query):
@@ -54,9 +54,7 @@ class DayTrajectories(MultiLocation, BaseLocation, Query):
         # This query represents the concatenated locations of the
         # subscribers. Similar to the first step when calculating
         # ModalLocations. See modal_locations.py
-        all_locs = reduce(
-            lambda x, y: x.union(y), (self._append_date(dl) for dl in self._all_dls)
-        )
+        all_locs = Union(*[self._append_date(dl) for dl in self._all_dls])
 
         sql = f"""
         SELECT 

--- a/flowmachine/flowmachine/features/subscriber/modal_location.py
+++ b/flowmachine/flowmachine/features/subscriber/modal_location.py
@@ -17,6 +17,7 @@ from functools import reduce
 from flowmachine.core import Query
 from flowmachine.features.utilities.subscriber_locations import BaseLocation
 from ..utilities.multilocation import MultiLocation
+from ...core.union import Union
 
 
 class ModalLocation(MultiLocation, BaseLocation, Query):
@@ -40,9 +41,7 @@ class ModalLocation(MultiLocation, BaseLocation, Query):
 
         # This query represents the concatenated locations of the
         # subscribers
-        all_locs = reduce(
-            lambda x, y: x.union(y), (self._append_date(dl) for dl in self._all_dls)
-        )
+        all_locs = Union(*[self._append_date(dl) for dl in self._all_dls])
 
         times_visited = f"""
         SELECT all_locs.subscriber, {location_columns_string}, count(*) AS total, max(all_locs.date) as date

--- a/flowmachine/flowmachine/features/subscriber/total_active_periods.py
+++ b/flowmachine/flowmachine/features/subscriber/total_active_periods.py
@@ -20,14 +20,13 @@ References
 ----------
 [1] Veronique Lefebvre, https://docs.google.com/document/d/1BVOAM8bVacen0U0wXbxRmEhxdRbW8J_lyaOcUtDGhx8/edit
 """
-from typing import List, Tuple, Union, Optional
+from typing import List, Tuple, Union as UnionType, Optional
 
 from flowmachine.core import Query
 from .metaclasses import SubscriberFeature
 from flowmachine.utils import time_period_add, standardise_date
 from ..utilities.sets import UniqueSubscribers
-
-from functools import reduce
+from ...core.union import Union
 
 
 class TotalActivePeriodsSubscriber(SubscriberFeature):
@@ -82,7 +81,7 @@ class TotalActivePeriodsSubscriber(SubscriberFeature):
         period_length: int = 1,
         period_unit: str = "days",
         hours: Optional[Tuple[int, int]] = None,
-        table: Union[str, List[str]] = "all",
+        table: UnionType[str, List[str]] = "all",
         subscriber_identifier: str = "msisdn",
         subscriber_subset: Optional[Query] = None,
     ):
@@ -129,8 +128,8 @@ class TotalActivePeriodsSubscriber(SubscriberFeature):
 
     def _get_unioned_subscribers_list(
         self,
-        hours: Union[str, Tuple[int, int]] = "all",
-        table: Union[str, List[str]] = "all",
+        hours: UnionType[str, Tuple[int, int]] = "all",
+        table: UnionType[str, List[str]] = "all",
         subscriber_identifier: str = "msisdn",
         subscriber_subset: Optional[Query] = None,
     ):
@@ -141,18 +140,19 @@ class TotalActivePeriodsSubscriber(SubscriberFeature):
         (as a query)
         """
 
-        all_subscribers = [
-            UniqueSubscribers(
-                start,
-                stop,
-                hours=hours,
-                table=table,
-                subscriber_identifier=subscriber_identifier,
-                subscriber_subset=subscriber_subset,
-            )
-            for start, stop in zip(self.starts, self.stops)
-        ]
-        return reduce(lambda x, y: x.union(y), all_subscribers)
+        return Union(
+            *[
+                UniqueSubscribers(
+                    start,
+                    stop,
+                    hours=hours,
+                    table=table,
+                    subscriber_identifier=subscriber_identifier,
+                    subscriber_subset=subscriber_subset,
+                )
+                for start, stop in zip(self.starts, self.stops)
+            ]
+        )
 
     @property
     def column_names(self) -> List[str]:

--- a/flowmachine/tests/test_query_union.py
+++ b/flowmachine/tests/test_query_union.py
@@ -48,7 +48,7 @@ def test_union_raises_with_mismatched_columns():
 
 def test_union_raises_with_not_enough_queries():
     """
-    Test that unioning less than two queries raises an error.
+    Test that unioning empty list raises an error.
     """
     with pytest.raises(ValueError):
-        Union(Table(schema="events", name="calls"))
+        Union(*[])

--- a/flowmachine/tests/test_query_union.py
+++ b/flowmachine/tests/test_query_union.py
@@ -52,3 +52,8 @@ def test_union_raises_with_not_enough_queries():
     """
     with pytest.raises(ValueError):
         Union(*[])
+
+
+def test_union_warns_on_single():
+    with pytest.warns(UserWarning, match="Single queries are not deduped by Union."):
+        Union(Table(schema="events", name="calls", columns=["msisdn"]), all=False)


### PR DESCRIPTION
Closes #4753 

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Makes the handful of uses of `Union` internally variadic instead of reduces. Haven't added a changelog for this because it is really only internal.