### PR TITLE
'get_aggregation_unit' action and 'aggregation_unit' params for all spatial aggregates

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -26,49 +26,49 @@ nav:
   - index.md
   - install.md
   - Analysts:
-    - analyst/index.md
-    - FlowClient:
-      - analyst/flowclient/example_usage.ipynb
-      - api-docs-flowclient
-    - Worked examples:
-      - analyst/worked_examples/index.md
-      - analyst/worked_examples/flows-above-normal.ipynb
-      - analyst/worked_examples/commuting-patterns.ipynb
-      - analyst/worked_examples/cell-towers-per-region.ipynb
-      - analyst/worked_examples/unique-subscriber-counts.ipynb
-      - analyst/worked_examples/joined-spatial-aggregate.ipynb
-    - analyst/autoflow.md
-    - Advanced usage:
-        - analyst/advanced_usage/index.md
-        - Worked examples:
-            - analyst/advanced_usage/worked_examples/mobile-data-usage.ipynb
+      - analyst/index.md
+      - FlowClient:
+          - analyst/flowclient/example_usage.ipynb
+          - api-docs-flowclient
+      - Worked examples:
+          - analyst/worked_examples/index.md
+          - analyst/worked_examples/flows-above-normal.ipynb
+          - analyst/worked_examples/commuting-patterns.ipynb
+          - analyst/worked_examples/cell-towers-per-region.ipynb
+          - analyst/worked_examples/unique-subscriber-counts.ipynb
+          - analyst/worked_examples/joined-spatial-aggregate.ipynb
+      - analyst/autoflow.md
+      - Advanced usage:
+          - analyst/advanced_usage/index.md
+          - Worked examples:
+              - analyst/advanced_usage/worked_examples/mobile-data-usage.ipynb
   - Developers:
       - developer/index.md
       - developer/dev_environment_setup.md
       - api-docs-flowmachine
       - FlowAPI specification: developer/api-spec.html
       - Architectural Decision Records (ADR):
-        - developer/adr/README.md
-        - developer/adr/0001-pipenv-for-package-and-dependency-management.md
-        - developer/adr/0002-pytest-for-testing.md
-        - developer/adr/0003-http-api.md
-        - developer/adr/0004-http-framework.md
-        - developer/adr/0005-IPC-methods.md
-        - developer/adr/0006-JWTs.md
-        - developer/adr/0007-mapbox-for-worked-examples.md
-        - developer/adr/0008-jupyter-notebooks-for-autoflow.md
-        - developer/adr/0009-asciidoctor-pdf-for-notebook-conversion.md
-        - developer/adr/0010-prefect-for-autoflow.md
+          - developer/adr/README.md
+          - developer/adr/0001-pipenv-for-package-and-dependency-management.md
+          - developer/adr/0002-pytest-for-testing.md
+          - developer/adr/0003-http-api.md
+          - developer/adr/0004-http-framework.md
+          - developer/adr/0005-IPC-methods.md
+          - developer/adr/0006-JWTs.md
+          - developer/adr/0007-mapbox-for-worked-examples.md
+          - developer/adr/0008-jupyter-notebooks-for-autoflow.md
+          - developer/adr/0009-asciidoctor-pdf-for-notebook-conversion.md
+          - developer/adr/0010-prefect-for-autoflow.md
   - System Administrators:
-    - administrator/index.md
-    - administrator/deployment.md
-    - System management:
-        - administrator/management/cache.md
-        - ETL:
-          - administrator/management/etl/etl.md
-          - api-docs-flowetl
-        - administrator/management/logging.md
-        - administrator/management/users.md
+      - administrator/index.md
+      - administrator/deployment.md
+      - System management:
+          - administrator/management/cache.md
+          - ETL:
+              - administrator/management/etl/etl.md
+              - api-docs-flowetl
+          - administrator/management/logging.md
+          - administrator/management/users.md
   - license.md
   - changelog.md
 
@@ -82,6 +82,7 @@ theme:
   language: en
   features:
     - navigation.tabs
+    - content.tabs.link
   palette:
     accent: "#095798"
     primary: "#2977B8"

--- a/flowapi/flowapi/api_spec.py
+++ b/flowapi/flowapi/api_spec.py
@@ -32,16 +32,6 @@ async def get_spec(socket: Socket, request_id: str) -> APISpec:
     #  Get the reply.
     reply = await socket.recv_json()
     flowmachine_query_schemas = reply["payload"]["query_schemas"]
