### PR TITLE
Extend trigger to cover 'CREATE TABLE AS' commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `unstored_dependencies_graph` no longer blocks until dependencies are in a determinate state. [#4949](https://github.com/Flowminder/FlowKit/issues/4949)
 
 ### Fixed
+- FlowDB trigger to alter ownership of cache tables is now triggered when a flowmachine query is `store`d. [#4714](https://github.com/Flowminder/FlowKit/issues/4714)
 
 ### Removed
 - `use_file_flux_sensor` removed entirely. [#2812](https://github.com/Flowminder/FlowKit/issues/2812)

--- a/flowdb/bin/build/9000_last_create_roles.sh
+++ b/flowdb/bin/build/9000_last_create_roles.sh
@@ -198,7 +198,7 @@ psql --dbname="$POSTGRES_DB" -c "
         DECLARE
           obj record;
         BEGIN
-          FOR obj IN SELECT * FROM pg_event_trigger_ddl_commands() WHERE command_tag='CREATE TABLE' AND schema_name='cache'  LOOP
+          FOR obj IN SELECT * FROM pg_event_trigger_ddl_commands() WHERE command_tag IN ('CREATE TABLE', 'CREATE TABLE AS') AND schema_name='cache'  LOOP
             EXECUTE format('ALTER TABLE %s OWNER TO $FLOWMACHINE_FLOWDB_USER', obj.object_identity);
           END LOOP;
         END;
@@ -206,6 +206,6 @@ psql --dbname="$POSTGRES_DB" -c "
 
         CREATE EVENT TRIGGER trg_create_in_cache_set_owner_to_flowmachine
          ON ddl_command_end
-         WHEN tag IN ('CREATE TABLE')
+         WHEN tag IN ('CREATE TABLE', 'CREATE TABLE AS')
          EXECUTE PROCEDURE trg_create_in_cache_set_owner_to_flowmachine();
         "


### PR DESCRIPTION
Closes #4714

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Extends the FlowDB "make tables in cache schema owned by flowmachine user" trigger to cover 'CREATE TABLE AS' commands as well as 'CREATE TABLE' commands, so that ownership is changed for cache tables created by storing a flowmachine query.