### PR TITLE
Fix worked example formatting

### DIFF
--- a/docs/notebook_preamble.py
+++ b/docs/notebook_preamble.py
@@ -27,7 +27,9 @@ logging.getLogger().setLevel(logging.ERROR)
 
 
 def format_dict(x):
-    return f'><div class="codehilite"><pre>{pprint.pformat(x)}</pre></div>'
+    return f"""```python
+    {pprint.pformat(x)}
+```"""
 
 
 get_ipython().display_formatter.formatters["text/markdown"].for_type(dict, format_dict)


### PR DESCRIPTION
Closes #4817

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Changes the `format_dict` function to return markdown, which fixes the wonky docs (see CI artefact).