### PR TITLE
Store prefect workflows within /mounts/outputs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -877,7 +877,7 @@ jobs:
       - attach_workspace:
           at: /home/circleci/
       - restore_cache:
-          key: flowkit-docs-deps-4-{{ checksum "Pipfile.lock" }}
+          key: flowkit-docs-deps-5-{{ checksum "Pipfile.lock" }}
       - run:
           name: Install pandoc
           command: |
@@ -971,7 +971,7 @@ jobs:
           path: /home/circleci/project/docs/pg_log.zip
           destination: pg_log
       - save_cache:
-          key: flowkit-docs-deps-4-{{ checksum "Pipfile.lock" }}
+          key: flowkit-docs-deps-5-{{ checksum "Pipfile.lock" }}
           paths:
             - /home/circleci/.local/share/virtualenvs/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,14 @@ commands:
       - run:
           name: Upload codecov
           command: |
-                  curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
-                  curl -Os https://uploader.codecov.io/latest/linux/codecov
-                  curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-                  curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-                  gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-                  shasum -a 256 -c codecov.SHA256SUM
-                  chmod +x codecov
-                  ./codecov <<parameters.test>>
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x codecov
+            ./codecov <<parameters.test>>
 
 defaults:
   - &base_docker
@@ -380,20 +380,19 @@ jobs:
           command: |
             docker push flowminder/flowdb-synthetic-data:${CIRCLE_SHA1}
 
-
   install_flowmachine_deps:
     docker: *base_docker
     working_directory: /home/circleci/project
     steps:
       - checkout
       - restore_cache:
-          key: flowmachine-deps-4-{{ checksum "flowmachine/Pipfile.lock" }}
+          key: flowmachine-deps-5-{{ checksum "flowmachine/Pipfile.lock" }}
       # Need to install graphviz and pygraphviz manually because it was removed from the Pipfile
       # (see https://github.com/Flowminder/FlowKit/issues/952)
       - run: cd flowmachine && pipenv install --dev --deploy && pipenv run pip install -e .
       - run: cd flowmachine && sudo apt-get update && sudo apt-get install -y libgraphviz-dev graphviz && pipenv run pip install pygraphviz
       - save_cache:
-          key: flowmachine-deps-4-{{ checksum "flowmachine/Pipfile.lock" }}
+          key: flowmachine-deps-5-{{ checksum "flowmachine/Pipfile.lock" }}
           paths:
             - /home/circleci/.local/share/virtualenvs/flowmachine-caaCcVrN
 
@@ -403,7 +402,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: flowmachine-deps-4-{{ checksum "flowmachine/Pipfile.lock" }}
+          key: flowmachine-deps-5-{{ checksum "flowmachine/Pipfile.lock" }}
       - run:
           name: Linting files with black
           # Installed the version of Black from flowmachine's lockfile
@@ -444,7 +443,7 @@ jobs:
       - attach_workspace:
           at: /home/circleci/
       - restore_cache:
-          key: flowmachine-deps-4-{{ checksum "Pipfile.lock" }}
+          key: flowmachine-deps-5-{{ checksum "Pipfile.lock" }}
       - run:
           name: Install graphviz
           command: sudo apt-get update && sudo apt-get install -y xvfb libgraphviz-dev graphviz
@@ -539,7 +538,6 @@ jobs:
       - upload_codecov:
           test: test_results
 
-
   run_flowauth_backend_tests:
     docker:
       - image: cimg/python:3.8
@@ -567,8 +565,6 @@ jobs:
           path: test_results
       - upload_codecov:
           test: test_results
-
-      
 
   run_flowauth_end_to_end_tests:
     docker:
@@ -638,8 +634,6 @@ jobs:
       - upload_codecov:
           test: test_results
 
-
-
   run_autoflow_tests:
     docker:
       - image: cimg/python:3.8.5
@@ -675,14 +669,19 @@ jobs:
       - upload_codecov:
           test: test_results
 
- 
-
   build_docker_image:
     parameters:
       component:
         type: enum
         enum:
