### PR TITLE
Fix explain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
-- Tables created under the cache schema in FlowDB will automatically be set to be owned by the `flowmachine` user. [#4714](https://github.com/Flowminder/FlowKit/issues/4714) 
+- Tables created under the cache schema in FlowDB will automatically be set to be owned by the `flowmachine` user. [#4714](https://github.com/Flowminder/FlowKit/issues/4714)
+- `Query.explain` will now explain the query even where it is already stored. [#1285](https://github.com/Flowminder/FlowKit/issues/1285)
 
 ### Fixed
 

--- a/flowmachine/flowmachine/core/query.py
+++ b/flowmachine/flowmachine/core/query.py
@@ -44,7 +44,7 @@ from flowmachine.core.errors import (
 )
 
 import flowmachine
-from flowmachine.utils import _sleep
+from flowmachine.utils import _sleep, pretty_sql
 from flowmachine.core.dependency_graph import (
     store_all_unstored_dependencies,
     store_queries_in_order,
@@ -287,7 +287,7 @@ class Query(metaclass=ABCMeta):
                 return "SELECT * FROM {}".format(table_name)
         except NotImplementedError:
             pass
-        return self._make_query()
+        return pretty_sql(self._make_query())
 
     def get_dataframe_async(self):
         """
@@ -659,7 +659,7 @@ class Query(metaclass=ABCMeta):
         opts = ["FORMAT {}".format(format)]
         if analyse:
             opts.append("ANALYZE")
-        Q = "EXPLAIN ({})".format(", ".join(opts)) + self.get_query()
+        Q = "EXPLAIN ({})".format(", ".join(opts)) + self._make_query()
 
         exp = get_db().fetch(Q)
 


### PR DESCRIPTION
Closes #ISSUE_NUMBER

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Makes `explain` call `_make_query` instead of `get_query` so that explain works sensibly even if the query is already in cache (e.g. why was that query I just ran so slow?)