-    # Need to mark query_kind as a required field
-    # this is a workaround because the marshmallow-oneOf plugin strips
-    # the query_kind off, which means it can't be required from the marshmallow
-    # side without raising an error
-    for schema, schema_dict in flowmachine_query_schemas.items():
-        try:
-            if "query_kind" in schema_dict["properties"]:
-                schema_dict["required"].append("query_kind")
-        except KeyError:
-            pass  # Doesn't have any properties
     spec = APISpec(
         title="FlowAPI",
         version=__version__,

--- a/flowapi/flowapi/permissions.py
+++ b/flowapi/flowapi/permissions.py
@@ -42,6 +42,9 @@ def enum_paths(
         "enum" in tree.keys()
         and len(tree["enum"]) > 1
         and new_path[-1] in argument_names_to_extract
+        and not (
+            ("readOnly" in tree.keys()) and tree["readOnly"]
+        )  # Workaround - read-only aggregation units will be required for new permissions, but should not be taken into account for current permissions
     ):
         yield (new_path, f"{{{new_path[-1]}}}")
     elif "items" in tree.keys():

--- a/flowclient/flowclient/query_specs.py
+++ b/flowclient/flowclient/query_specs.py
@@ -724,8 +724,10 @@ def nocturnal_events_spec(
         "query_kind": "nocturnal_events",
         "start_date": start_date,
         "end_date": end_date,
-        "night_start_hour": hours[0],
-        "night_end_hour": hours[1],
+        "night_hours": dict(
+            start_hour=hours[0],
+            end_hour=hours[1],
+        ),
         "event_types": event_types,
         "subscriber_subset": subscriber_subset,
     }

--- a/flowmachine/flowmachine/core/server/action_handlers.py
+++ b/flowmachine/flowmachine/core/server/action_handlers.py
@@ -58,7 +58,7 @@ async def action_handler__get_available_queries(
 
     Returns a list of available flowmachine queries.
     """
-    available_queries = list(FlowmachineQuerySchema.type_schemas.keys())
+    available_queries = list(FlowmachineQuerySchema().type_schemas.keys())
     return ZMQReply(status="success", payload={"available_queries": available_queries})
 
 

--- a/flowmachine/flowmachine/core/server/action_handlers.py
+++ b/flowmachine/flowmachine/core/server/action_handlers.py
@@ -139,9 +139,9 @@ async def action_handler__get_aggregation_unit(
                 **exc.details,
             ),
         )
-    try:
+    if hasattr(query_obj, "aggregation_unit"):
         aggregation_unit = query_obj.aggregation_unit.canonical_name
-    except AttributeError:
+    else:
         # Query does not have an aggregation unit associated with it
         aggregation_unit = None
     return ZMQReply(status="success", payload={"aggregation_unit": aggregation_unit})

--- a/flowmachine/flowmachine/core/server/action_handlers.py
+++ b/flowmachine/flowmachine/core/server/action_handlers.py
@@ -347,7 +347,9 @@ async def action_handler__get_geography(
     Returns SQL to get geography for the given `aggregation_unit` as GeoJSON.
     """
     try:
-        query_obj = GeographySchema().load({"aggregation_unit": aggregation_unit})
+        query_obj = GeographySchema().load(
+            {"query_kind": "geography", "aggregation_unit": aggregation_unit}
+        )
     except TypeError as exc:
         # We need to catch TypeError here, otherwise they propagate up to
         # perform_action() and result in a very misleading error message.

--- a/flowmachine/flowmachine/core/server/exceptions.py
+++ b/flowmachine/flowmachine/core/server/exceptions.py
@@ -11,3 +11,34 @@ class FlowmachineServerError(Exception):
     def __init__(self, error_msg):
         super().__init__(error_msg)
         self.error_msg = error_msg
+
+
+class QueryLoadError(Exception):
+    """
+    Exception which indicates an error while loading a query object from a dict of parameters.
+
+    Parameters
+    ----------
+    error_msg : str
+        Human-readable string describing the error that occurred.
+    params : dict
+        Query parameters that could not be deserialised.
+    **kwargs
+        Additional details relating to the error (e.g. validation errors).
+
+    Attributes
+    ----------
+    error_msg : str
+        Human-readable string describing the error that occurred.
+    params : dict
+        Query parameters that could not be deserialised.
+    details : dict
+        Dict of additional details relating to the error (e.g. validation errors).
+
+    """
+
+    def __init__(self, error_msg: str, params: dict, **kwargs):
+        super().__init__(error_msg)
+        self.error_msg = error_msg
+        self.params = params
+        self.details = kwargs

--- a/flowmachine/flowmachine/core/server/query_schemas/active_at_reference_location_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/active_at_reference_location_counts.py
@@ -76,19 +76,15 @@ class ActiveAtReferenceLocationCountsSchema(BaseSchema):
     unique_locations = fields.Nested(UniqueLocationsSchema(), required=True)
     reference_locations = fields.Nested(ReferenceLocationSchema(), required=True)
 
-    @validates_schema
+    @validates_schema(skip_on_field_errors=True)
     def validate_aggregation_units(self, data, **kwargs):
         """
         Validate that unique_locations and reference_locations have the same aggregation unit
         """
-        try:
-            if (
-                data["unique_locations"].aggregation_unit
-                != data["reference_locations"].aggregation_unit
-            ):
-                raise ValidationError(
-                    "'unique_locations' and 'reference_locations' parameters must have the same aggregation unit"
-                )
-        except AttributeError:
-            # Nested schema was invalid - appropriate ValidationError will be raised from elsewhere
-            pass
+        if (
+            data["unique_locations"].aggregation_unit
+            != data["reference_locations"].aggregation_unit
+        ):
+            raise ValidationError(
+                "'unique_locations' and 'reference_locations' parameters must have the same aggregation unit"
+            )

--- a/flowmachine/flowmachine/core/server/query_schemas/active_at_reference_location_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/active_at_reference_location_counts.py
@@ -30,6 +30,9 @@ from .unique_locations import UniqueLocationsSchema
 
 
 class ActiveAtReferenceLocationCountsExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "active_at_reference_location_counts"
+
     def __init__(
         self,
         unique_locations,
@@ -60,9 +63,9 @@ class ActiveAtReferenceLocationCountsExposed(BaseExposedQuery):
 
 
 class ActiveAtReferenceLocationCountsSchema(BaseSchema):
-    # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["active_at_reference_location_counts"]))
-    unique_locations = fields.Nested(UniqueLocationsSchema())
-    reference_locations = fields.Nested(ReferenceLocationSchema())
-
     __model__ = ActiveAtReferenceLocationCountsExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    unique_locations = fields.Nested(UniqueLocationsSchema(), required=True)
+    reference_locations = fields.Nested(ReferenceLocationSchema(), required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/aggregate_network_objects.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/aggregate_network_objects.py
@@ -6,6 +6,7 @@ from marshmallow import fields
 from marshmallow.validate import OneOf
 
 from flowmachine.features import AggregateNetworkObjects
+from .aggregation_unit import AggregationUnitKind
 from .base_exposed_query import BaseExposedQuery
 from .base_schema import BaseSchema
 from .total_network_objects import TotalNetworkObjectsSchema
@@ -24,6 +25,10 @@ class AggregateNetworkObjectsExposed(BaseExposedQuery):
         self.total_network_objects = total_network_objects
         self.statistic = statistic
         self.aggregate_by = aggregate_by
+
+    @property
+    def aggregation_unit(self):
+        return self.total_network_objects.aggregation_unit
 
     @property
     def _flowmachine_query_obj(self):
@@ -48,6 +53,7 @@ class AggregateNetworkObjectsSchema(BaseSchema):
 
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    aggregation_unit = AggregationUnitKind(dump_only=True)
     total_network_objects = fields.Nested(TotalNetworkObjectsSchema, required=True)
     statistic = Statistic()
     aggregate_by = AggregateBy()

--- a/flowmachine/flowmachine/core/server/query_schemas/aggregate_network_objects.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/aggregate_network_objects.py
@@ -15,6 +15,9 @@ __all__ = ["AggregateNetworkObjectsSchema", "AggregateNetworkObjectsExposed"]
 
 
 class AggregateNetworkObjectsExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "aggregate_network_objects"
+
     def __init__(self, *, total_network_objects, statistic, aggregate_by):
         # Note: all input parameters need to be defined as attributes on `self`
         # so that marshmallow can serialise the object correctly.
@@ -41,10 +44,10 @@ class AggregateNetworkObjectsExposed(BaseExposedQuery):
 
 
 class AggregateNetworkObjectsSchema(BaseSchema):
+    __model__ = AggregateNetworkObjectsExposed
+
     # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["aggregate_network_objects"]))
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     total_network_objects = fields.Nested(TotalNetworkObjectsSchema, required=True)
     statistic = Statistic()
     aggregate_by = AggregateBy()
-
-    __model__ = AggregateNetworkObjectsExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/aggregate_network_objects.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/aggregate_network_objects.py
@@ -55,5 +55,5 @@ class AggregateNetworkObjectsSchema(BaseSchema):
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     aggregation_unit = AggregationUnitKind(dump_only=True)
     total_network_objects = fields.Nested(TotalNetworkObjectsSchema, required=True)
-    statistic = Statistic()
-    aggregate_by = AggregateBy()
+    statistic = Statistic(required=True)
+    aggregate_by = AggregateBy(required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/aggregation_unit.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/aggregation_unit.py
@@ -14,13 +14,26 @@ class AggregationUnitKind(String):
     A string representing an aggregation unit (for example: "admin0", "admin1", "admin2", ...)
     """
 
-    def __init__(self, required=True, **kwargs):
+    def __init__(self, validate=None, **kwargs):
+        if validate is not None:
+            raise ValueError(
+                "The AggregationUnitKind field provides its own validation "
+                "and thus does not accept a the 'validate' argument."
+            )
         validate = OneOf(["admin0", "admin1", "admin2", "admin3", "lon-lat"])
-        super().__init__(required=required, validate=validate, **kwargs)
+        super().__init__(validate=validate, **kwargs)
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        # This won't serialize the other fields that went into constructing the spatial unit
+        # (e.g. 'mapping_table')
+        try:
+            return value.canonical_name
+        except AttributeError:
+            return super()._serialize(value, attr, obj, **kwargs)
 
 
 class AggregationUnitMixin:
-    aggregation_unit = AggregationUnitKind()
+    aggregation_unit = AggregationUnitKind(required=True)
     mapping_table = String(required=False, allow_none=True)
     geom_table = String(required=False, allow_none=True)
     geom_table_join_column = String(required=False, allow_none=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/coalesced_location.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/coalesced_location.py
@@ -65,34 +65,29 @@ class CoalescedLocationSchema(BaseQueryWithSamplingSchema):
     subscriber_location_weights = fields.Nested(LocationVisitsSchema, required=True)
     weight_threshold = fields.Integer(required=True)
 
-    @validates_schema
+    @validates_schema(skip_on_field_errors=True)
     def validate_aggregation_units(self, data, **kwargs):
         """
         Validate that preferred_location, fallback_location and
         subscriber_location_weights all have the same aggregation unit
         """
         errors = {}
-        try:
-            if (
-                data["fallback_location"].aggregation_unit
-                != data["preferred_location"].aggregation_unit
-            ):
-                errors["fallback_location"] = [
-                    "fallback_location must have the same aggregation_unit as preferred_location"
-                ]
-        except AttributeError:
-            # Nested schema was invalid - appropriate ValidationError will be raised from elsewhere
-            pass
-        try:
-            if (
-                data["subscriber_location_weights"].aggregation_unit
-                != data["fallback_location"].aggregation_unit
-            ):
-                errors["subscriber_location_weights"] = [
-                    "subscriber_location_weights must have the same aggregation_unit as fallback_location"
-                ]
-        except AttributeError:
-            # Nested schema was invalid - appropriate ValidationError will be raised from elsewhere
-            pass
+
+        if (
+            data["fallback_location"].aggregation_unit
+            != data["preferred_location"].aggregation_unit
+        ):
+            errors["fallback_location"] = [
+                "fallback_location must have the same aggregation_unit as preferred_location"
+            ]
+
+        if (
+            data["subscriber_location_weights"].aggregation_unit
+            != data["fallback_location"].aggregation_unit
+        ):
+            errors["subscriber_location_weights"] = [
+                "subscriber_location_weights must have the same aggregation_unit as fallback_location"
+            ]
+
         if errors:
             raise ValidationError(errors)

--- a/flowmachine/flowmachine/core/server/query_schemas/coalesced_location.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/coalesced_location.py
@@ -72,19 +72,27 @@ class CoalescedLocationSchema(BaseQueryWithSamplingSchema):
         subscriber_location_weights all have the same aggregation unit
         """
         errors = {}
-        if (
-            data["fallback_location"].aggregation_unit
-            != data["preferred_location"].aggregation_unit
-        ):
-            errors["fallback_location"] = [
-                "fallback_location must have the same aggregation_unit as preferred_location"
-            ]
-        if (
-            data["subscriber_location_weights"].aggregation_unit
-            != data["fallback_location"].aggregation_unit
-        ):
-            errors["subscriber_location_weights"] = [
-                "subscriber_location_weights must have the same aggregation_unit as fallback_location"
-            ]
+        try:
+            if (
+                data["fallback_location"].aggregation_unit
+                != data["preferred_location"].aggregation_unit
+            ):
+                errors["fallback_location"] = [
+                    "fallback_location must have the same aggregation_unit as preferred_location"
+                ]
+        except AttributeError:
+            # Nested schema was invalid - appropriate ValidationError will be raised from elsewhere
+            pass
+        try:
+            if (
+                data["subscriber_location_weights"].aggregation_unit
+                != data["fallback_location"].aggregation_unit
+            ):
+                errors["subscriber_location_weights"] = [
+                    "subscriber_location_weights must have the same aggregation_unit as fallback_location"
+                ]
+        except AttributeError:
+            # Nested schema was invalid - appropriate ValidationError will be raised from elsewhere
+            pass
         if errors:
             raise ValidationError(errors)

--- a/flowmachine/flowmachine/core/server/query_schemas/coalesced_location.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/coalesced_location.py
@@ -20,6 +20,9 @@ from flowmachine.features.subscriber.filtered_reference_location import (
 
 
 class CoalescedLocationExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "coalesced_location"
+
     def __init__(
         self,
         preferred_location,
@@ -53,7 +56,10 @@ class CoalescedLocationSchema(BaseQueryWithSamplingSchema):
     query as the fallback location
     """
 
-    query_kind = fields.String(validate=OneOf(["coalesced_location"]))
+    __model__ = CoalescedLocationExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     preferred_location = fields.Nested(MajorityLocationSchema, required=True)
     fallback_location = fields.Nested(MajorityLocationSchema, required=True)
     subscriber_location_weights = fields.Nested(LocationVisitsSchema, required=True)
@@ -82,5 +88,3 @@ class CoalescedLocationSchema(BaseQueryWithSamplingSchema):
             ]
         if errors:
             raise ValidationError(errors)
-
-    __model__ = CoalescedLocationExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/consecutive_trips_od_matrix.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/consecutive_trips_od_matrix.py
@@ -20,14 +20,15 @@ from .field_mixins import (
     SubscriberSubsetField,
 )
 from .base_schema import BaseSchema
-from .custom_fields import EventTypes, ISODateTime, Hours
-from .subscriber_subset import SubscriberSubset
 from .aggregation_unit import AggregationUnitMixin
 
 __all__ = ["ConsecutiveTripsODMatrixSchema", "ConsecutiveTripsODMatrixExposed"]
 
 
 class ConsecutiveTripsODMatrixExposed(AggregationUnitMixin, BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "consecutive_trips_od_matrix"
+
     def __init__(
         self,
         start_date,
@@ -78,7 +79,7 @@ class ConsecutiveTripsODMatrixSchema(
     AggregationUnitMixin,
     BaseSchema,
 ):
-    # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["consecutive_trips_od_matrix"]))
-
     __model__ = ConsecutiveTripsODMatrixExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/custom_fields.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/custom_fields.py
@@ -201,7 +201,7 @@ class ISODateTime(fields.DateTime):
 
 
 class Direction(fields.String):
-    def __init__(self, required=False, load_default="both", **kwargs):
+    def __init__(self, required=False, validate=None, load_default="both", **kwargs):
         if validate is not None:
             raise ValueError(
                 "The Direction field provides its own validation and"

--- a/flowmachine/flowmachine/core/server/query_schemas/custom_fields.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/custom_fields.py
@@ -201,6 +201,11 @@ class ISODateTime(fields.DateTime):
 
 
 class Direction(fields.String):
+    """
+    A string representing a direction for CDR events (i.e. incoming/outgoing).
+    Allowed values are 'in', 'out' or 'both' (defaults to 'both' if no value is provided).
+    """
+
     def __init__(self, required=False, validate=None, load_default="both", **kwargs):
         if validate is not None:
             raise ValueError(

--- a/flowmachine/flowmachine/core/server/query_schemas/custom_fields.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/custom_fields.py
@@ -198,3 +198,17 @@ class ISODateTime(fields.DateTime):
     DEFAULT_FORMAT = "iso"
 
     OBJ_TYPE = "datetime"
+
+
+class Direction(fields.String):
+    def __init__(self, required=False, load_default="both", **kwargs):
+        if validate is not None:
+            raise ValueError(
+                "The Direction field provides its own validation and"
+                "thus does not accept the 'validate' argument."
+            )
+
+        validate = OneOf(["in", "out", "both"])
+        super().__init__(
+            required=required, validate=validate, load_default=load_default, **kwargs
+        )

--- a/flowmachine/flowmachine/core/server/query_schemas/daily_location.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/daily_location.py
@@ -6,8 +6,7 @@ from marshmallow import fields
 from marshmallow.validate import OneOf
 
 from flowmachine.features import daily_location
-from .custom_fields import EventTypes, ISODateTime, Hours
-from .subscriber_subset import SubscriberSubset
+from .custom_fields import ISODateTime
 from .aggregation_unit import AggregationUnitMixin
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
@@ -19,6 +18,9 @@ __all__ = ["DailyLocationSchema", "DailyLocationExposed"]
 
 
 class DailyLocationExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "daily_location"
+
     def __init__(
         self,
         date,
@@ -66,9 +68,9 @@ class DailyLocationSchema(
     AggregationUnitMixin,
     BaseQueryWithSamplingSchema,
 ):
+    __model__ = DailyLocationExposed
+
     # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["daily_location"]))
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     date = ISODateTime(required=True)
     method = fields.String(required=True, validate=OneOf(["last", "most-common"]))
-
-    __model__ = DailyLocationExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/dfs_metric_total_amount.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/dfs_metric_total_amount.py
@@ -9,7 +9,7 @@ from flowmachine.features.dfs import DFSTotalMetricAmount
 from .base_exposed_query import BaseExposedQuery
 from .field_mixins import StartAndEndField
 from .base_schema import BaseSchema
-from .custom_fields import DFSMetric, ISODateTime
+from .custom_fields import DFSMetric
 from .aggregation_unit import AggregationUnitKind
 
 __all__ = ["DFSTotalMetricAmountSchema", "DFSTotalMetricAmountExposed"]
@@ -18,6 +18,9 @@ from ...spatial_unit import AdminSpatialUnit
 
 
 class DFSTotalMetricAmountExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "dfs_metric_total_amount"
+
     def __init__(
         self, *, metric, start_date, end_date, aggregation_unit: AdminSpatialUnit
     ):
@@ -46,9 +49,9 @@ class DFSTotalMetricAmountExposed(BaseExposedQuery):
 
 
 class DFSTotalMetricAmountSchema(StartAndEndField, BaseSchema):
+    __model__ = DFSTotalMetricAmountExposed
+
     # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["dfs_metric_total_amount"]))
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     metric = DFSMetric()
     aggregation_unit = AggregationUnitKind()
-
-    __model__ = DFSTotalMetricAmountExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/dfs_metric_total_amount.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/dfs_metric_total_amount.py
@@ -29,7 +29,7 @@ class DFSTotalMetricAmountExposed(BaseExposedQuery):
         self.metric = metric
         self.start_date = start_date
         self.end_date = end_date
-        self.aggregation_unit = aggregation_unit.canonical_name
+        self.aggregation_unit = aggregation_unit
 
     @property
     def _flowmachine_query_obj(self):
@@ -44,7 +44,7 @@ class DFSTotalMetricAmountExposed(BaseExposedQuery):
             metric=self.metric,
             start_date=self.start_date,
             end_date=self.end_date,
-            aggregation_unit=self.aggregation_unit,
+            aggregation_unit=self.aggregation_unit.canonical_name,
         )
 
 

--- a/flowmachine/flowmachine/core/server/query_schemas/dfs_metric_total_amount.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/dfs_metric_total_amount.py
@@ -54,4 +54,4 @@ class DFSTotalMetricAmountSchema(StartAndEndField, BaseSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     metric = DFSMetric()
-    aggregation_unit = AggregationUnitKind()
+    aggregation_unit = AggregationUnitKind(required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/displacement.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/displacement.py
@@ -4,14 +4,10 @@
 
 from marshmallow import fields
 from marshmallow.validate import OneOf
-from marshmallow_oneofschema import OneOfSchema
 
 from flowmachine.features import Displacement
-from .custom_fields import EventTypes, Statistic, ISODateTime, Hours
+from .custom_fields import Statistic
 from .reference_location import ReferenceLocationSchema
-from .subscriber_subset import SubscriberSubset
-from .daily_location import DailyLocationSchema
-from .modal_location import ModalLocationSchema
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
@@ -27,6 +23,9 @@ __all__ = ["DisplacementSchema", "DisplacementExposed"]
 
 
 class DisplacementExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "displacement"
+
     def __init__(
         self,
         *,
@@ -77,8 +76,9 @@ class DisplacementSchema(
     HoursField,
     BaseQueryWithSamplingSchema,
 ):
-    query_kind = fields.String(validate=OneOf(["displacement"]))
-    statistic = Statistic()
-    reference_location = fields.Nested(ReferenceLocationSchema, many=False)
-
     __model__ = DisplacementExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    statistic = Statistic()
+    reference_location = fields.Nested(ReferenceLocationSchema, required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/dummy_query.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/dummy_query.py
@@ -16,6 +16,9 @@ from .base_schema import BaseSchema
 
 
 class DummyQueryExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "dummy_query"
+
     def __init__(self, dummy_param, aggregation_unit, dummy_delay):
         # Note: all input parameters need to be defined as attributes on `self`
         # so that marshmallow can serialise the object correctly.
@@ -34,9 +37,9 @@ class DummyQuerySchema(AggregationUnitMixin, BaseSchema):
     Dummy query useful for testing.
     """
 
+    __model__ = DummyQueryExposed
+
     # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["dummy_query"]))
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     dummy_param = fields.String(required=True)
     dummy_delay = fields.Integer(missing=0, required=False)
-
-    __model__ = DummyQueryExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/event_count.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/event_count.py
@@ -2,12 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marshmallow import fields, post_load
+from marshmallow import fields
 from marshmallow.validate import OneOf
 
 from flowmachine.features import EventCount
-from .custom_fields import EventTypes, ISODateTime, Hours
-from .subscriber_subset import SubscriberSubset
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
@@ -23,6 +21,9 @@ __all__ = ["EventCountSchema", "EventCountExposed"]
 
 
 class EventCountExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "event_count"
+
     def __init__(
         self,
         *,
@@ -70,9 +71,10 @@ class EventCountSchema(
     HoursField,
     BaseQueryWithSamplingSchema,
 ):
-    query_kind = fields.String(validate=OneOf(["event_count"]))
+    __model__ = EventCountExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     direction = fields.String(
         required=False, validate=OneOf(["in", "out", "both"]), default="both"
     )  # TODO: use a globally defined enum for this
-
-    __model__ = EventCountExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/event_count.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/event_count.py
@@ -10,6 +10,7 @@ from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
 )
+from .custom_fields import Direction
 from .field_mixins import (
     HoursField,
     StartAndEndField,
@@ -75,6 +76,4 @@ class EventCountSchema(
 
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
-    direction = fields.String(
-        required=False, validate=OneOf(["in", "out", "both"]), default="both"
-    )  # TODO: use a globally defined enum for this
+    direction = Direction()

--- a/flowmachine/flowmachine/core/server/query_schemas/flowmachine_query.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/flowmachine_query.py
@@ -6,8 +6,6 @@ from functools import lru_cache
 from apispec import APISpec
 from apispec_oneofschema import MarshmallowPlugin
 
-from marshmallow_oneofschema import OneOfSchema
-
 from flowmachine.core.server.query_schemas.joined_spatial_aggregate import (
     JoinedSpatialAggregateSchema,
 )
@@ -31,7 +29,6 @@ from .aggregate_network_objects import AggregateNetworkObjectsSchema
 
 from .geography import GeographySchema
 from .location_event_counts import LocationEventCountsSchema
-from .most_frequent_location import MostFrequentLocationSchema
 from .trips_od_matrix import TripsODMatrixSchema
 from .unique_subscriber_counts import UniqueSubscriberCountsSchema
 from .location_introversion import LocationIntroversionSchema
@@ -44,37 +41,37 @@ from .unmoving_at_reference_location_counts import (
 from .unmoving_counts import UnmovingCountsSchema
 from .labelled_spatial_aggregate import LabelledSpatialAggregateSchema
 from .labelled_flows import LabelledFlowsSchema
+from .one_of_query import OneOfQuerySchema
 
 
-class FlowmachineQuerySchema(OneOfSchema):
-    type_field = "query_kind"
-    type_schemas = {
-        "dummy_query": DummyQuerySchema,
-        "flows": FlowsSchema,
-        "inflows": InflowsSchema,
-        "outflows": OutflowsSchema,
-        "meaningful_locations_aggregate": MeaningfulLocationsAggregateSchema,
-        "meaningful_locations_between_label_od_matrix": MeaningfulLocationsBetweenLabelODMatrixSchema,
-        "meaningful_locations_between_dates_od_matrix": MeaningfulLocationsBetweenDatesODMatrixSchema,
-        "geography": GeographySchema,
-        "location_event_counts": LocationEventCountsSchema,
-        "unique_subscriber_counts": UniqueSubscriberCountsSchema,
-        "location_introversion": LocationIntroversionSchema,
-        "total_network_objects": TotalNetworkObjectsSchema,
-        "aggregate_network_objects": AggregateNetworkObjectsSchema,
-        "dfs_metric_total_amount": DFSTotalMetricAmountSchema,
-        "spatial_aggregate": SpatialAggregateSchema,
-        "joined_spatial_aggregate": JoinedSpatialAggregateSchema,
-        "histogram_aggregate": HistogramAggregateSchema,
-        "active_at_reference_location_counts": ActiveAtReferenceLocationCountsSchema,
-        "unique_visitor_counts": UniqueVisitorCountsSchema,
-        "consecutive_trips_od_matrix": ConsecutiveTripsODMatrixSchema,
-        "unmoving_counts": UnmovingCountsSchema,
-        "unmoving_at_reference_location_counts": UnmovingAtReferenceLocationCountsSchema,
-        "trips_od_matrix": TripsODMatrixSchema,
-        "labelled_spatial_aggregate": LabelledSpatialAggregateSchema,
-        "labelled_flows": LabelledFlowsSchema,
-    }
+class FlowmachineQuerySchema(OneOfQuerySchema):
+    query_schemas = (
+        DummyQuerySchema,
+        FlowsSchema,
+        InflowsSchema,
+        OutflowsSchema,
+        MeaningfulLocationsAggregateSchema,
+        MeaningfulLocationsBetweenLabelODMatrixSchema,
+        MeaningfulLocationsBetweenDatesODMatrixSchema,
+        GeographySchema,
+        LocationEventCountsSchema,
+        UniqueSubscriberCountsSchema,
+        LocationIntroversionSchema,
+        TotalNetworkObjectsSchema,
+        AggregateNetworkObjectsSchema,
+        DFSTotalMetricAmountSchema,
+        SpatialAggregateSchema,
+        JoinedSpatialAggregateSchema,
+        HistogramAggregateSchema,
+        ActiveAtReferenceLocationCountsSchema,
+        UniqueVisitorCountsSchema,
+        ConsecutiveTripsODMatrixSchema,
+        UnmovingCountsSchema,
+        UnmovingAtReferenceLocationCountsSchema,
+        TripsODMatrixSchema,
+        LabelledSpatialAggregateSchema,
+        LabelledFlowsSchema,
+    )
 
 
 @lru_cache(maxsize=1)

--- a/flowmachine/flowmachine/core/server/query_schemas/flows.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/flows.py
@@ -69,19 +69,15 @@ class FlowsSchema(BaseSchema):
     to_location = fields.Nested(InputToFlowsSchema, required=True)
     join_type = fields.String(validate=OneOf(Join.join_kinds), missing="inner")
 
-    @validates_schema
+    @validates_schema(skip_on_field_errors=True)
     def validate_aggregation_units(self, data, **kwargs):
         """
         Validate that from_location and to_location have the same aggregation unit
         """
-        try:
-            if (
-                data["from_location"].aggregation_unit
-                != data["to_location"].aggregation_unit
-            ):
-                raise ValidationError(
-                    "'from_location' and 'to_location' parameters must have the same aggregation unit"
-                )
-        except AttributeError:
-            # Nested schema was invalid - appropriate ValidationError will be raised from elsewhere
-            pass
+        if (
+            data["from_location"].aggregation_unit
+            != data["to_location"].aggregation_unit
+        ):
+            raise ValidationError(
+                "'from_location' and 'to_location' parameters must have the same aggregation unit"
+            )

--- a/flowmachine/flowmachine/core/server/query_schemas/geography.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/geography.py
@@ -15,6 +15,9 @@ from .base_schema import BaseSchema
 
 
 class GeographyExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "geography"
+
     def __init__(self, *, aggregation_unit):
         # Note: all input parameters need to be defined as attributes on `self`
         # so that marshmallow can serialise the object correctly.
@@ -42,7 +45,7 @@ class GeographyExposed(BaseExposedQuery):
 
 
 class GeographySchema(AggregationUnitMixin, BaseSchema):
-    # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["geography"]))
-
     __model__ = GeographyExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/handset.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/handset.py
@@ -81,6 +81,7 @@ class HandsetSchema(
     characteristic = fields.String(
         validate=OneOf(
             ["hnd_type", "brand", "model", "software_os_name", "software_os_vendor"]
-        )
+        ),
+        required=True,
     )
-    method = fields.String(validate=OneOf(["last", "most-common"]))
+    method = fields.String(validate=OneOf(["last", "most-common"]), required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/handset.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/handset.py
@@ -2,12 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marshmallow import fields, post_load
+from marshmallow import fields
 from marshmallow.validate import OneOf
 
 from flowmachine.features import SubscriberHandsetCharacteristic
-from .custom_fields import EventTypes, ISODateTime, Hours
-from .subscriber_subset import SubscriberSubset
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
@@ -23,6 +21,9 @@ __all__ = ["HandsetSchema", "HandsetExposed"]
 
 
 class HandsetExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "handset"
+
     def __init__(
         self,
         *,
@@ -73,13 +74,13 @@ class HandsetSchema(
     HoursField,
     BaseQueryWithSamplingSchema,
 ):
+    __model__ = HandsetExposed
+
     # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["handset"]))
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     characteristic = fields.String(
         validate=OneOf(
             ["hnd_type", "brand", "model", "software_os_name", "software_os_vendor"]
         )
     )
     method = fields.String(validate=OneOf(["last", "most-common"]))
-
-    __model__ = HandsetExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/histogram_aggregate.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/histogram_aggregate.py
@@ -105,4 +105,4 @@ class HistogramAggregateSchema(BaseSchema):
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     metric = fields.Nested(HistogrammableMetrics, required=True)
     range = fields.Nested(Bounds)
-    bins = fields.Nested(HistogramBins)
+    bins = fields.Nested(HistogramBins, required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/histogram_aggregate.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/histogram_aggregate.py
@@ -4,7 +4,6 @@
 
 from marshmallow import Schema, fields, post_load, validates_schema, ValidationError
 from marshmallow.validate import OneOf
-from marshmallow_oneofschema import OneOfSchema
 
 from flowmachine.core.server.query_schemas.custom_fields import Bounds
 from flowmachine.core.server.query_schemas.radius_of_gyration import (
@@ -33,22 +32,22 @@ __all__ = ["HistogramAggregateSchema", "HistogramAggregateExposed"]
 
 from .base_schema import BaseSchema
 from .total_active_periods import TotalActivePeriodsSchema
+from .one_of_query import OneOfQuerySchema
 
 
-class HistogrammableMetrics(OneOfSchema):
-    type_field = "query_kind"
-    type_schemas = {
-        "radius_of_gyration": RadiusOfGyrationSchema,
-        "unique_location_counts": UniqueLocationCountsSchema,
-        "topup_balance": TopUpBalanceSchema,
-        "subscriber_degree": SubscriberDegreeSchema,
-        "topup_amount": TopUpAmountSchema,
-        "event_count": EventCountSchema,
-        "pareto_interactions": ParetoInteractionsSchema,
-        "nocturnal_events": NocturnalEventsSchema,
-        "displacement": DisplacementSchema,
-        "total_active_periods": TotalActivePeriodsSchema,
-    }
+class HistogrammableMetrics(OneOfQuerySchema):
+    query_schemas = (
+        RadiusOfGyrationSchema,
+        UniqueLocationCountsSchema,
+        TopUpBalanceSchema,
+        SubscriberDegreeSchema,
+        TopUpAmountSchema,
+        EventCountSchema,
+        ParetoInteractionsSchema,
+        NocturnalEventsSchema,
+        DisplacementSchema,
+        TotalActivePeriodsSchema,
+    )
 
 
 class HistogramBins(Schema):
@@ -76,6 +75,9 @@ class HistogramBins(Schema):
 
 
 class HistogramAggregateExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "histogram_aggregate"
+
     def __init__(self, *, metric, bins, range=None):
         # Note: all input parameters need to be defined as attributes on `self`
         # so that marshmallow can serialise the object correctly.
@@ -97,10 +99,10 @@ class HistogramAggregateExposed(BaseExposedQuery):
 
 
 class HistogramAggregateSchema(BaseSchema):
+    __model__ = HistogramAggregateExposed
+
     # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["histogram_aggregate"]))
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     metric = fields.Nested(HistogrammableMetrics, required=True)
     range = fields.Nested(Bounds)
     bins = fields.Nested(HistogramBins)
-
-    __model__ = HistogramAggregateExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/inflows.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/inflows.py
@@ -11,6 +11,9 @@ from flowmachine.features.location.redacted_flows import RedactedInOutFlow
 
 
 class InflowsExposed(FlowsExposed):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "inflows"
+
     @property
     def _flowmachine_query_obj(self):
         loc1 = self.from_location._flowmachine_query_obj
@@ -21,5 +24,7 @@ class InflowsExposed(FlowsExposed):
 
 
 class InflowsSchema(FlowsSchema):
-    query_kind = fields.String(validate=OneOf(["inflows"]))
     __model__ = InflowsExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/joined_spatial_aggregate.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/joined_spatial_aggregate.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marshmallow import fields, pre_load, ValidationError
+from marshmallow import fields, validates_schema, ValidationError
 from marshmallow.validate import OneOf
 
 from flowmachine.core.server.query_schemas.radius_of_gyration import (
@@ -104,7 +104,7 @@ class JoinedSpatialAggregateSchema(BaseSchema):
         validate=OneOf(JoinedSpatialAggregate.allowed_methods), required=True
     )
 
-    @pre_load
+    @validates_schema(skip_on_field_errors=True)
     def validate_method(self, data, **kwargs):
         continuous_metrics = [
             "radius_of_gyration",
@@ -119,13 +119,12 @@ class JoinedSpatialAggregateSchema(BaseSchema):
             "total_active_periods",
         ]
         categorical_metrics = ["handset"]
-        if data["metric"]["query_kind"] in continuous_metrics:
+        if data["metric"].query_kind in continuous_metrics:
             validate = OneOf([f"{stat}" for stat in Statistic])
-        elif data["metric"]["query_kind"] in categorical_metrics:
+        elif data["metric"].query_kind in categorical_metrics:
             validate = OneOf(["distr"])
         else:
             raise ValidationError(
-                f"{data['metric']['query_kind']} does not have a valid metric type."
+                f"{data['metric'].query_kind} does not have a valid metric type."
             )
         validate(data["method"])
-        return data

--- a/flowmachine/flowmachine/core/server/query_schemas/joined_spatial_aggregate.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/joined_spatial_aggregate.py
@@ -32,6 +32,7 @@ from flowmachine.features.location.redacted_joined_spatial_aggregate import (
 )
 from flowmachine.utils import Statistic
 from .base_exposed_query import BaseExposedQuery
+from .aggregation_unit import AggregationUnitKind
 
 
 __all__ = ["JoinedSpatialAggregateSchema", "JoinedSpatialAggregateExposed"]
@@ -70,6 +71,10 @@ class JoinedSpatialAggregateExposed(BaseExposedQuery):
         self.method = method
 
     @property
+    def aggregation_unit(self):
+        return self.locations.aggregation_unit
+
+    @property
     def _flowmachine_query_obj(self):
         """
         Return the underlying flowmachine object.
@@ -92,9 +97,12 @@ class JoinedSpatialAggregateSchema(BaseSchema):
 
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    aggregation_unit = AggregationUnitKind(dump_only=True)
     locations = fields.Nested(ReferenceLocationSchema, required=True)
     metric = fields.Nested(JoinableMetrics, required=True)
-    method = fields.String(validate=OneOf(JoinedSpatialAggregate.allowed_methods))
+    method = fields.String(
+        validate=OneOf(JoinedSpatialAggregate.allowed_methods), required=True
+    )
 
     @pre_load
     def validate_method(self, data, **kwargs):

--- a/flowmachine/flowmachine/core/server/query_schemas/labelled_flows.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/labelled_flows.py
@@ -72,19 +72,15 @@ class LabelledFlowsSchema(BaseSchema):
     labels = fields.Nested(MobilityClassificationSchema, required=True)
     join_type = fields.String(validate=OneOf(Join.join_kinds), missing="inner")
 
-    @validates_schema
+    @validates_schema(skip_on_field_errors=True)
     def validate_aggregation_units(self, data, **kwargs):
         """
         Validate that from_location and to_location have the same aggregation unit
         """
-        try:
-            if (
-                data["from_location"].aggregation_unit
-                != data["to_location"].aggregation_unit
-            ):
-                raise ValidationError(
-                    "'from_location' and 'to_location' parameters must have the same aggregation unit"
-                )
-        except AttributeError:
-            # Nested schema was invalid - appropriate ValidationError will be raised from elsewhere
-            pass
+        if (
+            data["from_location"].aggregation_unit
+            != data["to_location"].aggregation_unit
+        ):
+            raise ValidationError(
+                "'from_location' and 'to_location' parameters must have the same aggregation unit"
+            )

--- a/flowmachine/flowmachine/core/server/query_schemas/labelled_flows.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/labelled_flows.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marshmallow import fields
+from marshmallow import fields, validates_schema, ValidationError
 from marshmallow.validate import OneOf
 
 
@@ -20,6 +20,8 @@ from flowmachine.core.server.query_schemas.mobility_classification import (
 
 __all__ = ["LabelledFlowsSchema", "LabelledFlowsExposed"]
 
+from .aggregation_unit import AggregationUnitKind
+
 
 class LabelledFlowsExposed(BaseExposedQuery):
     # query_kind class attribute is required for nesting and serialisation
@@ -32,6 +34,10 @@ class LabelledFlowsExposed(BaseExposedQuery):
         self.to_location = to_location
         self.labels = labels
         self.join_type = join_type
+
+    @property
+    def aggregation_unit(self):
+        return self.from_location.aggregation_unit
 
     @property
     def _flowmachine_query_obj(self):
@@ -60,7 +66,25 @@ class LabelledFlowsSchema(BaseSchema):
 
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    aggregation_unit = AggregationUnitKind(dump_only=True)
     from_location = fields.Nested(CoalescedLocationSchema, required=True)
     to_location = fields.Nested(CoalescedLocationSchema, required=True)
     labels = fields.Nested(MobilityClassificationSchema, required=True)
     join_type = fields.String(validate=OneOf(Join.join_kinds), missing="inner")
+
+    @validates_schema
+    def validate_aggregation_units(self, data, **kwargs):
+        """
+        Validate that from_location and to_location have the same aggregation unit
+        """
+        try:
+            if (
+                data["from_location"].aggregation_unit
+                != data["to_location"].aggregation_unit
+            ):
+                raise ValidationError(
+                    "'from_location' and 'to_location' parameters must have the same aggregation unit"
+                )
+        except AttributeError:
+            # Nested schema was invalid - appropriate ValidationError will be raised from elsewhere
+            pass

--- a/flowmachine/flowmachine/core/server/query_schemas/labelled_flows.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/labelled_flows.py
@@ -22,6 +22,9 @@ __all__ = ["LabelledFlowsSchema", "LabelledFlowsExposed"]
 
 
 class LabelledFlowsExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "labelled_flows"
+
     def __init__(self, *, from_location, to_location, labels, join_type):
         # Note: all input parameters need to be defined as attributes on `self`
         # so that marshmallow can serialise the object correctly.
@@ -53,11 +56,11 @@ class LabelledFlowsExposed(BaseExposedQuery):
 
 
 class LabelledFlowsSchema(BaseSchema):
+    __model__ = LabelledFlowsExposed
+
     # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["labelled_flows"]))
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     from_location = fields.Nested(CoalescedLocationSchema, required=True)
     to_location = fields.Nested(CoalescedLocationSchema, required=True)
     labels = fields.Nested(MobilityClassificationSchema, required=True)
     join_type = fields.String(validate=OneOf(Join.join_kinds), missing="inner")
-
-    __model__ = LabelledFlowsExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/labelled_spatial_aggregate.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/labelled_spatial_aggregate.py
@@ -25,6 +25,8 @@ __all__ = [
     "LabelledSpatialAggregateExposed",
 ]
 
+from .aggregation_unit import AggregationUnitKind
+
 
 class LabelledSpatialAggregateExposed(BaseExposedQuery):
     # query_kind class attribute is required for nesting and serialisation
@@ -35,6 +37,10 @@ class LabelledSpatialAggregateExposed(BaseExposedQuery):
         # so that marshmallow can serialise the object correctly.
         self.locations = locations
         self.labels = labels
+
+    @property
+    def aggregation_unit(self):
+        return self.locations.aggregation_unit
 
     @property
     def _flowmachine_query_obj(self):
@@ -58,5 +64,6 @@ class LabelledSpatialAggregateSchema(BaseSchema):
 
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    aggregation_unit = AggregationUnitKind(dump_only=True)
     locations = fields.Nested(CoalescedLocationSchema, required=True)
     labels = fields.Nested(MobilityClassificationSchema, required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/labelled_spatial_aggregate.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/labelled_spatial_aggregate.py
@@ -27,6 +27,9 @@ __all__ = [
 
 
 class LabelledSpatialAggregateExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "labelled_spatial_aggregate"
+
     def __init__(self, *, locations, labels):
         # Note: all input parameters need to be defined as attributes on `self`
         # so that marshmallow can serialise the object correctly.
@@ -51,9 +54,9 @@ class LabelledSpatialAggregateExposed(BaseExposedQuery):
 
 
 class LabelledSpatialAggregateSchema(BaseSchema):
+    __model__ = LabelledSpatialAggregateExposed
+
     # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["labelled_spatial_aggregate"]))
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     locations = fields.Nested(CoalescedLocationSchema, required=True)
     labels = fields.Nested(MobilityClassificationSchema, required=True)
-
-    __model__ = LabelledSpatialAggregateExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/location_event_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/location_event_counts.py
@@ -8,6 +8,7 @@ from marshmallow.validate import OneOf
 from flowmachine.features import TotalLocationEvents
 from flowmachine.features.location.redacted_total_events import RedactedTotalEvents
 from .base_exposed_query import BaseExposedQuery
+from .custom_fields import Direction
 from .field_mixins import (
     HoursField,
     StartAndEndField,
@@ -85,6 +86,4 @@ class LocationEventCountsSchema(
     interval = fields.String(
         required=True, validate=OneOf(TotalLocationEvents.allowed_intervals)
     )
-    direction = fields.String(
-        required=True, validate=OneOf(["in", "out", "both"])
-    )  # TODO: use a globally defined enum for this
+    direction = Direction()

--- a/flowmachine/flowmachine/core/server/query_schemas/location_event_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/location_event_counts.py
@@ -21,6 +21,9 @@ __all__ = ["LocationEventCountsSchema", "LocationEventCountsExposed"]
 
 
 class LocationEventCountsExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "location_event_counts"
+
     def __init__(
         self,
         *,
@@ -75,13 +78,13 @@ class LocationEventCountsSchema(
     AggregationUnitMixin,
     BaseSchema,
 ):
+    __model__ = LocationEventCountsExposed
+
     # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["location_event_counts"]))
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     interval = fields.String(
         required=True, validate=OneOf(TotalLocationEvents.allowed_intervals)
     )
     direction = fields.String(
         required=True, validate=OneOf(["in", "out", "both"])
     )  # TODO: use a globally defined enum for this
-
-    __model__ = LocationEventCountsExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/location_introversion.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/location_introversion.py
@@ -9,6 +9,7 @@ from flowmachine.features import LocationIntroversion
 from flowmachine.features.location.redacted_location_introversion import (
     RedactedLocationIntroversion,
 )
+from .custom_fields import Direction
 from .field_mixins import (
     HoursField,
     StartAndEndField,
@@ -82,6 +83,4 @@ class LocationIntroversionSchema(
 
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
-    direction = fields.String(
-        validate=OneOf(["in", "out", "both"]), load_default="both"
-    )  # TODO: use a globally defined enum for this
+    direction = Direction

--- a/flowmachine/flowmachine/core/server/query_schemas/location_introversion.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/location_introversion.py
@@ -24,6 +24,9 @@ from .base_schema import BaseSchema
 
 
 class LocationIntroversionExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "location_introversion"
+
     def __init__(
         self,
         *,
@@ -75,10 +78,10 @@ class LocationIntroversionSchema(
     AggregationUnitMixin,
     BaseSchema,
 ):
+    __model__ = LocationIntroversionExposed
+
     # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["location_introversion"]))
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     direction = fields.String(
         required=False, validate=OneOf(["in", "out", "both"]), default="both"
     )  # TODO: use a globally defined enum for this
-
-    __model__ = LocationIntroversionExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/location_introversion.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/location_introversion.py
@@ -83,5 +83,5 @@ class LocationIntroversionSchema(
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     direction = fields.String(
-        required=False, validate=OneOf(["in", "out", "both"]), default="both"
+        validate=OneOf(["in", "out", "both"]), load_default="both"
     )  # TODO: use a globally defined enum for this

--- a/flowmachine/flowmachine/core/server/query_schemas/location_introversion.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/location_introversion.py
@@ -83,4 +83,4 @@ class LocationIntroversionSchema(
 
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
-    direction = Direction
+    direction = Direction()

--- a/flowmachine/flowmachine/core/server/query_schemas/location_visits.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/location_visits.py
@@ -43,7 +43,9 @@ class LocationVisitsSchema(BaseQueryWithSamplingSchema):
 
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
-    locations = fields.List(fields.Nested(VisitableLocation), validate=Length(min=1))
+    locations = fields.List(
+        fields.Nested(VisitableLocation), validate=Length(min=1), required=True
+    )
 
     @validates("locations")
     def validate_locations(self, locations):

--- a/flowmachine/flowmachine/core/server/query_schemas/location_visits.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/location_visits.py
@@ -47,5 +47,17 @@ class LocationVisitsSchema(BaseQueryWithSamplingSchema):
 
     @validates("locations")
     def validate_locations(self, locations):
-        if len(set(location.aggregation_unit for location in locations)) > 1:
+        # Filtering out locations with no aggregation_unit attribute -
+        # validation errors for these should be raised when validating the
+        # individual location query specs
+        if (
+            len(
+                set(
+                    location.aggregation_unit
+                    for location in locations
+                    if hasattr(location, "aggregation_unit")
+                )
+            )
+            > 1
+        ):
             raise ValidationError("All locations must have the same aggregation unit")

--- a/flowmachine/flowmachine/core/server/query_schemas/location_visits.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/location_visits.py
@@ -4,21 +4,22 @@
 
 from marshmallow import fields, validates, ValidationError
 from marshmallow.validate import OneOf, Length
-from marshmallow_oneofschema import OneOfSchema
 
-from flowmachine.core.server.query_schemas import BaseExposedQuery
 from flowmachine.core.server.query_schemas.base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
 )
-from flowmachine.core.server.query_schemas.base_schema import BaseSchema
 from flowmachine.core.server.query_schemas.daily_location import DailyLocationSchema
 from flowmachine.core.server.query_schemas.modal_location import ModalLocationSchema
 from flowmachine.features import DayTrajectories
 from flowmachine.features.subscriber.location_visits import LocationVisits
+from .one_of_query import OneOfQuerySchema
 
 
 class LocationVisitsExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "location_visits"
+
     def __init__(self, locations, *, sampling=None):
         self.locations = locations
         self.sampling = sampling
@@ -33,21 +34,18 @@ class LocationVisitsExposed(BaseExposedQueryWithSampling):
         )
 
 
-class VisitableLocation(OneOfSchema):
-    type_field = "query_kind"
-    type_schemas = {
-        "daily_location": DailyLocationSchema,
-        "modal_location": ModalLocationSchema,
-    }
+class VisitableLocation(OneOfQuerySchema):
+    query_schemas = (DailyLocationSchema, ModalLocationSchema)
 
 
 class LocationVisitsSchema(BaseQueryWithSamplingSchema):
-    query_kind = fields.String(validate=OneOf(["location_visits"]))
+    __model__ = LocationVisitsExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     locations = fields.List(fields.Nested(VisitableLocation), validate=Length(min=1))
 
     @validates("locations")
     def validate_locations(self, locations):
         if len(set(location.aggregation_unit for location in locations)) > 1:
             raise ValidationError("All locations must have the same aggregation unit")
-
-    __model__ = LocationVisitsExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/majority_location.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/majority_location.py
@@ -5,7 +5,6 @@
 # -*- coding: utf-8 -*-
 from marshmallow import fields
 from marshmallow.validate import OneOf
-from marshmallow_oneofschema import OneOfSchema
 
 from flowmachine.core.server.query_schemas.base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
@@ -14,8 +13,13 @@ from flowmachine.core.server.query_schemas.base_query_with_sampling import (
 from flowmachine.core.server.query_schemas.location_visits import LocationVisitsSchema
 from flowmachine.features.subscriber.majority_location import MajorityLocation
 
+from .one_of_query import OneOfQuerySchema
+
 
 class MajorityLocationExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "majority_location"
+
     def __init__(
         self, *, subscriber_location_weights, include_unlocatable, sampling=None
     ):
@@ -33,14 +37,14 @@ class MajorityLocationExposed(BaseExposedQueryWithSampling):
         )
 
 
-class WeightedLocationQueries(OneOfSchema):
-    type_field = "query_kind"
-    type_schemas = {"location_visits": LocationVisitsSchema}
+class WeightedLocationQueries(OneOfQuerySchema):
+    query_schemas = (LocationVisitsSchema,)
 
 
 class MajorityLocationSchema(BaseQueryWithSamplingSchema):
-    query_kind = fields.String(validate=OneOf(["majority_location"]))
+    __model__ = MajorityLocationExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     subscriber_location_weights = fields.Nested(WeightedLocationQueries, required=True)
     include_unlocatable = fields.Boolean(missing=False)
-
-    __model__ = MajorityLocationExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/meaningful_locations.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/meaningful_locations.py
@@ -28,12 +28,10 @@ from .base_exposed_query import BaseExposedQuery
 from .field_mixins import StartAndEndField, EventTypesField, SubscriberSubsetField
 from .base_schema import BaseSchema
 from .custom_fields import (
-    EventTypes,
     TowerHourOfDayScores,
     TowerDayOfWeekScores,
     ISODateTime,
 )
-from .subscriber_subset import SubscriberSubset
 from .aggregation_unit import AggregationUnitMixin
 
 __all__ = [
@@ -49,6 +47,9 @@ from ...spatial_unit import AnySpatialUnit
 
 
 class MeaningfulLocationsAggregateExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "meaningful_locations_aggregate"
+
     def __init__(
         self,
         *,
@@ -110,6 +111,9 @@ class MeaningfulLocationsAggregateExposed(BaseExposedQuery):
 
 
 class MeaningfulLocationsBetweenLabelODMatrixExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "meaningful_locations_between_label_od_matrix"
+
     def __init__(
         self,
         *,
@@ -176,6 +180,9 @@ class MeaningfulLocationsBetweenLabelODMatrixExposed(BaseExposedQuery):
 
 
 class MeaningfulLocationsBetweenDatesODMatrixExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "meaningful_locations_between_dates_od_matrix"
+
     def __init__(
         self,
         *,
@@ -251,8 +258,10 @@ class MeaningfulLocationsAggregateSchema(
     AggregationUnitMixin,
     BaseSchema,
 ):
+    __model__ = MeaningfulLocationsAggregateExposed
+
     # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["meaningful_locations_aggregate"]))
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     label = fields.String(required=True)
     labels = fields.Dict(
         required=True, keys=fields.String(), values=fields.Dict()
@@ -261,8 +270,6 @@ class MeaningfulLocationsAggregateSchema(
     tower_day_of_week_scores = TowerDayOfWeekScores(required=True)
     tower_cluster_radius = fields.Float(required=False, default=1.0)
     tower_cluster_call_threshold = fields.Integer(required=False, default=0)
-
-    __model__ = MeaningfulLocationsAggregateExposed
 
 
 def _make_meaningful_locations_object(
@@ -318,9 +325,10 @@ class MeaningfulLocationsBetweenLabelODMatrixSchema(
     AggregationUnitMixin,
     BaseSchema,
 ):
-    query_kind = fields.String(
-        validate=OneOf(["meaningful_locations_between_label_od_matrix"])
-    )
+    __model__ = MeaningfulLocationsBetweenLabelODMatrixExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     label_a = fields.String(required=True)
     label_b = fields.String(required=True)
     labels = fields.Dict(
@@ -331,15 +339,14 @@ class MeaningfulLocationsBetweenLabelODMatrixSchema(
     tower_cluster_radius = fields.Float(required=False, default=1.0)
     tower_cluster_call_threshold = fields.Integer(required=False, default=0)
 
-    __model__ = MeaningfulLocationsBetweenLabelODMatrixExposed
-
 
 class MeaningfulLocationsBetweenDatesODMatrixSchema(
     EventTypesField, SubscriberSubsetField, AggregationUnitMixin, BaseSchema
 ):
-    query_kind = fields.String(
-        validate=OneOf(["meaningful_locations_between_dates_od_matrix"])
-    )
+    __model__ = MeaningfulLocationsBetweenDatesODMatrixExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     start_date_a = ISODateTime(required=True)
     end_date_a = ISODateTime(required=True)
     start_date_b = ISODateTime(required=True)
@@ -352,5 +359,3 @@ class MeaningfulLocationsBetweenDatesODMatrixSchema(
     tower_day_of_week_scores = TowerDayOfWeekScores(required=True)
     tower_cluster_radius = fields.Float(required=False, default=1.0)
     tower_cluster_call_threshold = fields.Integer(required=False, default=0)
-
-    __model__ = MeaningfulLocationsBetweenDatesODMatrixExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/meaningful_locations.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/meaningful_locations.py
@@ -60,8 +60,8 @@ class MeaningfulLocationsAggregateExposed(BaseExposedQuery):
         labels: Dict[str, Dict[str, dict]],
         tower_day_of_week_scores: Dict[str, float],
         tower_hour_of_day_scores: List[float],
-        tower_cluster_radius: float = 1.0,
-        tower_cluster_call_threshold: int = 0,
+        tower_cluster_radius: float,
+        tower_cluster_call_threshold: int,
         event_types: Optional[Union[str, List[str]]],
         subscriber_subset: Union[dict, None] = None,
     ):
@@ -125,8 +125,8 @@ class MeaningfulLocationsBetweenLabelODMatrixExposed(BaseExposedQuery):
         labels: Dict[str, Dict[str, dict]],
         tower_day_of_week_scores: Dict[str, float],
         tower_hour_of_day_scores: List[float],
-        tower_cluster_radius: float = 1.0,
-        tower_cluster_call_threshold: int = 0,
+        tower_cluster_radius: float,
+        tower_cluster_call_threshold: int,
         event_types: Optional[Union[str, List[str]]],
         subscriber_subset: Union[dict, None] = None,
     ):
@@ -195,8 +195,8 @@ class MeaningfulLocationsBetweenDatesODMatrixExposed(BaseExposedQuery):
         labels: Dict[str, Dict[str, dict]],
         tower_day_of_week_scores: Dict[str, float],
         tower_hour_of_day_scores: List[float],
-        tower_cluster_radius: float = 1.0,
-        tower_cluster_call_threshold: int = 0,
+        tower_cluster_radius: float,
+        tower_cluster_call_threshold: int,
         event_types: Optional[Union[str, List[str]]],
         subscriber_subset: Union[dict, None] = None,
     ):
@@ -268,8 +268,8 @@ class MeaningfulLocationsAggregateSchema(
     )  # TODO: use custom field here for stricter validation!
     tower_hour_of_day_scores = TowerHourOfDayScores(required=True)
     tower_day_of_week_scores = TowerDayOfWeekScores(required=True)
-    tower_cluster_radius = fields.Float(required=False, default=1.0)
-    tower_cluster_call_threshold = fields.Integer(required=False, default=0)
+    tower_cluster_radius = fields.Float(required=False, load_default=1.0)
+    tower_cluster_call_threshold = fields.Integer(required=False, load_default=0)
 
 
 def _make_meaningful_locations_object(
@@ -332,12 +332,12 @@ class MeaningfulLocationsBetweenLabelODMatrixSchema(
     label_a = fields.String(required=True)
     label_b = fields.String(required=True)
     labels = fields.Dict(
-        keys=fields.String(), values=fields.Dict()
+        required=True, keys=fields.String(), values=fields.Dict()
     )  # TODO: use custom field here for stricter validation!
     tower_hour_of_day_scores = TowerHourOfDayScores(required=True)
     tower_day_of_week_scores = TowerDayOfWeekScores(required=True)
-    tower_cluster_radius = fields.Float(required=False, default=1.0)
-    tower_cluster_call_threshold = fields.Integer(required=False, default=0)
+    tower_cluster_radius = fields.Float(required=False, load_default=1.0)
+    tower_cluster_call_threshold = fields.Integer(required=False, load_default=0)
 
 
 class MeaningfulLocationsBetweenDatesODMatrixSchema(
@@ -353,9 +353,9 @@ class MeaningfulLocationsBetweenDatesODMatrixSchema(
     end_date_b = ISODateTime(required=True)
     label = fields.String(required=True)
     labels = fields.Dict(
-        keys=fields.String(), values=fields.Dict()
+        required=True, keys=fields.String(), values=fields.Dict()
     )  # TODO: use custom field here for stricter validation!
     tower_hour_of_day_scores = TowerHourOfDayScores(required=True)
     tower_day_of_week_scores = TowerDayOfWeekScores(required=True)
-    tower_cluster_radius = fields.Float(required=False, default=1.0)
-    tower_cluster_call_threshold = fields.Integer(required=False, default=0)
+    tower_cluster_radius = fields.Float(required=False, load_default=1.0)
+    tower_cluster_call_threshold = fields.Integer(required=False, load_default=0)

--- a/flowmachine/flowmachine/core/server/query_schemas/mobility_classification.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/mobility_classification.py
@@ -18,6 +18,9 @@ from flowmachine.features.subscriber.mobility_classification import (
 
 
 class MobilityClassificationExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "mobility_classification"
+
     def __init__(self, *, locations, stay_length_threshold, sampling=None):
         self.locations = locations
         self.stay_length_threshold = stay_length_threshold
@@ -32,7 +35,10 @@ class MobilityClassificationExposed(BaseExposedQueryWithSampling):
 
 
 class MobilityClassificationSchema(BaseQueryWithSamplingSchema):
-    query_kind = fields.String(validate=OneOf(["mobility_classification"]))
+    __model__ = MobilityClassificationExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     locations = fields.List(
         fields.Nested(CoalescedLocationSchema), validate=Length(min=1)
     )
@@ -42,5 +48,3 @@ class MobilityClassificationSchema(BaseQueryWithSamplingSchema):
     def validate_locations(self, locations):
         if len(set(location.aggregation_unit for location in locations)) > 1:
             raise ValidationError("All locations must have the same aggregation unit")
-
-    __model__ = MobilityClassificationExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/mobility_classification.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/mobility_classification.py
@@ -46,5 +46,17 @@ class MobilityClassificationSchema(BaseQueryWithSamplingSchema):
 
     @validates("locations")
     def validate_locations(self, locations):
-        if len(set(location.aggregation_unit for location in locations)) > 1:
+        # Filtering out locations with no aggregation_unit attribute -
+        # validation errors for these should be raised when validating the
+        # individual location query specs
+        if (
+            len(
+                set(
+                    location.aggregation_unit
+                    for location in locations
+                    if hasattr(location, "aggregation_unit")
+                )
+            )
+            > 1
+        ):
             raise ValidationError("All locations must have the same aggregation unit")

--- a/flowmachine/flowmachine/core/server/query_schemas/mobility_classification.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/mobility_classification.py
@@ -40,7 +40,7 @@ class MobilityClassificationSchema(BaseQueryWithSamplingSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     locations = fields.List(
-        fields.Nested(CoalescedLocationSchema), validate=Length(min=1)
+        fields.Nested(CoalescedLocationSchema), validate=Length(min=1), required=True
     )
     stay_length_threshold = fields.Integer(required=True)
 

--- a/flowmachine/flowmachine/core/server/query_schemas/modal_location.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/modal_location.py
@@ -49,7 +49,7 @@ class ModalLocationSchema(BaseQueryWithSamplingSchema):
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     locations = fields.List(
-        fields.Nested(InputToModalLocationSchema), validate=Length(min=1)
+        fields.Nested(InputToModalLocationSchema), validate=Length(min=1), required=True
     )
 
     @validates("locations")

--- a/flowmachine/flowmachine/core/server/query_schemas/modal_location.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/modal_location.py
@@ -54,7 +54,19 @@ class ModalLocationSchema(BaseQueryWithSamplingSchema):
 
     @validates("locations")
     def validate_locations(self, values):
-        if len(set(value.aggregation_unit for value in values)) > 1:
+        # Filtering out locations with no aggregation_unit attribute -
+        # validation errors for these should be raised when validating the
+        # individual location query specs
+        if (
+            len(
+                set(
+                    value.aggregation_unit
+                    for value in values
+                    if hasattr(value, "aggregation_unit")
+                )
+            )
+            > 1
+        ):
             raise ValidationError(
-                "All inputs to modal_locations should have the same aggregation unit"
+                "All inputs to modal_location should have the same aggregation unit"
             )

--- a/flowmachine/flowmachine/core/server/query_schemas/modal_location.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/modal_location.py
@@ -4,21 +4,23 @@
 
 from marshmallow import fields, validates, ValidationError
 from marshmallow.validate import OneOf, Length
-from marshmallow_oneofschema import OneOfSchema
 
 from .daily_location import DailyLocationSchema
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
 )
+from .one_of_query import OneOfQuerySchema
 
 
-class InputToModalLocationSchema(OneOfSchema):
-    type_field = "query_kind"
-    type_schemas = {"daily_location": DailyLocationSchema}
+class InputToModalLocationSchema(OneOfQuerySchema):
+    query_schemas = (DailyLocationSchema,)
 
 
 class ModalLocationExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "modal_location"
+
     def __init__(self, locations, *, sampling=None):
         # Note: all input parameters need to be defined as attributes on `self`
         # so that marshmallow can serialise the object correctly.
@@ -42,8 +44,10 @@ class ModalLocationExposed(BaseExposedQueryWithSampling):
 
 
 class ModalLocationSchema(BaseQueryWithSamplingSchema):
+    __model__ = ModalLocationExposed
+
     # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["modal_location"]))
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     locations = fields.List(
         fields.Nested(InputToModalLocationSchema), validate=Length(min=1)
     )
@@ -54,5 +58,3 @@ class ModalLocationSchema(BaseQueryWithSamplingSchema):
             raise ValidationError(
                 "All inputs to modal_locations should have the same aggregation unit"
             )
-
-    __model__ = ModalLocationExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/most_frequent_location.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/most_frequent_location.py
@@ -22,6 +22,9 @@ __all__ = ["MostFrequentLocationSchema", "MostFrequentLocationExposed"]
 
 
 class MostFrequentLocationExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "most_frequent_location"
+
     def __init__(
         self,
         start_date,
@@ -70,7 +73,7 @@ class MostFrequentLocationSchema(
     AggregationUnitMixin,
     BaseQueryWithSamplingSchema,
 ):
-    # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["most_frequent_location"]))
-
     __model__ = MostFrequentLocationExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/nocturnal_events.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/nocturnal_events.py
@@ -21,6 +21,9 @@ __all__ = ["NocturnalEventsSchema", "NocturnalEventsExposed"]
 
 
 class NocturnalEventsExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "nocturnal_events"
+
     def __init__(
         self,
         *,
@@ -65,10 +68,11 @@ class NocturnalEventsSchema(
     SubscriberSubsetField,
     BaseQueryWithSamplingSchema,
 ):
-    query_kind = fields.String(validate=OneOf(["nocturnal_events"]))
+    __model__ = NocturnalEventsExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     night_start_hour = fields.Integer(
         validate=Range(0, 23)
     )  # Tuples aren't supported by apispec https://github.com/marshmallow-code/apispec/issues/399
     night_end_hour = fields.Integer(validate=Range(0, 23))
-
-    __model__ = NocturnalEventsExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/nocturnal_events.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/nocturnal_events.py
@@ -11,6 +11,7 @@ from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
 )
+from .custom_fields import Hours
 from .field_mixins import (
     StartAndEndField,
     EventTypesField,
@@ -29,8 +30,7 @@ class NocturnalEventsExposed(BaseExposedQueryWithSampling):
         *,
         start_date,
         end_date,
-        night_start_hour,
-        night_end_hour,
+        night_hours,
         event_types,
         subscriber_subset=None,
         sampling=None
@@ -39,7 +39,7 @@ class NocturnalEventsExposed(BaseExposedQueryWithSampling):
         # so that marshmallow can serialise the object correctly.
         self.start = start_date
         self.stop = end_date
-        self.hours = (night_start_hour, night_end_hour)
+        self.hours = night_hours
         self.event_types = event_types
         self.subscriber_subset = subscriber_subset
         self.sampling = sampling
@@ -72,7 +72,4 @@ class NocturnalEventsSchema(
 
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
-    night_start_hour = fields.Integer(
-        validate=Range(0, 23)
-    )  # Tuples aren't supported by apispec https://github.com/marshmallow-code/apispec/issues/399
-    night_end_hour = fields.Integer(validate=Range(0, 23))
+    night_hours = fields.Nested(Hours, required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/one_of_query.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/one_of_query.py
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marshmallow_oneofschema import OneOfSchema
+
+
+class OneOfQuerySchema(OneOfSchema):
+    type_field = "query_kind"
+    type_field_remove = False
+    query_schemas = ()
+
+    @property
+    def type_schemas(self):
+        return {schema.__model__.query_kind: schema for schema in self.query_schemas}
+
+    def get_obj_type(self, obj):
+        return obj.query_kind

--- a/flowmachine/flowmachine/core/server/query_schemas/outflows.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/outflows.py
@@ -11,6 +11,9 @@ from flowmachine.features.location.redacted_in_out_flows import RedactedInOutFlo
 
 
 class OutflowsExposed(FlowsExposed):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "outflows"
+
     @property
     def _flowmachine_query_obj(self):
         loc1 = self.from_location._flowmachine_query_obj
@@ -21,5 +24,7 @@ class OutflowsExposed(FlowsExposed):
 
 
 class OutflowsSchema(FlowsSchema):
-    query_kind = fields.String(validate=OneOf(["outflows"]))
     __model__ = OutflowsExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/pareto_interactions.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/pareto_interactions.py
@@ -21,6 +21,9 @@ __all__ = ["ParetoInteractionsSchema", "ParetoInteractionsExposed"]
 
 
 class ParetoInteractionsExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "pareto_interactions"
+
     def __init__(
         self,
         *,
@@ -68,7 +71,8 @@ class ParetoInteractionsSchema(
     HoursField,
     BaseQueryWithSamplingSchema,
 ):
-    query_kind = fields.String(validate=OneOf(["pareto_interactions"]))
-    proportion = fields.Float(required=True, validate=Range(min=0.0, max=1.0))
-
     __model__ = ParetoInteractionsExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    proportion = fields.Float(required=True, validate=Range(min=0.0, max=1.0))

--- a/flowmachine/flowmachine/core/server/query_schemas/radius_of_gyration.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/radius_of_gyration.py
@@ -21,6 +21,9 @@ __all__ = ["RadiusOfGyrationSchema", "RadiusOfGyrationExposed"]
 
 
 class RadiusOfGyrationExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "radius_of_gyration"
+
     def __init__(
         self,
         *,
@@ -65,7 +68,7 @@ class RadiusOfGyrationSchema(
     HoursField,
     BaseQueryWithSamplingSchema,
 ):
-    # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["radius_of_gyration"]))
-
     __model__ = RadiusOfGyrationExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/reference_location.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/reference_location.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marshmallow_oneofschema import OneOfSchema
-
 from flowmachine.core.server.query_schemas.coalesced_location import (
     CoalescedLocationSchema,
 )
@@ -18,19 +16,19 @@ from flowmachine.core.server.query_schemas.most_frequent_location import (
 from flowmachine.core.server.query_schemas.visited_most_days import (
     VisitedMostDaysSchema,
 )
+from flowmachine.core.server.query_schemas.one_of_query import OneOfQuerySchema
 
 
-class ReferenceLocationSchema(OneOfSchema):
+class ReferenceLocationSchema(OneOfQuerySchema):
     """
     A set of queries that return a mapping between unique subscribers and locations
     """
 
-    type_field = "query_kind"
-    type_schemas = {
-        "daily_location": DailyLocationSchema,
-        "modal_location": ModalLocationSchema,
-        "most_frequent_location": MostFrequentLocationSchema,
-        "visited_most_days": VisitedMostDaysSchema,
-        "majority_location": MajorityLocationSchema,
-        "coalesced_location": CoalescedLocationSchema,
-    }
+    query_schemas = (
+        DailyLocationSchema,
+        ModalLocationSchema,
+        MostFrequentLocationSchema,
+        VisitedMostDaysSchema,
+        MajorityLocationSchema,
+        CoalescedLocationSchema,
+    )

--- a/flowmachine/flowmachine/core/server/query_schemas/spatial_aggregate.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/spatial_aggregate.py
@@ -2,9 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marshmallow import fields, post_load
+from marshmallow import fields
 from marshmallow.validate import OneOf
-from marshmallow_oneofschema import OneOfSchema
 
 from flowmachine.features.location.redacted_spatial_aggregate import (
     RedactedSpatialAggregate,
@@ -12,8 +11,6 @@ from flowmachine.features.location.redacted_spatial_aggregate import (
 from flowmachine.features.location.spatial_aggregate import SpatialAggregate
 from .base_exposed_query import BaseExposedQuery
 from .base_schema import BaseSchema
-from .daily_location import DailyLocationSchema
-from .modal_location import ModalLocationSchema
 
 __all__ = [
     "SpatialAggregateSchema",
@@ -24,6 +21,9 @@ from .reference_location import ReferenceLocationSchema
 
 
 class SpatialAggregateExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "spatial_aggregate"
+
     def __init__(self, *, locations):
         # Note: all input parameters need to be defined as attributes on `self`
         # so that marshmallow can serialise the object correctly.
@@ -45,8 +45,8 @@ class SpatialAggregateExposed(BaseExposedQuery):
 
 
 class SpatialAggregateSchema(BaseSchema):
-    # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["spatial_aggregate"]))
-    locations = fields.Nested(ReferenceLocationSchema, required=True)
-
     __model__ = SpatialAggregateExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    locations = fields.Nested(ReferenceLocationSchema, required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/spatial_aggregate.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/spatial_aggregate.py
@@ -9,6 +9,7 @@ from flowmachine.features.location.redacted_spatial_aggregate import (
     RedactedSpatialAggregate,
 )
 from flowmachine.features.location.spatial_aggregate import SpatialAggregate
+from .aggregation_unit import AggregationUnitKind
 from .base_exposed_query import BaseExposedQuery
 from .base_schema import BaseSchema
 
@@ -30,6 +31,10 @@ class SpatialAggregateExposed(BaseExposedQuery):
         self.locations = locations
 
     @property
+    def aggregation_unit(self):
+        return self.locations.aggregation_unit
+
+    @property
     def _flowmachine_query_obj(self):
         """
         Return the underlying flowmachine object.
@@ -49,4 +54,5 @@ class SpatialAggregateSchema(BaseSchema):
 
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    aggregation_unit = AggregationUnitKind(dump_only=True)
     locations = fields.Nested(ReferenceLocationSchema, required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/subscriber_degree.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/subscriber_degree.py
@@ -21,6 +21,9 @@ __all__ = ["SubscriberDegreeSchema", "SubscriberDegreeExposed"]
 
 
 class SubscriberDegreeExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "subscriber_degree"
+
     def __init__(
         self,
         *,
@@ -68,9 +71,10 @@ class SubscriberDegreeSchema(
     HoursField,
     BaseQueryWithSamplingSchema,
 ):
-    query_kind = fields.String(validate=OneOf(["subscriber_degree"]))
+    __model__ = SubscriberDegreeExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     direction = fields.String(
         required=False, validate=OneOf(["in", "out", "both"]), default="both"
     )  # TODO: use a globally defined enum for this
-
-    __model__ = SubscriberDegreeExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/subscriber_degree.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/subscriber_degree.py
@@ -10,6 +10,7 @@ from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
 )
+from .custom_fields import Direction
 from .field_mixins import (
     HoursField,
     StartAndEndField,
@@ -75,6 +76,4 @@ class SubscriberDegreeSchema(
 
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
-    direction = fields.String(
-        required=False, validate=OneOf(["in", "out", "both"]), default="both"
-    )  # TODO: use a globally defined enum for this
+    direction = Direction()

--- a/flowmachine/flowmachine/core/server/query_schemas/topup_amount.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/topup_amount.py
@@ -17,6 +17,9 @@ __all__ = ["TopUpAmountSchema", "TopUpAmountExposed"]
 
 
 class TopUpAmountExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "topup_amount"
+
     def __init__(
         self,
         *,
@@ -57,7 +60,8 @@ class TopUpAmountExposed(BaseExposedQueryWithSampling):
 class TopUpAmountSchema(
     StartAndEndField, SubscriberSubsetField, HoursField, BaseQueryWithSamplingSchema
 ):
-    query_kind = fields.String(validate=OneOf(["topup_amount"]))
-    statistic = Statistic()
-
     __model__ = TopUpAmountExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    statistic = Statistic()

--- a/flowmachine/flowmachine/core/server/query_schemas/topup_balance.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/topup_balance.py
@@ -6,8 +6,7 @@ from marshmallow import fields
 from marshmallow.validate import OneOf
 
 from flowmachine.features import TopUpBalance
-from .custom_fields import Statistic, ISODateTime
-from .subscriber_subset import SubscriberSubset
+from .custom_fields import Statistic
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
@@ -15,7 +14,6 @@ from .base_query_with_sampling import (
 from .field_mixins import (
     HoursField,
     StartAndEndField,
-    EventTypesField,
     SubscriberSubsetField,
 )
 
@@ -23,6 +21,9 @@ __all__ = ["TopUpBalanceSchema", "TopUpBalanceExposed"]
 
 
 class TopUpBalanceExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "topup_balance"
+
     def __init__(
         self,
         *,
@@ -66,7 +67,8 @@ class TopUpBalanceSchema(
     HoursField,
     BaseQueryWithSamplingSchema,
 ):
-    query_kind = fields.String(validate=OneOf(["topup_balance"]))
-    statistic = Statistic()
-
     __model__ = TopUpBalanceExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    statistic = Statistic()

--- a/flowmachine/flowmachine/core/server/query_schemas/total_active_periods.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/total_active_periods.py
@@ -19,6 +19,9 @@ __all__ = ["TotalActivePeriodsSchema", "TotalActivePeriodsExposed"]
 
 
 class TotalActivePeriodsExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "total_active_periods"
+
     def __init__(
         self,
         *,
@@ -65,8 +68,10 @@ class TotalActivePeriodsExposed(BaseExposedQueryWithSampling):
 class TotalActivePeriodsSchema(
     EventTypesField, SubscriberSubsetField, HoursField, BaseSchema
 ):
+    __model__ = TotalActivePeriodsExposed
+
     # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["total_active_periods"]))
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
     start_date = ISODateTime(required=True)
     total_periods = fields.Integer(required=True)
     period_length = fields.Integer(missing=1, required=False, default=1)
@@ -76,5 +81,3 @@ class TotalActivePeriodsSchema(
         required=False,
         default="days",
     )
-
-    __model__ = TotalActivePeriodsExposed

--- a/flowmachine/flowmachine/core/server/query_schemas/total_network_objects.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/total_network_objects.py
@@ -19,10 +19,11 @@ from .aggregation_unit import AggregationUnitMixin
 
 __all__ = ["TotalNetworkObjectsSchema", "TotalNetworkObjectsExposed"]
 
-from .subscriber_subset import SubscriberSubset
-
 
 class TotalNetworkObjectsExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "total_network_objects"
+
     def __init__(
         self,
         *,
@@ -72,8 +73,8 @@ class TotalNetworkObjectsSchema(
     AggregationUnitMixin,
     BaseSchema,
 ):
-    # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["total_network_objects"]))
-    total_by = TotalBy(required=False, missing="day")
-
     __model__ = TotalNetworkObjectsExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    total_by = TotalBy(required=False, missing="day")

--- a/flowmachine/flowmachine/core/server/query_schemas/trips_od_matrix.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/trips_od_matrix.py
@@ -22,6 +22,9 @@ __all__ = ["TripsODMatrixSchema", "TripsODMatrixExposed"]
 
 
 class TripsODMatrixExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "trips_od_matrix"
+
     def __init__(
         self,
         start_date,
@@ -72,7 +75,7 @@ class TripsODMatrixSchema(
     AggregationUnitMixin,
     BaseSchema,
 ):
-    # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["trips_od_matrix"]))
-
     __model__ = TripsODMatrixExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/unique_location_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/unique_location_counts.py
@@ -20,6 +20,9 @@ __all__ = ["UniqueLocationCountsSchema", "UniqueLocationCountsExposed"]
 
 
 class UniqueLocationCountsExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "unique_location_counts"
+
     def __init__(
         self,
         *,
@@ -66,6 +69,7 @@ class UniqueLocationCountsSchema(
     AggregationUnitMixin,
     BaseSchema,
 ):
-    query_kind = fields.String(validate=OneOf(["unique_location_counts"]))
-
     __model__ = UniqueLocationCountsExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/unique_locations.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/unique_locations.py
@@ -7,8 +7,6 @@ from marshmallow.validate import OneOf
 
 from flowmachine.features import SubscriberLocations
 from flowmachine.features.subscriber.unique_locations import UniqueLocations
-from .custom_fields import EventTypes, ISODateTime
-from .subscriber_subset import SubscriberSubset
 from .aggregation_unit import AggregationUnitMixin
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
@@ -25,6 +23,9 @@ __all__ = ["UniqueLocationsSchema", "UniqueLocationsExposed"]
 
 
 class UniqueLocationsExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "unique_locations"
+
     def __init__(
         self,
         start_date,
@@ -75,7 +76,7 @@ class UniqueLocationsSchema(
     AggregationUnitMixin,
     BaseQueryWithSamplingSchema,
 ):
-    # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["unique_locations"]))
-
     __model__ = UniqueLocationsExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/unique_subscriber_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/unique_subscriber_counts.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marshmallow import fields, post_load
+from marshmallow import fields
 from marshmallow.validate import OneOf
 
 from flowmachine.features import UniqueSubscriberCounts
@@ -25,6 +25,9 @@ from .base_schema import BaseSchema
 
 
 class UniqueSubscriberCountsExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "unique_subscriber_counts"
+
     def __init__(
         self,
         *,
@@ -73,7 +76,7 @@ class UniqueSubscriberCountsSchema(
     AggregationUnitMixin,
     BaseSchema,
 ):
-    # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["unique_subscriber_counts"]))
-
     __model__ = UniqueSubscriberCountsExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/unique_visitor_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/unique_visitor_counts.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marshmallow import fields, post_load
+from marshmallow import fields
 from marshmallow.validate import OneOf
 
 from flowmachine.features.location.unique_visitor_counts import UniqueVisitorCounts
@@ -20,6 +20,9 @@ __all__ = [
 
 
 class UniqueVisitorCountsExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "unique_visitor_counts"
+
     def __init__(
         self,
         active_at_reference_location_counts,
@@ -47,11 +50,13 @@ class UniqueVisitorCountsExposed(BaseExposedQuery):
 
 
 class UniqueVisitorCountsSchema(BaseSchema):
-    # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["unique_visitor_counts"]))
-    active_at_reference_location_counts = fields.Nested(
-        ActiveAtReferenceLocationCountsSchema()
-    )
-    unique_subscriber_counts = fields.Nested(UniqueSubscriberCountsSchema())
-
     __model__ = UniqueVisitorCountsExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    active_at_reference_location_counts = fields.Nested(
+        ActiveAtReferenceLocationCountsSchema(), required=True
+    )
+    unique_subscriber_counts = fields.Nested(
+        UniqueSubscriberCountsSchema(), required=True
+    )

--- a/flowmachine/flowmachine/core/server/query_schemas/unique_visitor_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/unique_visitor_counts.py
@@ -2,11 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marshmallow import fields
+from marshmallow import fields, validates_schema, ValidationError
 from marshmallow.validate import OneOf
 
 from flowmachine.features.location.unique_visitor_counts import UniqueVisitorCounts
 from .active_at_reference_location_counts import ActiveAtReferenceLocationCountsSchema
+from .aggregation_unit import AggregationUnitKind
 from .base_schema import BaseSchema
 
 from .unique_subscriber_counts import UniqueSubscriberCountsSchema
@@ -34,6 +35,10 @@ class UniqueVisitorCountsExposed(BaseExposedQuery):
         self.unique_subscriber_counts = unique_subscriber_counts
 
     @property
+    def aggregation_unit(self):
+        return self.unique_subscriber_counts.aggregation_unit
+
+    @property
     def _flowmachine_query_obj(self):
         """
         Return the underlying flowmachine object.
@@ -54,9 +59,27 @@ class UniqueVisitorCountsSchema(BaseSchema):
 
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    aggregation_unit = AggregationUnitKind(dump_only=True)
     active_at_reference_location_counts = fields.Nested(
         ActiveAtReferenceLocationCountsSchema(), required=True
     )
     unique_subscriber_counts = fields.Nested(
         UniqueSubscriberCountsSchema(), required=True
     )
+
+    @validates_schema
+    def validate_aggregation_units(self, data, **kwargs):
+        """
+        Validate that active_at_reference_location_counts and unique_subscriber_counts have the same aggregation unit
+        """
+        try:
+            if (
+                data["active_at_reference_location_counts"].aggregation_unit
+                != data["unique_subscriber_counts"].aggregation_unit
+            ):
+                raise ValidationError(
+                    "'active_at_reference_location_counts' and 'unique_subscriber_counts' parameters must have the same aggregation unit"
+                )
+        except AttributeError:
+            # Nested schema was invalid - appropriate ValidationError will be raised from elsewhere
+            pass

--- a/flowmachine/flowmachine/core/server/query_schemas/unique_visitor_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/unique_visitor_counts.py
@@ -67,19 +67,15 @@ class UniqueVisitorCountsSchema(BaseSchema):
         UniqueSubscriberCountsSchema(), required=True
     )
 
-    @validates_schema
+    @validates_schema(skip_on_field_errors=True)
     def validate_aggregation_units(self, data, **kwargs):
         """
         Validate that active_at_reference_location_counts and unique_subscriber_counts have the same aggregation unit
         """
-        try:
-            if (
-                data["active_at_reference_location_counts"].aggregation_unit
-                != data["unique_subscriber_counts"].aggregation_unit
-            ):
-                raise ValidationError(
-                    "'active_at_reference_location_counts' and 'unique_subscriber_counts' parameters must have the same aggregation unit"
-                )
-        except AttributeError:
-            # Nested schema was invalid - appropriate ValidationError will be raised from elsewhere
-            pass
+        if (
+            data["active_at_reference_location_counts"].aggregation_unit
+            != data["unique_subscriber_counts"].aggregation_unit
+        ):
+            raise ValidationError(
+                "'active_at_reference_location_counts' and 'unique_subscriber_counts' parameters must have the same aggregation unit"
+            )

--- a/flowmachine/flowmachine/core/server/query_schemas/unmoving_at_reference_location_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/unmoving_at_reference_location_counts.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marshmallow import fields, post_load
+from marshmallow import fields
 from marshmallow.validate import OneOf
 
 from flowmachine.features.location.redacted_unmoving_at_reference_location_counts import (
@@ -26,6 +26,9 @@ __all__ = [
 
 
 class UnmovingAtReferenceLocationCountsExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "unmoving_at_reference_location_counts"
+
     def __init__(self, locations, reference_locations):
         # Note: all input parameters need to be defined as attributes on `self`
         # so that marshmallow can serialise the object correctly.
@@ -52,11 +55,9 @@ class UnmovingAtReferenceLocationCountsExposed(BaseExposedQuery):
 
 
 class UnmovingAtReferenceLocationCountsSchema(BaseSchema):
-    # query_kind parameter is required here for claims validation
-    query_kind = fields.String(
-        validate=OneOf(["unmoving_at_reference_location_counts"])
-    )
-    locations = fields.Nested(UniqueLocationsSchema)
-    reference_locations = fields.Nested(ReferenceLocationSchema)
-
     __model__ = UnmovingAtReferenceLocationCountsExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    locations = fields.Nested(UniqueLocationsSchema, required=True)
+    reference_locations = fields.Nested(ReferenceLocationSchema, required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/unmoving_at_reference_location_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/unmoving_at_reference_location_counts.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marshmallow import fields
+from marshmallow import fields, validates_schema, ValidationError
 from marshmallow.validate import OneOf
 
 from flowmachine.features.location.redacted_unmoving_at_reference_location_counts import (
@@ -15,6 +15,7 @@ from flowmachine.features.subscriber.unmoving_at_reference_location import (
     UnmovingAtReferenceLocation,
 )
 from . import BaseExposedQuery
+from .aggregation_unit import AggregationUnitKind
 from .base_schema import BaseSchema
 from .reference_location import ReferenceLocationSchema
 from .unique_locations import UniqueLocationsSchema
@@ -34,6 +35,10 @@ class UnmovingAtReferenceLocationCountsExposed(BaseExposedQuery):
         # so that marshmallow can serialise the object correctly.
         self.locations = locations
         self.reference_locations = reference_locations
+
+    @property
+    def aggregation_unit(self):
+        return self.locations.aggregation_unit
 
     @property
     def _flowmachine_query_obj(self):
@@ -59,5 +64,23 @@ class UnmovingAtReferenceLocationCountsSchema(BaseSchema):
 
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    aggregation_unit = AggregationUnitKind(dump_only=True)
     locations = fields.Nested(UniqueLocationsSchema, required=True)
     reference_locations = fields.Nested(ReferenceLocationSchema, required=True)
+
+    @validates_schema
+    def validate_aggregation_units(self, data, **kwargs):
+        """
+        Validate that locations and reference_locations have the same aggregation unit
+        """
+        try:
+            if (
+                data["locations"].aggregation_unit
+                != data["reference_locations"].aggregation_unit
+            ):
+                raise ValidationError(
+                    "'locations' and 'reference_locations' parameters must have the same aggregation unit"
+                )
+        except AttributeError:
+            # Nested schema was invalid - appropriate ValidationError will be raised from elsewhere
+            pass

--- a/flowmachine/flowmachine/core/server/query_schemas/unmoving_at_reference_location_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/unmoving_at_reference_location_counts.py
@@ -68,19 +68,15 @@ class UnmovingAtReferenceLocationCountsSchema(BaseSchema):
     locations = fields.Nested(UniqueLocationsSchema, required=True)
     reference_locations = fields.Nested(ReferenceLocationSchema, required=True)
 
-    @validates_schema
+    @validates_schema(skip_on_field_errors=True)
     def validate_aggregation_units(self, data, **kwargs):
         """
         Validate that locations and reference_locations have the same aggregation unit
         """
-        try:
-            if (
-                data["locations"].aggregation_unit
-                != data["reference_locations"].aggregation_unit
-            ):
-                raise ValidationError(
-                    "'locations' and 'reference_locations' parameters must have the same aggregation unit"
-                )
-        except AttributeError:
-            # Nested schema was invalid - appropriate ValidationError will be raised from elsewhere
-            pass
+        if (
+            data["locations"].aggregation_unit
+            != data["reference_locations"].aggregation_unit
+        ):
+            raise ValidationError(
+                "'locations' and 'reference_locations' parameters must have the same aggregation unit"
+            )

--- a/flowmachine/flowmachine/core/server/query_schemas/unmoving_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/unmoving_counts.py
@@ -18,6 +18,9 @@ __all__ = ["UnmovingCountsSchema", "UnmovingCountsExposed"]
 
 
 class UnmovingCountsExposed(BaseExposedQuery):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "unmoving_counts"
+
     def __init__(self, locations):
         # Note: all input parameters need to be defined as attributes on `self`
         # so that marshmallow can serialise the object correctly.
@@ -40,8 +43,8 @@ class UnmovingCountsExposed(BaseExposedQuery):
 
 
 class UnmovingCountsSchema(BaseSchema):
-    # query_kind parameter is required here for claims validation
-    query_kind = fields.String(validate=OneOf(["unmoving_counts"]))
-    locations = fields.Nested(UniqueLocationsSchema)
-
     __model__ = UnmovingCountsExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    locations = fields.Nested(UniqueLocationsSchema)

--- a/flowmachine/flowmachine/core/server/query_schemas/unmoving_counts.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/unmoving_counts.py
@@ -11,6 +11,7 @@ from flowmachine.features.location.redacted_unmoving_counts import (
 from flowmachine.features.location.unmoving_counts import UnmovingCounts
 from flowmachine.features.subscriber.unmoving import Unmoving
 from . import BaseExposedQuery
+from .aggregation_unit import AggregationUnitKind
 from .base_schema import BaseSchema
 from .unique_locations import UniqueLocationsSchema
 
@@ -25,6 +26,10 @@ class UnmovingCountsExposed(BaseExposedQuery):
         # Note: all input parameters need to be defined as attributes on `self`
         # so that marshmallow can serialise the object correctly.
         self.locations = locations
+
+    @property
+    def aggregation_unit(self):
+        return self.locations.aggregation_unit
 
     @property
     def _flowmachine_query_obj(self):
@@ -47,4 +52,5 @@ class UnmovingCountsSchema(BaseSchema):
 
     # query_kind parameter is required here for claims validation
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
-    locations = fields.Nested(UniqueLocationsSchema)
+    aggregation_unit = AggregationUnitKind(dump_only=True)
+    locations = fields.Nested(UniqueLocationsSchema, required=True)

--- a/flowmachine/flowmachine/core/server/query_schemas/visited_most_days.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/visited_most_days.py
@@ -27,6 +27,9 @@ __all__ = [
 
 
 class VisitedMostDaysExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "visited_most_days"
+
     def __init__(
         self,
         start_date,
@@ -35,8 +38,6 @@ class VisitedMostDaysExposed(BaseExposedQueryWithSampling):
         aggregation_unit,
         event_types,
         subscriber_subset=None,
-        subscriber_identifier=None,
-        ignore_nulls=None,
         hours=None,
         sampling=None,
     ):
@@ -45,9 +46,7 @@ class VisitedMostDaysExposed(BaseExposedQueryWithSampling):
         self.aggregation_unit = aggregation_unit
         self.hours = hours
         self.event_types = event_types
-        self.subscriber_subset = (subscriber_subset,)
-        self.subscriber_identifier = (subscriber_identifier,)
-        self.ignore_nulls = ignore_nulls
+        self.subscriber_subset = subscriber_subset
         self.sampling = sampling
 
     @property
@@ -67,8 +66,6 @@ class VisitedMostDaysExposed(BaseExposedQueryWithSampling):
                 spatial_unit=self.aggregation_unit,
                 table=self.event_types,
                 subscriber_subset=self.subscriber_subset,
-                subscriber_identifier=self.subscriber_identifier,
-                ignore_nulls=self.ignore_nulls,
             )
         )
 
@@ -81,6 +78,7 @@ class VisitedMostDaysSchema(
     AggregationUnitMixin,
     BaseQueryWithSamplingSchema,
 ):
-    query_kind = fields.String(validate=OneOf(["visited_most_days"]))
-
     __model__ = VisitedMostDaysExposed
+
+    # query_kind parameter is required here for claims validation
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)

--- a/flowmachine/tests/server/test_action_handlers.py
+++ b/flowmachine/tests/server/test_action_handlers.py
@@ -24,6 +24,7 @@ from flowmachine.core.server.action_handlers import (
     action_handler__get_query_params,
     action_handler__get_sql,
     action_handler__run_query,
+    action_handler__get_aggregation_unit,
     get_action_handler,
 )
 from flowmachine.core.server.exceptions import FlowmachineServerError
@@ -143,8 +144,11 @@ async def test_rerun_query_after_cancelled(server_config, real_connections):
     assert query_obj.is_stored
 
 
+@pytest.mark.parametrize(
+    "handler", [action_handler__run_query, action_handler__get_aggregation_unit]
+)
 @pytest.mark.asyncio
-async def test_run_query_type_error(monkeypatch, server_config):
+async def test_run_query_type_error(handler, monkeypatch, server_config):
     """
     Test that developer errors when creating schemas return the error message.
     """
@@ -156,7 +160,7 @@ async def test_run_query_type_error(monkeypatch, server_config):
     monkeypatch.setattr(
         flowmachine.core.server.action_handlers, "FlowmachineQuerySchema", BrokenSchema
     )
-    msg = await action_handler__run_query(config=server_config, query_kind={})
+    msg = await handler(config=server_config, query_kind={})
     assert msg.status == ZMQReplyStatus.ERROR
     assert (
         msg.msg
@@ -167,7 +171,7 @@ async def test_run_query_type_error(monkeypatch, server_config):
 @pytest.mark.asyncio
 async def test_run_query_error_handled(dummy_redis, server_config):
     """
-    Run query handler should return an error status if query construction failed.
+    Action handler should return an error status if query construction failed.
     """
     # This is going to error, because the db connection is a mock.
     msg = await action_handler__run_query(
@@ -228,3 +232,57 @@ async def test_get_sql_error_states(query_state, dummy_redis, server_config):
     assert msg.status == ZMQReplyStatus.ERROR
     assert msg.payload["query_state"] == query_state
     redis_connection.reset(redis_reset)
+
+
+@pytest.mark.parametrize(
+    "params, expected_aggregation_unit",
+    [
+        (
+            dict(
+                query_kind="spatial_aggregate",
+                locations=dict(
+                    query_kind="modal_location",
+                    locations=[
+                        dict(
+                            query_kind="daily_location",
+                            date="2016-01-01",
+                            method="last",
+                            aggregation_unit="admin3",
+                        )
+                    ],
+                ),
+            ),
+            "admin3",
+        ),
+        (
+            dict(
+                query_kind="histogram_aggregate",
+                metric=dict(
+                    query_kind="displacement",
+                    start_date="2016-01-01",
+                    end_date="2016-01-02",
+                    statistic="avg",
+                    reference_location=dict(
+                        query_kind="daily_location",
+                        date="2016-01-01",
+                        method="last",
+                        aggregation_unit="lon-lat",
+                    ),
+                ),
+                bins=dict(n_bins=10),
+            ),
+            None,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_aggregation_unit(params, expected_aggregation_unit, server_config):
+    """
+    'get_aggregation_unit' handler returns correct aggregation unit
+    """
+    msg = await action_handler__get_aggregation_unit(
+        config=server_config,
+        **params,
+    )
+    assert msg["status"] == ZMQReplyStatus.SUCCESS
+    assert msg.payload["aggregation_unit"] == expected_aggregation_unit

--- a/flowmachine/tests/server/test_action_handlers.py
+++ b/flowmachine/tests/server/test_action_handlers.py
@@ -276,10 +276,15 @@ async def test_get_sql_error_states(query_state, dummy_redis, server_config):
     ],
 )
 @pytest.mark.asyncio
-async def test_get_aggregation_unit(params, expected_aggregation_unit, server_config):
+async def test_get_aggregation_unit(
+    params, expected_aggregation_unit, server_config, real_connections
+):
     """
     'get_aggregation_unit' handler returns correct aggregation unit
     """
+    # Have to use real_connections fixture here because query deserialisation
+    # involves constructing a spatial unit object, which requires talking to
+    # the db.
     msg = await action_handler__get_aggregation_unit(
         config=server_config,
         **params,

--- a/flowmachine/tests/test_query_object_construction.py
+++ b/flowmachine/tests/test_query_object_construction.py
@@ -946,6 +946,7 @@ def test_construct_query(diff_reporter):
                         aggregation_unit="lon-lat",
                     ),
                 ),
+                method="avg",
             ),
             "admin3",
         ),

--- a/flowmachine/tests/test_query_object_construction.py
+++ b/flowmachine/tests/test_query_object_construction.py
@@ -842,7 +842,6 @@ def test_construct_query(diff_reporter):
     diff_reporter(query_ids_and_specs_as_json_string)
 
 
-# TODO: Need one of these for every spatial aggregate kind
 @pytest.mark.parametrize(
     "params, expected_aggregation_unit",
     [
@@ -866,6 +865,42 @@ def test_construct_query(diff_reporter):
         (
             dict(
                 query_kind="flows",
+                from_location=dict(
+                    query_kind="visited_most_days",
+                    start_date="2016-01-01",
+                    end_date="2016-01-07",
+                    aggregation_unit="admin2",
+                ),
+                to_location=dict(
+                    query_kind="unique_locations",
+                    start_date="2016-01-07",
+                    end_date="2016-01-08",
+                    aggregation_unit="admin2",
+                ),
+            ),
+            "admin2",
+        ),
+        (
+            dict(
+                query_kind="inflows",
+                from_location=dict(
+                    query_kind="visited_most_days",
+                    start_date="2016-01-01",
+                    end_date="2016-01-07",
+                    aggregation_unit="admin2",
+                ),
+                to_location=dict(
+                    query_kind="unique_locations",
+                    start_date="2016-01-07",
+                    end_date="2016-01-08",
+                    aggregation_unit="admin2",
+                ),
+            ),
+            "admin2",
+        ),
+        (
+            dict(
+                query_kind="outflows",
                 from_location=dict(
                     query_kind="visited_most_days",
                     start_date="2016-01-01",
@@ -912,6 +947,847 @@ def test_construct_query(diff_reporter):
                     ),
                 ),
             ),
+            "admin3",
+        ),
+        (
+            dict(
+                query_kind="geography",
+                aggregation_unit="admin3",
+            ),
+            "admin3",
+        ),
+        (
+            {
+                "query_kind": "meaningful_locations_aggregate",
+                "aggregation_unit": "admin1",
+                "start_date": "2016-01-01",
+                "end_date": "2016-01-02",
+                "label": "unknown",
+                "labels": {
+                    "evening": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [[1e-06, -0.5], [1e-06, -1.1], [1.1, -1.1], [1.1, -0.5]]
+                        ],
+                    },
+                    "day": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [[-1.1, -0.5], [-1.1, 0.5], [-1e-06, 0.5], [0, -0.5]]
+                        ],
+                    },
+                },
+                "tower_hour_of_day_scores": [
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    0,
+                    0,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    -1,
+                    -1,
+                    -1,
+                ],
+                "tower_day_of_week_scores": {
+                    "monday": 1,
+                    "tuesday": 1,
+                    "wednesday": 1,
+                    "thursday": 0,
+                    "friday": -1,
+                    "saturday": -1,
+                    "sunday": -1,
+                },
+                "tower_cluster_radius": 1.0,
+                "tower_cluster_call_threshold": 0,
+                "subscriber_subset": None,
+            },
+            "admin1",
+        ),
+        (
+            {
+                "query_kind": "meaningful_locations_between_label_od_matrix",
+                "aggregation_unit": "admin1",
+                "start_date": "2016-01-01",
+                "end_date": "2016-01-02",
+                "label_a": "day",
+                "label_b": "evening",
+                "labels": {
+                    "day": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [[-1.1, -0.5], [-1.1, 0.5], [-1e-06, 0.5], [0, -0.5]]
+                        ],
+                    },
+                    "evening": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [[1e-06, -0.5], [1e-06, -1.1], [1.1, -1.1], [1.1, -0.5]]
+                        ],
+                    },
+                },
+                "tower_hour_of_day_scores": [
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    0,
+                    0,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    -1,
+                    -1,
+                    -1,
+                ],
+                "tower_day_of_week_scores": {
+                    "monday": 1,
+                    "tuesday": 1,
+                    "wednesday": 1,
+                    "thursday": 0,
+                    "friday": -1,
+                    "saturday": -1,
+                    "sunday": -1,
+                },
+                "tower_cluster_radius": 1.0,
+                "tower_cluster_call_threshold": 0,
+                "event_types": None,
+                "subscriber_subset": None,
+            },
+            "admin1",
+        ),
+        (
+            {
+                "query_kind": "meaningful_locations_between_dates_od_matrix",
+                "aggregation_unit": "admin1",
+                "start_date_a": "2016-01-01",
+                "end_date_a": "2016-01-02",
+                "start_date_b": "2016-01-01",
+                "end_date_b": "2016-01-05",
+                "label": "unknown",
+                "labels": {
+                    "day": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [[-1.1, -0.5], [-1.1, 0.5], [-1e-06, 0.5], [0, -0.5]]
+                        ],
+                    },
+                    "evening": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [[1e-06, -0.5], [1e-06, -1.1], [1.1, -1.1], [1.1, -0.5]]
+                        ],
+                    },
+                },
+                "tower_hour_of_day_scores": [
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    0,
+                    0,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    -1,
+                    -1,
+                    -1,
+                ],
+                "tower_day_of_week_scores": {
+                    "monday": 1,
+                    "tuesday": 1,
+                    "wednesday": 1,
+                    "thursday": 0,
+                    "friday": -1,
+                    "saturday": -1,
+                    "sunday": -1,
+                },
+                "tower_cluster_radius": 1.0,
+                "tower_cluster_call_threshold": 2,
+                "event_types": ["calls", "sms"],
+                "subscriber_subset": None,
+            },
+            "admin1",
+        ),
+        (
+            dict(
+                query_kind="location_event_counts",
+                start_date="2016-01-01",
+                end_date="2016-01-02",
+                interval="day",
+                aggregation_unit="admin3",
+                direction="both",
+            ),
+            "admin3",
+        ),
+        (
+            dict(
+                query_kind="unmoving_counts",
+                locations=dict(
+                    query_kind="unique_locations",
+                    start_date="2016-01-01",
+                    end_date="2016-01-02",
+                    aggregation_unit="admin2",
+                ),
+            ),
+            "admin2",
+        ),
+        (
+            dict(
+                query_kind="unmoving_at_reference_location_counts",
+                locations=dict(
+                    query_kind="unique_locations",
+                    start_date="2016-01-01",
+                    end_date="2016-01-02",
+                    aggregation_unit="admin2",
+                ),
+                reference_locations=dict(
+                    query_kind="daily_location",
+                    date="2016-01-01",
+                    method="last",
+                    aggregation_unit="admin2",
+                ),
+            ),
+            "admin2",
+        ),
+        (
+            dict(
+                query_kind="active_at_reference_location_counts",
+                unique_locations=dict(
+                    query_kind="unique_locations",
+                    start_date="2016-01-01",
+                    end_date="2016-01-02",
+                    aggregation_unit="admin2",
+                ),
+                reference_locations=dict(
+                    query_kind="daily_location",
+                    date="2016-01-01",
+                    method="last",
+                    aggregation_unit="admin2",
+                ),
+            ),
+            "admin2",
+        ),
+        (
+            dict(
+                query_kind="unique_visitor_counts",
+                unique_subscriber_counts=dict(
+                    query_kind="unique_subscriber_counts",
+                    start_date="2016-01-01",
+                    end_date="2016-01-02",
+                    aggregation_unit="admin3",
+                ),
+                active_at_reference_location_counts=dict(
+                    query_kind="active_at_reference_location_counts",
+                    unique_locations=dict(
+                        query_kind="unique_locations",
+                        start_date="2016-01-01",
+                        end_date="2016-01-02",
+                        aggregation_unit="admin3",
+                    ),
+                    reference_locations=dict(
+                        query_kind="daily_location",
+                        date="2016-01-01",
+                        method="last",
+                        aggregation_unit="admin3",
+                    ),
+                ),
+            ),
+            "admin3",
+        ),
+        (
+            dict(
+                query_kind="location_introversion",
+                start_date="2016-01-01",
+                end_date="2016-01-02",
+                aggregation_unit="admin3",
+            ),
+            "admin3",
+        ),
+        (
+            dict(
+                query_kind="dfs_metric_total_amount",
+                start_date="2016-01-01",
+                end_date="2016-01-02",
+                metric="amount",
+                aggregation_unit="admin3",
+            ),
+            "admin3",
+        ),
+        (
+            dict(
+                query_kind="trips_od_matrix",
+                start_date="2016-01-01",
+                end_date="2016-01-02",
+                aggregation_unit="admin1",
+            ),
+            "admin1",
+        ),
+        (
+            dict(
+                query_kind="consecutive_trips_od_matrix",
+                start_date="2016-01-01",
+                end_date="2016-01-02",
+                aggregation_unit="admin1",
+            ),
+            "admin1",
+        ),
+        (
+            dict(
+                query_kind="total_network_objects",
+                start_date="2016-01-01",
+                end_date="2016-01-02",
+                aggregation_unit="admin2",
+                total_by="day",
+            ),
+            "admin2",
+        ),
+        (
+            dict(
+                query_kind="aggregate_network_objects",
+                total_network_objects=dict(
+                    query_kind="total_network_objects",
+                    start_date="2016-01-01",
+                    end_date="2016-01-02",
+                    aggregation_unit="admin2",
+                    total_by="hour",
+                ),
+                statistic="avg",
+                aggregate_by="day",
+            ),
+            "admin2",
+        ),
+        (
+            {
+                "query_kind": "labelled_spatial_aggregate",
+                "locations": {
+                    "query_kind": "coalesced_location",
+                    "preferred_location": {
+                        "query_kind": "majority_location",
+                        "subscriber_location_weights": {
+                            "query_kind": "location_visits",
+                            "locations": [
+                                {
+                                    "query_kind": "daily_location",
+                                    "date": "2016-01-01",
+                                    "aggregation_unit": "admin3",
+                                    "method": "last",
+                                    "subscriber_subset": None,
+                                },
+                                {
+                                    "query_kind": "daily_location",
+                                    "date": "2016-01-02",
+                                    "aggregation_unit": "admin3",
+                                    "method": "last",
+                                    "subscriber_subset": None,
+                                },
+                            ],
+                        },
+                    },
+                    "fallback_location": {
+                        "query_kind": "majority_location",
+                        "subscriber_location_weights": {
+                            "query_kind": "location_visits",
+                            "locations": [
+                                {
+                                    "query_kind": "daily_location",
+                                    "date": "2016-01-01",
+                                    "aggregation_unit": "admin3",
+                                    "method": "last",
+                                    "subscriber_subset": None,
+                                },
+                                {
+                                    "query_kind": "daily_location",
+                                    "date": "2016-01-02",
+                                    "aggregation_unit": "admin3",
+                                    "method": "last",
+                                    "subscriber_subset": None,
+                                },
+                            ],
+                        },
+                    },
+                    "subscriber_location_weights": {
+                        "query_kind": "location_visits",
+                        "locations": [
+                            {
+                                "query_kind": "daily_location",
+                                "date": "2016-01-01",
+                                "aggregation_unit": "admin3",
+                                "method": "last",
+                                "subscriber_subset": None,
+                            },
+                            {
+                                "query_kind": "daily_location",
+                                "date": "2016-01-02",
+                                "aggregation_unit": "admin3",
+                                "method": "last",
+                                "subscriber_subset": None,
+                            },
+                        ],
+                    },
+                    "weight_threshold": 2,
+                },
+                "labels": {
+                    "query_kind": "mobility_classification",
+                    "locations": [
+                        {
+                            "query_kind": "coalesced_location",
+                            "preferred_location": {
+                                "query_kind": "majority_location",
+                                "subscriber_location_weights": {
+                                    "query_kind": "location_visits",
+                                    "locations": [
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-01",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-02",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                    ],
+                                },
+                            },
+                            "fallback_location": {
+                                "query_kind": "majority_location",
+                                "subscriber_location_weights": {
+                                    "query_kind": "location_visits",
+                                    "locations": [
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-01",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-02",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                    ],
+                                },
+                            },
+                            "subscriber_location_weights": {
+                                "query_kind": "location_visits",
+                                "locations": [
+                                    {
+                                        "query_kind": "daily_location",
+                                        "date": "2016-01-05",
+                                        "aggregation_unit": "admin3",
+                                        "method": "last",
+                                        "subscriber_subset": None,
+                                    },
+                                    {
+                                        "query_kind": "daily_location",
+                                        "date": "2016-01-06",
+                                        "aggregation_unit": "admin3",
+                                        "method": "last",
+                                        "subscriber_subset": None,
+                                    },
+                                ],
+                            },
+                            "weight_threshold": 2,
+                        },
+                        {
+                            "query_kind": "coalesced_location",
+                            "preferred_location": {
+                                "query_kind": "majority_location",
+                                "subscriber_location_weights": {
+                                    "query_kind": "location_visits",
+                                    "locations": [
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-01",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-02",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                    ],
+                                },
+                            },
+                            "fallback_location": {
+                                "query_kind": "majority_location",
+                                "subscriber_location_weights": {
+                                    "query_kind": "location_visits",
+                                    "locations": [
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-01",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-02",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                    ],
+                                },
+                            },
+                            "subscriber_location_weights": {
+                                "query_kind": "location_visits",
+                                "locations": [
+                                    {
+                                        "query_kind": "daily_location",
+                                        "date": "2016-01-01",
+                                        "aggregation_unit": "admin3",
+                                        "method": "last",
+                                        "subscriber_subset": None,
+                                    },
+                                    {
+                                        "query_kind": "daily_location",
+                                        "date": "2016-01-02",
+                                        "aggregation_unit": "admin3",
+                                        "method": "last",
+                                        "subscriber_subset": None,
+                                    },
+                                ],
+                            },
+                            "weight_threshold": 2,
+                        },
+                    ],
+                    "stay_length_threshold": 2,
+                },
+            },
+            "admin3",
+        ),
+        (
+            # TODO: Use a more compact 'labelled_flows' example once such a thing is exposed
+            {
+                "query_kind": "labelled_flows",
+                "from_location": {
+                    "query_kind": "coalesced_location",
+                    "preferred_location": {
+                        "query_kind": "majority_location",
+                        "subscriber_location_weights": {
+                            "query_kind": "location_visits",
+                            "locations": [
+                                {
+                                    "query_kind": "daily_location",
+                                    "date": "2016-01-01",
+                                    "aggregation_unit": "admin3",
+                                    "method": "last",
+                                    "subscriber_subset": None,
+                                },
+                                {
+                                    "query_kind": "daily_location",
+                                    "date": "2016-01-02",
+                                    "aggregation_unit": "admin3",
+                                    "method": "last",
+                                    "subscriber_subset": None,
+                                },
+                            ],
+                        },
+                    },
+                    "fallback_location": {
+                        "query_kind": "majority_location",
+                        "subscriber_location_weights": {
+                            "query_kind": "location_visits",
+                            "locations": [
+                                {
+                                    "query_kind": "daily_location",
+                                    "date": "2016-01-01",
+                                    "aggregation_unit": "admin3",
+                                    "method": "last",
+                                    "subscriber_subset": None,
+                                },
+                                {
+                                    "query_kind": "daily_location",
+                                    "date": "2016-01-02",
+                                    "aggregation_unit": "admin3",
+                                    "method": "last",
+                                    "subscriber_subset": None,
+                                },
+                            ],
+                        },
+                    },
+                    "subscriber_location_weights": {
+                        "query_kind": "location_visits",
+                        "locations": [
+                            {
+                                "query_kind": "daily_location",
+                                "date": "2016-01-01",
+                                "aggregation_unit": "admin3",
+                                "method": "last",
+                                "subscriber_subset": None,
+                            },
+                            {
+                                "query_kind": "daily_location",
+                                "date": "2016-01-02",
+                                "aggregation_unit": "admin3",
+                                "method": "last",
+                                "subscriber_subset": None,
+                            },
+                        ],
+                    },
+                    "weight_threshold": 2,
+                },
+                "to_location": {
+                    "query_kind": "coalesced_location",
+                    "preferred_location": {
+                        "query_kind": "majority_location",
+                        "subscriber_location_weights": {
+                            "query_kind": "location_visits",
+                            "locations": [
+                                {
+                                    "query_kind": "daily_location",
+                                    "date": "2016-01-03",
+                                    "aggregation_unit": "admin3",
+                                    "method": "last",
+                                    "subscriber_subset": None,
+                                },
+                                {
+                                    "query_kind": "daily_location",
+                                    "date": "2016-01-04",
+                                    "aggregation_unit": "admin3",
+                                    "method": "last",
+                                    "subscriber_subset": None,
+                                },
+                            ],
+                        },
+                    },
+                    "fallback_location": {
+                        "query_kind": "majority_location",
+                        "subscriber_location_weights": {
+                            "query_kind": "location_visits",
+                            "locations": [
+                                {
+                                    "query_kind": "daily_location",
+                                    "date": "2016-01-03",
+                                    "aggregation_unit": "admin3",
+                                    "method": "last",
+                                    "subscriber_subset": None,
+                                },
+                                {
+                                    "query_kind": "daily_location",
+                                    "date": "2016-01-04",
+                                    "aggregation_unit": "admin3",
+                                    "method": "last",
+                                    "subscriber_subset": None,
+                                },
+                            ],
+                        },
+                    },
+                    "subscriber_location_weights": {
+                        "query_kind": "location_visits",
+                        "locations": [
+                            {
+                                "query_kind": "daily_location",
+                                "date": "2016-01-03",
+                                "aggregation_unit": "admin3",
+                                "method": "last",
+                                "subscriber_subset": None,
+                            },
+                            {
+                                "query_kind": "daily_location",
+                                "date": "2016-01-04",
+                                "aggregation_unit": "admin3",
+                                "method": "last",
+                                "subscriber_subset": None,
+                            },
+                        ],
+                    },
+                    "weight_threshold": 2,
+                },
+                "labels": {
+                    "query_kind": "mobility_classification",
+                    "locations": [
+                        {
+                            "query_kind": "coalesced_location",
+                            "preferred_location": {
+                                "query_kind": "majority_location",
+                                "subscriber_location_weights": {
+                                    "query_kind": "location_visits",
+                                    "locations": [
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-01",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-02",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                    ],
+                                },
+                            },
+                            "fallback_location": {
+                                "query_kind": "majority_location",
+                                "subscriber_location_weights": {
+                                    "query_kind": "location_visits",
+                                    "locations": [
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-01",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-02",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                    ],
+                                },
+                            },
+                            "subscriber_location_weights": {
+                                "query_kind": "location_visits",
+                                "locations": [
+                                    {
+                                        "query_kind": "daily_location",
+                                        "date": "2016-01-05",
+                                        "aggregation_unit": "admin3",
+                                        "method": "last",
+                                        "subscriber_subset": None,
+                                    },
+                                    {
+                                        "query_kind": "daily_location",
+                                        "date": "2016-01-06",
+                                        "aggregation_unit": "admin3",
+                                        "method": "last",
+                                        "subscriber_subset": None,
+                                    },
+                                ],
+                            },
+                            "weight_threshold": 2,
+                        },
+                        {
+                            "query_kind": "coalesced_location",
+                            "preferred_location": {
+                                "query_kind": "majority_location",
+                                "subscriber_location_weights": {
+                                    "query_kind": "location_visits",
+                                    "locations": [
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-01",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-02",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                    ],
+                                },
+                            },
+                            "fallback_location": {
+                                "query_kind": "majority_location",
+                                "subscriber_location_weights": {
+                                    "query_kind": "location_visits",
+                                    "locations": [
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-01",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                        {
+                                            "query_kind": "daily_location",
+                                            "date": "2016-01-02",
+                                            "aggregation_unit": "admin3",
+                                            "method": "last",
+                                            "subscriber_subset": None,
+                                        },
+                                    ],
+                                },
+                            },
+                            "subscriber_location_weights": {
+                                "query_kind": "location_visits",
+                                "locations": [
+                                    {
+                                        "query_kind": "daily_location",
+                                        "date": "2016-01-01",
+                                        "aggregation_unit": "admin3",
+                                        "method": "last",
+                                        "subscriber_subset": None,
+                                    },
+                                    {
+                                        "query_kind": "daily_location",
+                                        "date": "2016-01-02",
+                                        "aggregation_unit": "admin3",
+                                        "method": "last",
+                                        "subscriber_subset": None,
+                                    },
+                                ],
+                            },
+                            "weight_threshold": 2,
+                        },
+                    ],
+                    "stay_length_threshold": 2,
+                },
+                "join_type": "full outer",
+            },
             "admin3",
         ),
     ],

--- a/flowmachine/tests/test_query_object_construction.py
+++ b/flowmachine/tests/test_query_object_construction.py
@@ -841,6 +841,88 @@ def test_construct_query(diff_reporter):
     diff_reporter(query_ids_and_specs_as_json_string)
 
 
+# TODO: Need one of these for every spatial aggregate kind
+@pytest.mark.parametrize(
+    "params, expected_aggregation_unit",
+    [
+        (
+            dict(
+                query_kind="spatial_aggregate",
+                locations=dict(
+                    query_kind="modal_location",
+                    locations=[
+                        dict(
+                            query_kind="daily_location",
+                            date="2016-01-01",
+                            method="last",
+                            aggregation_unit="admin3",
+                        )
+                    ],
+                ),
+            ),
+            "admin3",
+        ),
+        (
+            dict(
+                query_kind="flows",
+                from_location=dict(
+                    query_kind="visited_most_days",
+                    start_date="2016-01-01",
+                    end_date="2016-01-07",
+                    aggregation_unit="admin2",
+                ),
+                to_location=dict(
+                    query_kind="unique_locations",
+                    start_date="2016-01-07",
+                    end_date="2016-01-08",
+                    aggregation_unit="admin2",
+                ),
+            ),
+            "admin2",
+        ),
+        (
+            dict(
+                query_kind="unique_subscriber_counts",
+                start_date="2016-01-01",
+                end_date="2016-01-02",
+                aggregation_unit="lon-lat",
+            ),
+            "lon-lat",
+        ),
+        (
+            dict(
+                query_kind="joined_spatial_aggregate",
+                locations=dict(
+                    query_kind="daily_location",
+                    date="2016-01-01",
+                    method="last",
+                    aggregation_unit="admin3",
+                ),
+                metric=dict(
+                    query_kind="displacement",
+                    start_date="2016-01-01",
+                    end_date="2016-01-02",
+                    statistic="avg",
+                    reference_location=dict(
+                        query_kind="daily_location",
+                        date="2016-01-01",
+                        method="last",
+                        aggregation_unit="lon-lat",
+                    ),
+                ),
+            ),
+            "admin3",
+        ),
+    ],
+)
+def test_aggregation_unit_attribute(params, expected_aggregation_unit):
+    """
+    Test that spatially aggregated query kinds have the correct aggregation unit when deserialised
+    """
+    loaded_query = FlowmachineQuerySchema().load(params)
+    assert loaded_query.aggregation_unit.canonical_name == expected_aggregation_unit
+
+
 # TODO: we should re-think how we want to test invalid values, now that these are validated using marshmallow
 def test_wrong_geography_aggregation_unit_raises_error():
     """

--- a/integration_tests/tests/flowmachine_server_tests/test_server.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.py
@@ -248,3 +248,36 @@ def test_run_dfs_metric_total_amount_query(zmq_host, zmq_port):
     # occur when we reset the cache before the next test
     # (see https://github.com/Flowminder/FlowKit/issues/1245).
     poll_until_done(zmq_port, expected_query_id)
+
+
+def test_get_aggregation_unit(zmq_host, zmq_port):
+    """
+    'get_aggregation_unit' action returns correct aggregation unit
+    """
+    msg = {
+        "action": "get_aggregation_unit",
+        "params": {
+            "query_kind": "spatial_aggregate",
+            "locations": {
+                "query_kind": "modal_location",
+                "locations": [
+                    {
+                        "query_kind": "daily_location",
+                        "date": "2016-01-01",
+                        "method": "last",
+                        "aggregation_unit": "admin3",
+                    }
+                ],
+            },
+        },
+        "request_id": "DUMMY_ID",
+    }
+    reply = send_zmq_message_and_receive_reply(msg, port=zmq_port, host=zmq_host)
+    expected_reply = {
+        "status": "success",
+        "msg": "",
+        "payload": {
+            "aggregation_unit": "admin3",
+        },
+    }
+    assert expected_reply == reply

--- a/integration_tests/tests/flowmachine_server_tests/test_server.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.py
@@ -39,7 +39,7 @@ def test_unknown_action_returns_error(zmq_host, zmq_port):
         "msg": "Invalid action request.",
         "payload": {
             "action": [
-                "Must be one of: ping, get_available_queries, get_query_schemas, run_query, poll_query, get_query_kind, get_query_params, get_sql_for_query_result, get_geo_sql_for_query_result, get_geography, get_available_dates."
+                "Must be one of: ping, get_available_queries, get_query_schemas, run_query, poll_query, get_query_kind, get_query_params, get_sql_for_query_result, get_geo_sql_for_query_result, get_geography, get_available_dates, get_aggregation_unit."
             ]
         },
     }

--- a/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
@@ -1,6 +1,17 @@
 {
   "ActiveAtReferenceLocationCounts": {
     "properties": {
+      "aggregation_unit": {
+        "enum": [
+          "admin0",
+          "admin1",
+          "admin2",
+          "admin3",
+          "lon-lat"
+        ],
+        "readOnly": true,
+        "type": "string"
+      },
       "query_kind": {
         "enum": [
           "active_at_reference_location_counts"
@@ -35,6 +46,17 @@
         ],
         "type": "string"
       },
+      "aggregation_unit": {
+        "enum": [
+          "admin0",
+          "admin1",
+          "admin2",
+          "admin3",
+          "lon-lat"
+        ],
+        "readOnly": true,
+        "type": "string"
+      },
       "query_kind": {
         "enum": [
           "aggregate_network_objects"
@@ -60,6 +82,7 @@
       }
     },
     "required": [
+      "aggregate_by",
       "query_kind",
       "statistic",
       "total_network_objects"
@@ -484,6 +507,7 @@
   "EventCount": {
     "properties": {
       "direction": {
+        "default": "both",
         "enum": [
           "both",
           "in",
@@ -660,6 +684,17 @@
   },
   "Flows": {
     "properties": {
+      "aggregation_unit": {
+        "enum": [
+          "admin0",
+          "admin1",
+          "admin2",
+          "admin3",
+          "lon-lat"
+        ],
+        "readOnly": true,
+        "type": "string"
+      },
       "from_location": {
         "$ref": "#/components/schemas/InputToFlows"
       },
@@ -800,7 +835,9 @@
       }
     },
     "required": [
+      "characteristic",
       "end_date",
+      "method",
       "query_kind",
       "start_date"
     ],
@@ -825,6 +862,7 @@
       }
     },
     "required": [
+      "bins",
       "metric",
       "query_kind"
     ],
@@ -914,6 +952,17 @@
   },
   "Inflows": {
     "properties": {
+      "aggregation_unit": {
+        "enum": [
+          "admin0",
+          "admin1",
+          "admin2",
+          "admin3",
+          "lon-lat"
+        ],
+        "readOnly": true,
+        "type": "string"
+      },
       "from_location": {
         "$ref": "#/components/schemas/InputToFlows"
       },
@@ -1051,6 +1100,17 @@
   },
   "JoinedSpatialAggregate": {
     "properties": {
+      "aggregation_unit": {
+        "enum": [
+          "admin0",
+          "admin1",
+          "admin2",
+          "admin3",
+          "lon-lat"
+        ],
+        "readOnly": true,
+        "type": "string"
+      },
       "locations": {
         "$ref": "#/components/schemas/ReferenceLocation"
       },
@@ -1081,6 +1141,7 @@
     },
     "required": [
       "locations",
+      "method",
       "metric",
       "query_kind"
     ],
@@ -1088,6 +1149,17 @@
   },
   "LabelledFlows": {
     "properties": {
+      "aggregation_unit": {
+        "enum": [
+          "admin0",
+          "admin1",
+          "admin2",
+          "admin3",
+          "lon-lat"
+        ],
+        "readOnly": true,
+        "type": "string"
+      },
       "from_location": {
         "$ref": "#/components/schemas/CoalescedLocation"
       },
@@ -1126,6 +1198,17 @@
   },
   "LabelledSpatialAggregate": {
     "properties": {
+      "aggregation_unit": {
+        "enum": [
+          "admin0",
+          "admin1",
+          "admin2",
+          "admin3",
+          "lon-lat"
+        ],
+        "readOnly": true,
+        "type": "string"
+      },
       "labels": {
         "$ref": "#/components/schemas/MobilityClassification"
       },
@@ -1159,6 +1242,7 @@
         "type": "string"
       },
       "direction": {
+        "default": "both",
         "enum": [
           "both",
           "in",
@@ -1231,7 +1315,6 @@
     },
     "required": [
       "aggregation_unit",
-      "direction",
       "end_date",
       "interval",
       "query_kind",
@@ -1252,6 +1335,7 @@
         "type": "string"
       },
       "direction": {
+        "default": "both",
         "enum": [
           "both",
           "in",
@@ -1347,6 +1431,7 @@
       }
     },
     "required": [
+      "locations",
       "query_kind"
     ],
     "type": "object"
@@ -1448,9 +1533,11 @@
         "type": "string"
       },
       "tower_cluster_call_threshold": {
+        "default": 0,
         "type": "integer"
       },
       "tower_cluster_radius": {
+        "default": 1.0,
         "type": "number"
       },
       "tower_day_of_week_scores": {
@@ -1559,9 +1646,11 @@
         "type": "string"
       },
       "tower_cluster_call_threshold": {
+        "default": 0,
         "type": "integer"
       },
       "tower_cluster_radius": {
+        "default": 1.0,
         "type": "number"
       },
       "tower_day_of_week_scores": {
@@ -1588,6 +1677,7 @@
       "end_date_a",
       "end_date_b",
       "label",
+      "labels",
       "query_kind",
       "start_date_a",
       "start_date_b",
@@ -1666,9 +1756,11 @@
         "type": "string"
       },
       "tower_cluster_call_threshold": {
+        "default": 0,
         "type": "integer"
       },
       "tower_cluster_radius": {
+        "default": 1.0,
         "type": "number"
       },
       "tower_day_of_week_scores": {
@@ -1695,6 +1787,7 @@
       "end_date",
       "label_a",
       "label_b",
+      "labels",
       "query_kind",
       "start_date",
       "tower_day_of_week_scores",
@@ -1730,6 +1823,7 @@
       }
     },
     "required": [
+      "locations",
       "query_kind",
       "stay_length_threshold"
     ],
@@ -1760,6 +1854,7 @@
       }
     },
     "required": [
+      "locations",
       "query_kind"
     ],
     "type": "object"
@@ -1868,15 +1963,8 @@
         "nullable": true,
         "type": "array"
       },
-      "night_end_hour": {
-        "maximum": 23,
-        "minimum": 0,
-        "type": "integer"
-      },
-      "night_start_hour": {
-        "maximum": 23,
-        "minimum": 0,
-        "type": "integer"
+      "night_hours": {
+        "$ref": "#/components/schemas/Hours"
       },
       "query_kind": {
         "enum": [
@@ -1903,6 +1991,7 @@
     },
     "required": [
       "end_date",
+      "night_hours",
       "query_kind",
       "start_date"
     ],
@@ -1910,6 +1999,17 @@
   },
   "Outflows": {
     "properties": {
+      "aggregation_unit": {
+        "enum": [
+          "admin0",
+          "admin1",
+          "admin2",
+          "admin3",
+          "lon-lat"
+        ],
+        "readOnly": true,
+        "type": "string"
+      },
       "from_location": {
         "$ref": "#/components/schemas/InputToFlows"
       },
@@ -2188,6 +2288,7 @@
   "SubscriberDegree": {
     "properties": {
       "direction": {
+        "default": "both",
         "enum": [
           "both",
           "in",
@@ -2869,6 +2970,17 @@
       "active_at_reference_location_counts": {
         "$ref": "#/components/schemas/ActiveAtReferenceLocationCounts"
       },
+      "aggregation_unit": {
+        "enum": [
+          "admin0",
+          "admin1",
+          "admin2",
+          "admin3",
+          "lon-lat"
+        ],
+        "readOnly": true,
+        "type": "string"
+      },
       "query_kind": {
         "enum": [
           "unique_visitor_counts"
@@ -2888,6 +3000,17 @@
   },
   "UnmovingAtReferenceLocationCounts": {
     "properties": {
+      "aggregation_unit": {
+        "enum": [
+          "admin0",
+          "admin1",
+          "admin2",
+          "admin3",
+          "lon-lat"
+        ],
+        "readOnly": true,
+        "type": "string"
+      },
       "locations": {
         "$ref": "#/components/schemas/UniqueLocations"
       },
@@ -2910,6 +3033,17 @@
   },
   "UnmovingCounts": {
     "properties": {
+      "aggregation_unit": {
+        "enum": [
+          "admin0",
+          "admin1",
+          "admin2",
+          "admin3",
+          "lon-lat"
+        ],
+        "readOnly": true,
+        "type": "string"
+      },
       "locations": {
         "$ref": "#/components/schemas/UniqueLocations"
       },
@@ -2921,6 +3055,7 @@
       }
     },
     "required": [
+      "locations",
       "query_kind"
     ],
     "type": "object"

--- a/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
@@ -14,6 +14,11 @@
         "$ref": "#/components/schemas/UniqueLocations"
       }
     },
+    "required": [
+      "query_kind",
+      "reference_locations",
+      "unique_locations"
+    ],
     "type": "object"
   },
   "AggregateNetworkObjects": {
@@ -55,6 +60,7 @@
       }
     },
     "required": [
+      "query_kind",
       "statistic",
       "total_network_objects"
     ],
@@ -139,6 +145,7 @@
     "required": [
       "fallback_location",
       "preferred_location",
+      "query_kind",
       "subscriber_location_weights",
       "weight_threshold"
     ],
@@ -214,6 +221,7 @@
     "required": [
       "aggregation_unit",
       "end_date",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -258,6 +266,7 @@
       "aggregation_unit",
       "end_date",
       "metric",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -343,7 +352,8 @@
     "required": [
       "aggregation_unit",
       "date",
-      "method"
+      "method",
+      "query_kind"
     ],
     "type": "object"
   },
@@ -419,6 +429,8 @@
     },
     "required": [
       "end_date",
+      "query_kind",
+      "reference_location",
       "start_date",
       "statistic"
     ],
@@ -464,7 +476,8 @@
     },
     "required": [
       "aggregation_unit",
-      "dummy_param"
+      "dummy_param",
+      "query_kind"
     ],
     "type": "object"
   },
@@ -531,6 +544,7 @@
     },
     "required": [
       "end_date",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -673,6 +687,7 @@
     },
     "required": [
       "from_location",
+      "query_kind",
       "to_location"
     ],
     "type": "object"
@@ -709,7 +724,8 @@
       }
     },
     "required": [
-      "aggregation_unit"
+      "aggregation_unit",
+      "query_kind"
     ],
     "type": "object"
   },
@@ -785,6 +801,7 @@
     },
     "required": [
       "end_date",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -808,7 +825,8 @@
       }
     },
     "required": [
-      "metric"
+      "metric",
+      "query_kind"
     ],
     "type": "object"
   },
@@ -923,6 +941,7 @@
     },
     "required": [
       "from_location",
+      "query_kind",
       "to_location"
     ],
     "type": "object"
@@ -1062,7 +1081,8 @@
     },
     "required": [
       "locations",
-      "metric"
+      "metric",
+      "query_kind"
     ],
     "type": "object"
   },
@@ -1099,6 +1119,7 @@
     "required": [
       "from_location",
       "labels",
+      "query_kind",
       "to_location"
     ],
     "type": "object"
@@ -1120,7 +1141,8 @@
     },
     "required": [
       "labels",
-      "locations"
+      "locations",
+      "query_kind"
     ],
     "type": "object"
   },
@@ -1212,6 +1234,7 @@
       "direction",
       "end_date",
       "interval",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -1294,6 +1317,7 @@
     "required": [
       "aggregation_unit",
       "end_date",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -1322,6 +1346,9 @@
         "nullable": true
       }
     },
+    "required": [
+      "query_kind"
+    ],
     "type": "object"
   },
   "MajorityLocation": {
@@ -1349,6 +1376,7 @@
       }
     },
     "required": [
+      "query_kind",
       "subscriber_location_weights"
     ],
     "type": "object"
@@ -1449,6 +1477,7 @@
       "end_date",
       "label",
       "labels",
+      "query_kind",
       "start_date",
       "tower_day_of_week_scores",
       "tower_hour_of_day_scores"
@@ -1559,6 +1588,7 @@
       "end_date_a",
       "end_date_b",
       "label",
+      "query_kind",
       "start_date_a",
       "start_date_b",
       "tower_day_of_week_scores",
@@ -1665,6 +1695,7 @@
       "end_date",
       "label_a",
       "label_b",
+      "query_kind",
       "start_date",
       "tower_day_of_week_scores",
       "tower_hour_of_day_scores"
@@ -1699,6 +1730,7 @@
       }
     },
     "required": [
+      "query_kind",
       "stay_length_threshold"
     ],
     "type": "object"
@@ -1727,6 +1759,9 @@
         "nullable": true
       }
     },
+    "required": [
+      "query_kind"
+    ],
     "type": "object"
   },
   "MostFrequentLocation": {
@@ -1807,6 +1842,7 @@
     "required": [
       "aggregation_unit",
       "end_date",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -1867,6 +1903,7 @@
     },
     "required": [
       "end_date",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -1900,6 +1937,7 @@
     },
     "required": [
       "from_location",
+      "query_kind",
       "to_location"
     ],
     "type": "object"
@@ -1965,6 +2003,7 @@
     "required": [
       "end_date",
       "proportion",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -2024,6 +2063,7 @@
     },
     "required": [
       "end_date",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -2118,6 +2158,17 @@
   },
   "SpatialAggregate": {
     "properties": {
+      "aggregation_unit": {
+        "enum": [
+          "admin0",
+          "admin1",
+          "admin2",
+          "admin3",
+          "lon-lat"
+        ],
+        "readOnly": true,
+        "type": "string"
+      },
       "locations": {
         "$ref": "#/components/schemas/ReferenceLocation"
       },
@@ -2129,7 +2180,8 @@
       }
     },
     "required": [
-      "locations"
+      "locations",
+      "query_kind"
     ],
     "type": "object"
   },
@@ -2196,6 +2248,7 @@
     },
     "required": [
       "end_date",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -2286,6 +2339,7 @@
     },
     "required": [
       "end_date",
+      "query_kind",
       "start_date",
       "statistic"
     ],
@@ -2345,6 +2399,7 @@
     },
     "required": [
       "end_date",
+      "query_kind",
       "start_date",
       "statistic"
     ],
@@ -2408,6 +2463,7 @@
       }
     },
     "required": [
+      "query_kind",
       "start_date",
       "total_periods"
     ],
@@ -2495,6 +2551,7 @@
     "required": [
       "aggregation_unit",
       "end_date",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -2569,6 +2626,7 @@
     "required": [
       "aggregation_unit",
       "end_date",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -2643,6 +2701,7 @@
     "required": [
       "aggregation_unit",
       "end_date",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -2725,6 +2784,7 @@
     "required": [
       "aggregation_unit",
       "end_date",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -2799,6 +2859,7 @@
     "required": [
       "aggregation_unit",
       "end_date",
+      "query_kind",
       "start_date"
     ],
     "type": "object"
@@ -2818,6 +2879,11 @@
         "$ref": "#/components/schemas/UniqueSubscriberCounts"
       }
     },
+    "required": [
+      "active_at_reference_location_counts",
+      "query_kind",
+      "unique_subscriber_counts"
+    ],
     "type": "object"
   },
   "UnmovingAtReferenceLocationCounts": {
@@ -2835,6 +2901,11 @@
         "$ref": "#/components/schemas/ReferenceLocation"
       }
     },
+    "required": [
+      "locations",
+      "query_kind",
+      "reference_locations"
+    ],
     "type": "object"
   },
   "UnmovingCounts": {
@@ -2849,6 +2920,9 @@
         "type": "string"
       }
     },
+    "required": [
+      "query_kind"
+    ],
     "type": "object"
   },
   "VisitableLocation": {
@@ -2946,6 +3020,7 @@
     "required": [
       "aggregation_unit",
       "end_date",
+      "query_kind",
       "start_date"
     ],
     "type": "object"


### PR DESCRIPTION
Closes #5141, #4816

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [ ] Brought the branch up to date with master
- [ ] Added any relevant Github labels
- [x] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Adds a new flowmachine server action, `get_aggregation_unit`, which returns the aggregation unit associated with a spatial aggregate query (or `None` if the query is not a spatial aggregate). To support this, all exposed query class instances corresponding to a spatial aggregate query now have an `aggregation_unit` attribute or property.

Also adds a _dump-only_ `aggregation_unit` parameter to all spatial aggregates that do not have an explicit `aggregation_unit` parameter - a dump-only field is not accepted as an input parameter, but it is included in the API spec (marked as "read-only") so that FlowAPI can use this parameter to determine whether a query kind is a spatial aggregate when generating permission scopes. The dump-only `aggregation_unit` fields also mean that the `aggregation_unit` property of an exposed query will be included if the query is serialised - while that's a nice feature, it's not something we currently rely on for anything.

Adds a docs section on exposing a new query kind, since there are an increasing number of steps that need to be included in an exposed query.

Also a few changes to query schemas that are not directly related to the original aims of this PR:
- Defines `OneOfQuerySchema` (subclass of `OneOfSchema`) for nesting a choice of multiple sub-query schemas. Consequences are that all exposed query classes now need a `query_kind` class attribute, and we no longer need a workaround in FlowAPI to mark `query_kind` parameters as required.
- Fixes some custom validators so that errors in nested fields do not cause validation errors to be masked by key/attribute errors (#4816)
- Ensures that all required parameters are marked as such in the query schemas
- Defines a `Direction` field, to replace the duplicated code used for `direction` fields in several query schemas