-          ["flowmachine", "flowauth", "flowapi", "flowkit-examples", "flowetl", "autoflow"]
+          [
+            "flowmachine",
+            "flowauth",
+            "flowapi",
+            "flowkit-examples",
+            "flowetl",
+            "autoflow",
+          ]
       component_path:
         type: string
     machine:
@@ -716,7 +715,7 @@ jobs:
       - checkout:
           path: /home/circleci/project/
       - restore_cache:
-          key: flowetl-unit-deps-4-{{ checksum "Pipfile.lock"}}
+          key: flowetl-unit-deps-5-{{ checksum "Pipfile.lock"}}
       - run:
           name: Install pipenv
           command: pip install --upgrade pipenv
@@ -725,7 +724,7 @@ jobs:
           command: |
             pipenv install --deploy --dev
       - save_cache:
-          key: flowetl-unit-deps-4-{{ checksum "Pipfile.lock" }}
+          key: flowetl-unit-deps-5-{{ checksum "Pipfile.lock" }}
           paths:
             - /home/circleci/.local/share/virtualenvs/
       - run:
@@ -750,7 +749,7 @@ jobs:
       - checkout:
           path: /home/circleci/project/
       - restore_cache:
-          key: flowetl-deps-4-{{ checksum "Pipfile.lock"}}
+          key: flowetl-deps-5-{{ checksum "Pipfile.lock"}}
       - run:
           name: Set python version
           command: |
@@ -768,7 +767,7 @@ jobs:
           command: |
             sudo apt-get update && sudo apt-get install -y postgresql
       - save_cache:
-          key: flowetl-deps-4-{{ checksum "Pipfile.lock" }}
+          key: flowetl-deps-5-{{ checksum "Pipfile.lock" }}
           paths:
             - /home/circleci/.local/share/virtualenvs/
       - run:
@@ -802,7 +801,7 @@ jobs:
           key: integration-test-deps-4-{{ checksum "Pipfile.lock" }}
       - when:
           condition:
-            equal: [ "not query_tests", << parameters.pytest_selector >> ]
+            equal: ["not query_tests", << parameters.pytest_selector >>]
           steps:
             - run: *install_autoflow_deps
       - run: pipenv install --deploy --dev
@@ -1173,7 +1172,12 @@ workflows:
       - integration_tests:
           matrix:
             parameters:
-              pytest_selector: ["query_tests and ASyncConnection", "query_tests and not ASyncConnection", "not query_tests"]
+              pytest_selector:
+                [
+                  "query_tests and ASyncConnection",
+                  "query_tests and not ASyncConnection",
+                  "not query_tests",
+                ]
           requires:
             - install_flowmachine_deps
             - build_flowdb_testdata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fixed a potential deadlock when using a small connection pool and `store`-ing queries
