### PR TITLE
Add a trigger to make cache tables owned by flowmachine 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- Tables created under the cache schema in FlowDB will automatically be set to be owned by the `flowmachine` user. [#4714](https://github.com/Flowminder/FlowKit/issues/4714) 
 
 ### Fixed
 

--- a/flowdb/bin/build/9000_last_create_roles.sh
+++ b/flowdb/bin/build/9000_last_create_roles.sh
@@ -199,7 +199,7 @@ psql --dbname="$POSTGRES_DB" -c "
           obj record;
         BEGIN
           FOR obj IN SELECT * FROM pg_event_trigger_ddl_commands() WHERE command_tag='CREATE TABLE' AND schema_name='cache'  LOOP
-            EXECUTE format('ALTER TABLE %s OWNER TO flowmachine', obj.object_identity);
+            EXECUTE format('ALTER TABLE %s OWNER TO $FLOWMACHINE_FLOWDB_USER', obj.object_identity);
           END LOOP;
         END;
         \$\$;


### PR DESCRIPTION
Closes #4714

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [ ] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Adds a trigger on table creation under the cache schema which alters the table to be owned by flowmachine.

Worth discussing whether this should be done this way, or whether this is more properly the responsibility of flowmachine.