+- AutoFlow can now be run in a docker container with non-default user. [#5574](https://github.com/Flowminder/FlowKit/issues/5574)
 
 ### Removed
 

--- a/autoflow/autoflow/app.py
+++ b/autoflow/autoflow/app.py
@@ -61,8 +61,11 @@ def main(run_on_schedule: bool = True):
 
     # Create workflows according to workflow definition file
     inputs_dir = os.environ["AUTOFLOW_INPUTS_DIR"]
+    workflow_storage_dir = str(outputs_path / ".prefect/flows")
     logger.info(f"Creating workflows defined in '{Path(inputs_dir)/'workflows.yml'}'.")
-    workflow_storage, sensor_config = parse_workflows_yaml("workflows.yml", inputs_dir)
+    workflow_storage, sensor_config = parse_workflows_yaml(
+        "workflows.yml", inputs_dir, workflow_storage_dir
+    )
 
     # Run available dates sensor
     logger.info("Running available dates sensor.")

--- a/autoflow/autoflow/parser/workflow_schema.py
+++ b/autoflow/autoflow/parser/workflow_schema.py
@@ -34,7 +34,6 @@ class WorkflowSchema(Schema):
 
     name = fields.String(required=True)
     notebooks = NotebooksField(required=True)
-    storage_path = fields.String(required=False)
 
     @validates_schema(pass_many=True)
     def check_for_duplicate_names(self, data, many, **kwargs):
@@ -63,8 +62,7 @@ class WorkflowSchema(Schema):
 
         if not many:
             data = [data]
-        storage_path = data[0].get("storage_path")
-        workflow_storage = storage.Local(directory=storage_path)
+        workflow_storage = storage.Local(directory=self.context["workflow_storage_dir"])
         for workflow_spec in data:
             workflow = make_notebooks_workflow(**workflow_spec)
             workflow_storage.add_flow(workflow)

--- a/autoflow/tests/schema_tests/test_workflow_schema.py
+++ b/autoflow/tests/schema_tests/test_workflow_schema.py
@@ -10,7 +10,7 @@ from prefect import storage
 from autoflow.parser.workflow_schema import WorkflowSchema
 
 
-def test_workflow_schema(monkeypatch):
+def test_workflow_schema(monkeypatch, tmp_path):
     """
     Test that WorkflowSchema loads a workflow specification as a Storage object
     containing the defined flow.
@@ -20,14 +20,17 @@ def test_workflow_schema(monkeypatch):
         "name": "DUMMY_WORKFLOW",
         "notebooks": {"notebook1": {"filename": "NOTEBOOK1.ipynb"}},
     }
-    workflow_storage = WorkflowSchema(context={"inputs_dir": "DUMMY_INPUTS_DIR"}).load(
-        workflow
-    )
+    workflow_storage = WorkflowSchema(
+        context={
+            "inputs_dir": "DUMMY_INPUTS_DIR",
+            "workflow_storage_dir": str(tmp_path),
+        }
+    ).load(workflow)
     assert isinstance(workflow_storage, storage.Storage)
     assert "DUMMY_WORKFLOW" in workflow_storage
 
 
-def test_workflow_schema_missing_name(monkeypatch):
+def test_workflow_schema_missing_name(monkeypatch, tmp_path):
     """
     Test that WorkflowSchema raises a ValidationError if the 'name' field is missing.
     """
@@ -35,12 +38,15 @@ def test_workflow_schema_missing_name(monkeypatch):
     workflow = {"notebooks": {"notebook1": {"filename": "NOTEBOOK1.ipynb"}}}
     with pytest.raises(ValidationError) as exc_info:
         workflow_storage = WorkflowSchema(
-            context={"inputs_dir": "DUMMY_INPUTS_DIR"}
+            context={
+                "inputs_dir": "DUMMY_INPUTS_DIR",
+                "workflow_storage_dir": str(tmp_path),
+            }
         ).load(workflow)
     assert "Missing data for required field." in exc_info.value.messages["name"]
 
 
-def test_workflow_schema_invalid_name(monkeypatch):
+def test_workflow_schema_invalid_name(monkeypatch, tmp_path):
     """
     Test that WorkflowSchema raises a ValidationError if the 'name' field is not a string.
     """
@@ -51,12 +57,15 @@ def test_workflow_schema_invalid_name(monkeypatch):
     }
     with pytest.raises(ValidationError) as exc_info:
         workflow_storage = WorkflowSchema(
-            context={"inputs_dir": "DUMMY_INPUTS_DIR"}
+            context={
+                "inputs_dir": "DUMMY_INPUTS_DIR",
+                "workflow_storage_dir": str(tmp_path),
+            }
         ).load(workflow)
     assert "Not a valid string." in exc_info.value.messages["name"]
 
 
-def test_workflow_schema_missing_notebooks(monkeypatch):
+def test_workflow_schema_missing_notebooks(monkeypatch, tmp_path):
     """
     Test that WorkflowSchema raises a ValidationError if the 'notebooks' field is missing.
     """
@@ -64,12 +73,15 @@ def test_workflow_schema_missing_notebooks(monkeypatch):
     workflow = {"name": "DUMMY_WORKFLOW"}
     with pytest.raises(ValidationError) as exc_info:
         workflow_storage = WorkflowSchema(
-            context={"inputs_dir": "DUMMY_INPUTS_DIR"}
+            context={
+                "inputs_dir": "DUMMY_INPUTS_DIR",
+                "workflow_storage_dir": str(tmp_path),
+            }
         ).load(workflow)
     assert "Missing data for required field." in exc_info.value.messages["notebooks"]
 
 
-def test_workflow_schema_many(monkeypatch):
+def test_workflow_schema_many(monkeypatch, tmp_path):
     """
     Test that WorkflowSchema can load multiple workflow specifications as a
     single Storage object.
@@ -86,14 +98,18 @@ def test_workflow_schema_many(monkeypatch):
         },
     ]
     workflow_storage = WorkflowSchema(
-        many=True, context={"inputs_dir": "DUMMY_INPUTS_DIR"}
+        many=True,
+        context={
+            "inputs_dir": "DUMMY_INPUTS_DIR",
+            "workflow_storage_dir": str(tmp_path),
+        },
     ).load(workflows)
     assert isinstance(workflow_storage, storage.Storage)
     assert "DUMMY_WORKFLOW_1" in workflow_storage
     assert "DUMMY_WORKFLOW_2" in workflow_storage
 
 
-def test_workflow_schema_duplicate_name(monkeypatch):
+def test_workflow_schema_duplicate_name(monkeypatch, tmp_path):
     """
     Test that WorkflowSchema raises a ValidationError if multiple workflows
     have the same name.
@@ -115,7 +131,11 @@ def test_workflow_schema_duplicate_name(monkeypatch):
     ]
     with pytest.raises(ValidationError) as exc_info:
         workflow_storage = WorkflowSchema(
-            many=True, context={"inputs_dir": "DUMMY_INPUTS_DIR"}
+            many=True,
+            context={
+                "inputs_dir": "DUMMY_INPUTS_DIR",
+                "workflow_storage_dir": str(tmp_path),
+            },
         ).load(workflows)
     assert "Duplicate workflow name." in exc_info.value.messages[1]["name"]
     assert "Duplicate workflow name." in exc_info.value.messages[2]["name"]

--- a/autoflow/tests/test_parser.py
+++ b/autoflow/tests/test_parser.py
@@ -66,7 +66,9 @@ def test_parse_workflows_yaml(tmp_path):
         )
     )
     workflow_storage, sensor_config = parse_workflows_yaml(
-        filename="dummy_input.yml", inputs_dir=str(tmp_path)
+        filename="dummy_input.yml",
+        inputs_dir=str(tmp_path),
+        workflow_storage_dir=str(tmp_path / ".prefect/flows"),
     )
     assert isinstance(workflow_storage, storage.Storage)
     assert "workflow1" in workflow_storage
@@ -105,7 +107,9 @@ def test_parse_workflows_yaml_missing_workflows(tmp_path):
         ValueError, match="Input file does not have a 'workflows' section."
     ):
         workflow_storage, sensor_config = parse_workflows_yaml(
-            filename="dummy_input.yml", inputs_dir=str(tmp_path)
+            filename="dummy_input.yml",
+            inputs_dir=str(tmp_path),
+            workflow_storage_dir=str(tmp_path / ".prefect/flows"),
         )
 
 
@@ -131,5 +135,7 @@ def test_parse_workflows_yaml_missing_available_dates_sensor(tmp_path):
         match="Input file does not have an 'available_dates_sensor' section.",
     ):
         workflow_storage, sensor_config = parse_workflows_yaml(
-            filename="dummy_input.yml", inputs_dir=str(tmp_path)
+            filename="dummy_input.yml",
+            inputs_dir=str(tmp_path),
+            workflow_storage_dir=str(tmp_path / ".prefect/flows"),
         )


### PR DESCRIPTION
Closes #5574

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

- Changes the AutoFlow `WorkflowSchema` so that the storage directory is specified once via a context parameter (as is the case for inputs_dir)
- Uses `<outputs_dir>/.prefect/flows` as the storage directory, as this should always be readable and writable by the autoflow user.