### PR TITLE
Rebuild rolescopepicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- RoleScopePicker component redesigned and reimplemented.
 
 ### Fixed
 - Fixed a potential deadlock when using a small connection pool and `store`-ing queries

--- a/flowauth/frontend/src/RoleScopePicker.cy.jsx
+++ b/flowauth/frontend/src/RoleScopePicker.cy.jsx
@@ -1,102 +1,110 @@
-import RoleScopePicker from './RoleScopePicker'
+/* eslint-disable no-undef */
+/* eslint-disable react/react-in-jsx-scope */
+import RoleScopePicker from "./RoleScopePicker"
 
 //Need a dummy set of server scopes
 //and a dummy set of existing role scopes
 //
 
 
-describe('<RoleScopePicker>', () => {
-	it('mounts', () => {
-		cy.intercept({
-				method: 'GET',
-				url: '/admin/servers/1/scopes', 
-			},
-			[
-				{
-					"enabled": true,
-					"id": 1,
-					"name": "admin0:dummy_query:dummy_nested_query"
-				},
-				{
-					"enabled": true,
-					"id": 3,
-					"name": "admin0:dummy_query:inner_dummy_query"
-				},
-				{
-					"enabled": true,
-					"id": 5,
-					"name": "get_results"
-				}
-			]
-		).as('getServerScopes');
+describe("<RoleScopePicker>", () => {
+  it("mounts", () => {
+    cy.intercept({
+      method: "GET",
+      url: "/admin/servers/1/scopes", 
+    },
+    [
+      {
+        "enabled": true,
+        "id": 1,
+        "name": "admin0:dummy_query:dummy_nested_query"
+      },
+      {
+        "enabled": true,
+        "id": 3,
+        "name": "admin0:dummy_query:inner_dummy_query"
+      },
+      {
+        "enabled": true,
+        "id": 4,
+        "name": "admin1:dummy_query:inner_dummy_query"
+      },
+      {
+        "enabled": true,
+        "id": 5,
+        "name": "get_results"
+      }
+    ]
+    ).as("getServerScopes");
 
-		cy.intercept({
-			method: 'GET',
-			url:'/roles/1/scopes'
-		},
-		[{
-			"id": 3,
-			"name": "admin0:dummy_query:inner_dummy_query",
-		},
-		{
-			"id":1,
-			"name":"admin0:dummy_query:dummy_nested_query"
-		},
-		{
-			"id":7,
-			"name":"get_results"
-		}
-	]
-		).as('getRoleScopes');
+    cy.intercept({
+      method: "GET",
+      url:"/roles/1/scopes"
+    },
+    [{
+      "id": 3,
+      "name": "admin0:dummy_query:inner_dummy_query",
+    },
+    {
+      "id":1,
+      "name":"admin0:dummy_query:dummy_nested_query"
+    },
+    {
+      "id":7,
+      "name":"get_results"
+    }
+    ]
+    ).as("getRoleScopes");
 				
-		cy.mount(<RoleScopePicker
-				updateScopes={()=>{}}
-				server_id = {1}
-				role_id = {1}
-			/>);
-		cy.wait("@getServerScopes")
-		cy.wait("@getRoleScopes")
-		cy.get('.rs-picker-toggle-value > span').should("include.text", "admin0 (All), get_results")
-	}),
+    cy.mount(<RoleScopePicker
+      updateScopes={()=>{}}
+      server_id = {1}
+      role_id = {1}
+    />);
+    cy.wait("@getServerScopes")
+    cy.wait("@getRoleScopes")
+    cy.get(".rs-picker-toggle-value > span").should("include.text", "admin0 (All), get_results")
+  })
 
-	it('respects deeply nested loading differences', () => {
-		cy.intercept({
-				method: 'GET',
-				url: '/admin/servers/1/scopes', 
-			},
-			[
-				{
-					"enabled": true,
-					"id": 1,
-					"name": "admin0:dummy_query:other_query"
-				},
-				{
-					"enabled": true,
-					"id": 3,
-					"name": "admin0:dummy_query:dummy_query"
-				}
-			]
-		).as('getServerScopes');
+  // it("respects deeply nested loading differences", () => {
+  //   cy.intercept({
+  //     method: "GET",
+  //     url: "/admin/servers/1/scopes", 
+  //   },
+  //   [
+  //     {
+  //       "enabled": true,
+  //       "id": 1,
+  //       "name": "admin0:dummy_query:other_query"
+  //     },
+  //     {
+  //       "enabled": true,
+  //       "id": 3,
+  //       "name": "admin0:dummy_query:dummy_query"
+  //     }
+  //   ]
+  //   ).as("getServerScopes");
 
-		cy.intercept({
-			method: 'GET',
-			url:'/roles/1/scopes'
-		},
-		[{
-			"id": 3,
-			"name": "admin0:dummy_query:dummy_query",
-		},
-	]
-		).as('getRoleScopes');
+  //   cy.intercept({
+  //     method: "GET",
+  //     url:"/roles/1/scopes"
+  //   },
+  //   [{
+  //     "id": 3,
+  //     "name": "admin0:dummy_query:dummy_query",
+  //   },
+  //   ]
+  //   ).as("getRoleScopes");
 				
-		cy.mount(<RoleScopePicker
-				updateScopes={()=>{}}
-				server_id = {1}
-				role_id = {1}
-			/>);
-		cy.wait("@getServerScopes")
-		cy.wait("@getRoleScopes")
-		cy.get('.rs-picker-toggle-value > span').should("include.text", "admin0:dummy_query:dummy_query")
-	})
-})
+  //   cy.mount(<RoleScopePicker
+  //     updateScopes={()=>{}}
+  //     server_id = {1}
+  //     role_id = {1}
+  //   />);
+  //   cy.wait("@getServerScopes")
+  //   cy.wait("@getRoleScopes")
+  //   cy.get(".rs-picker-toggle-value > span").should("include.text", "admin0:dummy_query:dummy_query")
+  // })
+}
+)
 

--- a/flowauth/frontend/src/RoleScopePicker.cy.jsx
+++ b/flowauth/frontend/src/RoleScopePicker.cy.jsx
@@ -17,7 +17,7 @@ describe("<RoleScopePicker>", () => {
       {
         "enabled": true,
         "id": 1,
-        "name": "admin0:dummy_query:dummy_nested_query"
+        "name": "admin0:dummy_query:dummy_nested_query:silly_query"
       },
       {
         "enabled": true,
@@ -26,12 +26,17 @@ describe("<RoleScopePicker>", () => {
       },
       {
         "enabled": true,
+        "id": 6,
+        "name": "admin0:other_query:inner_dummy_query"
+      },
+      {
+        "enabled": true,
         "id": 4,
         "name": "admin1:dummy_query:inner_dummy_query"
       },
       {
         "enabled": true,
-        "id": 5,
+        "id": 7,
         "name": "get_results"
       }
     ]
@@ -75,7 +80,7 @@ describe("<RoleScopePicker>", () => {
   //     {
   //       "enabled": true,
   //       "id": 1,
-  //       "name": "admin0:dummy_query:other_query"
+  //       "name": "admin0:dummy_query:other_query:silly_query"
   //     },
   //     {
   //       "enabled": true,

--- a/flowauth/frontend/src/RoleScopePicker.cy.jsx
+++ b/flowauth/frontend/src/RoleScopePicker.cy.jsx
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* eslint-disable quotes */
 /* eslint-disable no-undef */
 /* eslint-disable react/react-in-jsx-scope */

--- a/flowauth/frontend/src/RoleScopePicker.jsx
+++ b/flowauth/frontend/src/RoleScopePicker.jsx
@@ -42,7 +42,7 @@ function ScopeItem(props) {
   // When an inner scope item is checked, use flipScopeCallback to
   // flip the scope with scope.key in the root of the component
   const onClick = () => {
-    flipScopeCallback(scope.key, !scope.enabled)
+    flipScopeCallback([scope.key], !scope.enabled)
   }
 
   useEffect(() => {
@@ -94,9 +94,7 @@ function NestedScopeList(props) {
     } else {
       is_checked = !isChecked
     }
-    inner_scopes.forEach(s => {
-      flipScopeCallback(s.key, is_checked)
-    })  
+    flipScopeCallback(inner_scopes.map(s => s.key), is_checked) 
   }
 
   return <ListItem  className={classes[".MuiListItem-root"]}>
@@ -194,9 +192,10 @@ function RoleScopePicker (props) {
   )
 
   // Callback that flips all checkboxes
-  const flipScope = (changed_scope_name, enabled) => {
-    console.debug(`Flipping ${changed_scope_name} to ${enabled} from RoleScopeCallback`)
-    const new_scopes = checkedScopes.map(s => changed_scope_name === s.name ? {"name":s.name, "key":s.key, "enabled":enabled} : s)
+  const flipScopes = (changed_scope_names, enabled) => {
+    console.debug(`Flipping ${changed_scope_names} to ${enabled} from RoleScopeCallback`)
+    const new_scopes = checkedScopes.map(s => changed_scope_names.includes(s.name) ? {"name":s.name, "key":s.key, "enabled":enabled} : s)
+    console.log("New scopes:", new_scopes)
     setCheckedScopes(new_scopes)
   }
 
@@ -207,7 +206,7 @@ function RoleScopePicker (props) {
     }, [checkedScopes]
   )
 
-  return <ScopeList scopes = {checkedScopes} flipScopeCallback = {flipScope} />
+  return <ScopeList scopes = {checkedScopes} flipScopeCallback = {flipScopes} />
 }
 
 export default RoleScopePicker

--- a/flowauth/frontend/src/RoleScopePicker.jsx
+++ b/flowauth/frontend/src/RoleScopePicker.jsx
@@ -13,7 +13,6 @@ import { getServerScopes, getRoleScopes } from "./util/api";
 import { List, ListItem, Checkbox, ListItemIcon, ListItemText, Collapse, Button} from "@material-ui/core"
 import { ExpandLess, ExpandMore} from "@material-ui/icons";
 import { makeStyles } from "@material-ui/core/styles"
-//import {scopesGraph, jsonify, highest_common_roots} from "./util/util"
 
 const useStyles = makeStyles((theme) => ({
   ".MuiListItem-root": {
@@ -49,7 +48,12 @@ function ScopeItem(props) {
     setIsChecked(scope.enabled)
   }, [scope])
 
-  return <ListItem key={scope.key} value={scope.enabled} onClick={onClick}>
+  return <ListItem 
+    key={scope.key}
+    value={scope.enabled} 
+    onClick={onClick}
+    data-cy={`scope-item-${scope.key}`}
+  >
     <ListItemIcon>
       <Checkbox checked ={isChecked} />
     </ListItemIcon>
@@ -61,7 +65,7 @@ function ScopeItem(props) {
 function NestedScopeList(props) {
   const classes = useStyles()
   const {outer_scope, inner_scopes, flipScopeCallback} = props
-  const [open, setOpen] = useState(true) //remember to put this back to false
+  const [open, setOpen] = useState(false) //remember to put this back to false
   const [isChecked, setIsChecked] = useState(false)
   const [isIndeterminant, setIsIndeterminant] = useState(false)
 
@@ -97,17 +101,25 @@ function NestedScopeList(props) {
     flipScopeCallback(inner_scopes.map(s => s.key), is_checked) 
   }
 
-  return <ListItem  className={classes[".MuiListItem-root"]}>
+  return <ListItem 
+    className={classes[".MuiListItem-root"]}
+    data-cy={`nested-${outer_scope}`}
+  >
     <div className={classes[".CollapsibleScope"]}>
-      <Checkbox checked={isChecked} indeterminate={isIndeterminant} onClick={handleCheckboxClick} />
+      <Checkbox 
+        checked={isChecked}
+        indeterminate={isIndeterminant}
+        onClick={handleCheckboxClick} 
+        data-cy={"checkbox"}
+      />
       <ListItemText primary = {outer_scope} />
-      <Button onClick={handleChevronClick}>
+      <Button onClick={handleChevronClick} data-cy={"chevron"}>
         {open ? <ExpandLess className={classes[".MuiSvgIcon-root"]} /> : <ExpandMore className={classes[".MuiSvgIcon-root"]} />}
       </Button>
     </div>
     <Collapse in={open}>
       <ScopeList scopes = {inner_scopes} flipScopeCallback={flipScopeCallback}/>
-    </Collapse>
+    </Collapse> 
   </ListItem>
 }
 
@@ -142,7 +154,11 @@ function ScopeList (props) {
     setNestedScopes(nested_scopes)
   }, [scopes])
 
-  return <List disablePadding className = {classes[".MuiListItem-root"]}>
+  return <List 
+    disablePadding
+    className = {classes[".MuiListItem-root"]}
+    data-cy = {`scope-list-${flatScopes[0] ? flatScopes[0].key : ""}`}
+  >
     {flatScopes.map(scope => 
       <ScopeItem 
         scope = {scope}

--- a/flowauth/frontend/src/RoleScopePicker.jsx
+++ b/flowauth/frontend/src/RoleScopePicker.jsx
@@ -8,6 +8,7 @@ import {useEffect, useState} from "react"
 import { Grid } from "rsuite";
 import { getServerScopes, getRoleScopes } from "./util/api";
 import { List, ListItem, Checkbox, ListItemIcon, ListItemText} from "@material-ui/core"
+import cs from "date-fns/esm/locale/cs/index.js";
 //import {scopesGraph, jsonify, highest_common_roots} from "./util/util"
 
 function ScopeItem(props) {
@@ -20,6 +21,12 @@ function ScopeItem(props) {
   </ListItem>
 }
 
+function NestedScopeList(props) {
+  const {nested_scopes} = props
+
+  return <ListItem key = {"foo"} />
+}
+
 function ScopeList (props) {
   const {scopes} = props
   const [flatScopes, setFlatScopes] = useState([])
@@ -29,14 +36,28 @@ function ScopeList (props) {
   useEffect(() => {
     console.debug("Scopes", scopes)
     setFlatScopes(scopes.filter(s => !s.name.includes(":")))
-    setNestedScopes(scopes.filter(s => s.name.includes(":")))
+    const complex_scopes = scopes.filter(s => s.name.includes(":"))
+    // If Array.prototype.group() existed it would be ideal here...
+    const tl_scopes = [...new Set(complex_scopes.map(s => s.name.split(":")[0]))]
+    console.debug(tl_scopes)
+    const nested_scopes = tl_scopes.map(
+      ts => new Object({[ts]:
+        complex_scopes
+          .filter(cs => cs.name.startsWith(ts))
+          .map(cs => new Object({
+            "name": cs.name.replace(ts, cs.name),
+            "enabled": cs.enabled
+          }))
+      })
+    )
+    console.debug(nested_scopes)
   }, [scopes])
 
   return <List>
     {flatScopes.map(
       scope => <ScopeItem scope_name = {scope.name} key={scope.name} is_checked={scope.enabled}/>
     )}
-    {/* map<ScopeList scopes={nested_scopes} /> */}
+    {/* map<NestedScopeList scopes={nested_scopes} /> */}
   </List>
 }
 

--- a/flowauth/frontend/src/RoleScopePicker.jsx
+++ b/flowauth/frontend/src/RoleScopePicker.jsx
@@ -7,9 +7,23 @@ import React from "react";
 import {useEffect, useState} from "react"
 import { Grid } from "rsuite";
 import { getServerScopes, getRoleScopes } from "./util/api";
-import { List, ListItem, Checkbox, ListItemIcon, ListItemText, Collapse} from "@material-ui/core"
+import { List, ListItem, Checkbox, ListItemIcon, ListItemText, Collapse, Button} from "@material-ui/core"
 import { ExpandLess, ExpandMore} from "@material-ui/icons";
+import { makeStyles } from "@material-ui/core/styles"
 //import {scopesGraph, jsonify, highest_common_roots} from "./util/util"
+
+const useStyles = makeStyles((theme) => ({
+  ".MuiListItem-root": {
+    "flex-direction": "column",
+    "align-items": "self-start"
+  },
+  ".CollapsibleScope":{
+    "display":"flex"
+  },
+  ".MuiSvgIcon-root": {
+    "margin":"4px 0"
+  }
+}));
 
 function ScopeItem(props) {
   var {scope_name, init_check, onChangeCallback} = props
@@ -34,6 +48,7 @@ function ScopeItem(props) {
 
 
 function NestedScopeList(props) {
+  const classes = useStyles()
   const {outer_scope, inner_scopes, onChangeCallback} = props
   const [open, setOpen] = useState(false)
   const handleClick = () =>{
@@ -44,17 +59,25 @@ function NestedScopeList(props) {
     onChangeCallback(outer_scope + ":" + inner_scope)
   }
 
-  return <ListItem button onClick={handleClick}>
-    <ListItemText primary = {outer_scope} />
-    {open ? <ExpandLess /> : <ExpandMore />}
+  return <ListItem  className={classes[".MuiListItem-root"]}>
+    <div className={classes[".CollapsibleScope"]}>
+      <ListItemText primary = {outer_scope} >
+      </ListItemText>
+      <Button onClick={handleClick}>
+        {open ? <ExpandLess className={classes[".MuiSvgIcon-root"]} /> : <ExpandMore className={classes[".MuiSvgIcon-root"]} />}
+      </Button>
+      
+    </div>
     <Collapse in={open}>
       <ScopeList scopes = {inner_scopes} onChangeCallback = {newCallback}/>
     </Collapse>
+
   </ListItem>
 }
 
 
 function ScopeList (props) {
+  const classes = useStyles();
   const {scopes, onChangeCallback} = props
   const [flatScopes, setFlatScopes] = useState([])
   const [nestedScopes, setNestedScopes] = useState([])
@@ -82,7 +105,9 @@ function ScopeList (props) {
     setNestedScopes(nested_scopes)
   }, [scopes])
 
-  return <List disablePadding>
+  return <List 
+    disablePadding
+    className = {classes[".MuiListItem-root"]}>
     {flatScopes.map(
       scope => <ScopeItem 
         scope_name = {scope.name}
@@ -100,6 +125,7 @@ function ScopeList (props) {
 
 // Component for picking scopes for a role
 function RoleScopePicker (props) {
+
   const {role_id, server_id, updateScopes} = props
   const [checkedScopes, setCheckedScopes] = useState([])
   const [hasError, setHasError] = useState(false)

--- a/flowauth/frontend/src/RoleScopePicker.jsx
+++ b/flowauth/frontend/src/RoleScopePicker.jsx
@@ -7,80 +7,114 @@ import React from "react";
 import {useEffect, useState} from "react"
 import { Grid } from "rsuite";
 import { getServerScopes, getRoleScopes } from "./util/api";
-import { List, ListItem, Checkbox, ListItemIcon, ListItemText} from "@material-ui/core"
-import cs from "date-fns/esm/locale/cs/index.js";
+import { List, ListItem, Checkbox, ListItemIcon, ListItemText, Collapse} from "@material-ui/core"
+import { ExpandLess, ExpandMore} from "@material-ui/icons";
 //import {scopesGraph, jsonify, highest_common_roots} from "./util/util"
 
 function ScopeItem(props) {
-  const {scope_name, is_checked} = props
-  return <ListItem key = {scope_name} role={undefined} value={is_checked} onClick={undefined}>
+  var {scope_name, init_check, onChangeCallback} = props
+
+  const [isChecked, setIsChecked] = useState(init_check)
+
+  const flip_check = () => {
+    setIsChecked(!isChecked)
+  }
+
+  useEffect(() => {
+    onChangeCallback(scope_name)
+  }, [isChecked])
+
+  return <ListItem key={scope_name} value={isChecked} onClick={flip_check}>
     <ListItemIcon>
-      <Checkbox checked ={is_checked} />
+      <Checkbox checked ={isChecked} />
     </ListItemIcon>
     <ListItemText primary={scope_name} />
   </ListItem>
 }
 
-function NestedScopeList(props) {
-  const {nested_scopes} = props
 
-  return <ListItem key = {"foo"} />
+function NestedScopeList(props) {
+  const {outer_scope, inner_scopes, onChangeCallback} = props
+  const [open, setOpen] = useState(false)
+  const handleClick = () =>{
+    setOpen(!open)
+  }
+
+  const newCallback = (inner_scope) => {
+    onChangeCallback(outer_scope + ":" + inner_scope)
+  }
+
+  return <ListItem button onClick={handleClick}>
+    <ListItemText primary = {outer_scope} />
+    {open ? <ExpandLess /> : <ExpandMore />}
+    <Collapse in={open}>
+      <ScopeList scopes = {inner_scopes} onChangeCallback = {newCallback}/>
+    </Collapse>
+  </ListItem>
 }
 
+
 function ScopeList (props) {
-  const {scopes} = props
+  const {scopes, onChangeCallback} = props
   const [flatScopes, setFlatScopes] = useState([])
   const [nestedScopes, setNestedScopes] = useState([])
   // const flat_scopes 
   // const nested_scopes
   useEffect(() => {
-    console.debug("Scopes", scopes)
     setFlatScopes(scopes.filter(s => !s.name.includes(":")))
+
+    // This mess takes every scope that is 
+    // {name:scope1:scope2, enabled:true}, {name:scope1:scope3, enabled:false}
+    // and turns it into 
+    // {outer_scope : scope1, inner_scopes[{name:scope2, enabled:true}, {name:scope3, enabled:false}]}
     const complex_scopes = scopes.filter(s => s.name.includes(":"))
     // If Array.prototype.group() existed it would be ideal here...
     const tl_scopes = [...new Set(complex_scopes.map(s => s.name.split(":")[0]))]
-    console.debug(tl_scopes)
     const nested_scopes = tl_scopes.map(
-      ts => new Object({[ts]:
-        complex_scopes
+      ts => new Object({"outer_scope":ts,
+        "inner_scopes":complex_scopes
           .filter(cs => cs.name.startsWith(ts))
           .map(cs => new Object({
-            "name": cs.name.replace(ts, cs.name),
+            "name": cs.name.replace(ts, "").replace(":", ""),
             "enabled": cs.enabled
           }))
-      })
-    )
-    console.debug(nested_scopes)
+      }))
+    setNestedScopes(nested_scopes)
   }, [scopes])
 
-  return <List>
+  return <List disablePadding>
     {flatScopes.map(
-      scope => <ScopeItem scope_name = {scope.name} key={scope.name} is_checked={scope.enabled}/>
+      scope => <ScopeItem 
+        scope_name = {scope.name}
+        key={scope.name}
+        init_checked={scope.enabled}
+        onChangeCallback={onChangeCallback}
+      />
     )}
-    {/* map<NestedScopeList scopes={nested_scopes} /> */}
+    {nestedScopes.map( scope =>
+      <NestedScopeList outer_scope = {scope.outer_scope} inner_scopes={scope.inner_scopes} key={scope.name} onChangeCallback={onChangeCallback}/>
+    )}
   </List>
 }
+
 
 // Component for picking scopes for a role
 function RoleScopePicker (props) {
   const {role_id, server_id, updateScopes} = props
-  const [roleScopes, setRoleScopes] = useState([])
-  const [serverScopes, setServerScopes] = useState([])
   const [checkedScopes, setCheckedScopes] = useState([])
-  const [rightsChoices, setRightsChoices] = useState({})
-  const [selectedRights, setSelectedRights] = useState([])
   const [hasError, setHasError] = useState(false)
   const [error, setError] = useState({})
 
+  //Initial setup
   useEffect(
     () => {
       const fetch_scopes = async () => {
         const role_scopes = await getRoleScopes(role_id)
         const server_scopes = await getServerScopes(server_id)
         const checked_scopes = server_scopes.map(
-          srv_scp => new Object({
-            "name":srv_scp.name,
-            "enabled":role_scopes.map(y => y.name).includes(srv_scp.name)})
+          srv_scope => new Object({
+            "name":srv_scope.name,
+            "enabled":role_scopes.map(y => y.name).includes(srv_scope.name)})
         )
         setCheckedScopes(checked_scopes)
       }
@@ -89,9 +123,16 @@ function RoleScopePicker (props) {
       // This needs to be cancellable
     }, []
   )
-  
-  return <ScopeList scopes = {checkedScopes}></ScopeList>
 
+  const onChangeCallback = (changed_scopes) => {
+    const new_scopes = checkedScopes.map(s => changed_scopes.includes(s.name) ? {"name":s.name, "enabled":!s.enabled} : s)
+    console.debug(new_scopes)
+    setCheckedScopes(new_scopes)
+  }
+
+  useEffect(() => updateScopes(checkedScopes), [checkedScopes])
+
+  return <ScopeList scopes = {checkedScopes} onChangeCallback = {onChangeCallback} />
 }
 
 

--- a/flowauth/frontend/src/RoleScopePicker.jsx
+++ b/flowauth/frontend/src/RoleScopePicker.jsx
@@ -1,110 +1,77 @@
+/* eslint-disable react/prop-types */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from "react";
 import {useEffect, useState} from "react"
+import { Grid } from "rsuite";
 import { getServerScopes, getRoleScopes } from "./util/api";
-import RightsCascade from "./RightsCascade";
-import {scopesGraph, jsonify, highest_common_roots} from "./util/util"
+import { List, ListItem, Checkbox, ListItemIcon, ListItemText} from "@material-ui/core"
+//import {scopesGraph, jsonify, highest_common_roots} from "./util/util"
+
+function ScopeItem(props) {
+  const {scope_name, is_checked} = props
+  return <ListItem key = {scope_name} role={undefined} value={is_checked} onClick={undefined}>
+    <ListItemIcon>
+      <Checkbox checked ={is_checked} />
+    </ListItemIcon>
+    <ListItemText primary={scope_name} />
+  </ListItem>
+}
+
+function ScopeList (props) {
+  const {scopes} = props
+  const [flatScopes, setFlatScopes] = useState([])
+  const [nestedScopes, setNestedScopes] = useState([])
+  // const flat_scopes 
+  // const nested_scopes
+  useEffect(() => {
+    console.debug("Scopes", scopes)
+    setFlatScopes(scopes.filter(s => !s.name.includes(":")))
+    setNestedScopes(scopes.filter(s => s.name.includes(":")))
+  }, [scopes])
+
+  return <List>
+    {flatScopes.map(
+      scope => <ScopeItem scope_name = {scope.name} key={scope.name} is_checked={scope.enabled}/>
+    )}
+    {/* map<ScopeList scopes={nested_scopes} /> */}
+  </List>
+}
 
 // Component for picking scopes for a role
 function RoleScopePicker (props) {
   const {role_id, server_id, updateScopes} = props
   const [roleScopes, setRoleScopes] = useState([])
   const [serverScopes, setServerScopes] = useState([])
+  const [checkedScopes, setCheckedScopes] = useState([])
   const [rightsChoices, setRightsChoices] = useState({})
   const [selectedRights, setSelectedRights] = useState([])
   const [hasError, setHasError] = useState(false)
   const [error, setError] = useState({})
 
-  useEffect(() => {
-    const fetch_role_scopes = async (server_scopes) => {
-      console.log("Fetching role scopes...")
-      const role_scopes = await getRoleScopes(role_id);
-      console.log("Role scopes fetched: ", role_scopes)
-      console.log("Server scopes are:", server_scopes)
-      setRoleScopes(role_scopes);
-      
-      // selectedRights contains the list of names of selected scopes for this role.
-      // The trick is that, in the case of nested scopes, selectedRights only contains
-      // the shortest needed name.
-      // For example, there are two scopes available, admin1:foo and admin1:bar.
-      // If roleScopes contains both admin1:foo and admin1:bar, selectedRights should
-      // only contain admin1 - presence of only that implies that all sub-scopes are selected as well.
-      // On the other hand, if roleScopes only contains admin1:foo, selectedRights should also
-      // only contain admin1:foo
-
-      const sel_rights = highest_common_roots(
-        scopesGraph(role_scopes.map(x => x.name)),
-        scopesGraph(server_scopes.map(x => x.name)))
-      console.debug("Selected rights:", sel_rights.join(":"))
-      setSelectedRights(sel_rights)
-    }
-
-    const fetch_server_scopes = async() => {
-      console.log("Fetching server scopes....")
-      const server_scopes = await getServerScopes(server_id);
-      console.log("Server scopes fetched: ", server_scopes)
-      setServerScopes(server_scopes)
-      return server_scopes
-    }
-
-    const set_initial_state = async () => {
-      if (server_id >= 0){
-        const server_scopes = await fetch_server_scopes()
-        if (role_id >= 0){
-          await fetch_role_scopes(server_scopes)
-        }
+  useEffect(
+    () => {
+      const fetch_scopes = async () => {
+        const role_scopes = await getRoleScopes(role_id)
+        const server_scopes = await getServerScopes(server_id)
+        const checked_scopes = server_scopes.map(
+          srv_scp => new Object({
+            "name":srv_scp.name,
+            "enabled":role_scopes.map(y => y.name).includes(srv_scp.name)})
+        )
+        setCheckedScopes(checked_scopes)
       }
-    }
-
-    set_initial_state()//.catch(err => console.log(err))
-    
-  }, [role_id, server_id])
-
-  // On scopes change, jsonify the scopes into the appropriate format for
-  // MultiCascader
-  useEffect(() =>{
-    if (serverScopes.length > 0){
-      const unneeded = []
-      const baz = scopesGraph(serverScopes.map(x => x.name))
-      const foo = jsonify(baz, unneeded);
-      setRightsChoices(foo)
-    }
-
-  }, [serverScopes])
-
-  useEffect(() => {
-    updateScopes(roleScopes)
-  }, [roleScopes])
+      
+      fetch_scopes().catch((err) => console.error(err))
+      // This needs to be cancellable
+    }, []
+  )
   
-  const handleChange = (checked_roles) => {
-    //'checked_roles' in this case is a list of _labels_ from RightsCascade's onChange
-    // So we need to filter RoleScopes to all the scopes with that 'name' string
-    // This is further complicated by RightsCascade...apparently only returning the root
-    // label of a tree? This could be a case of it returning the lowest common root of a
-    // selected node; so if there is _only_ admin3:dummy_query:dummy_query, and you select
-    // admin3 -> dummy_query -> dummy_query, you have selected all _admin3_, therefore 
-    // new_labels contains only admin3.
-    
-    setSelectedRights(checked_roles)
-    console.debug("checked_roles:",checked_roles)
-    setRoleScopes(serverScopes.filter(
-      s_scope => checked_roles.some(
-        c_role => s_scope.name.startsWith(c_role)
-      )
-    ))
-  };
+  return <ScopeList scopes = {checkedScopes}></ScopeList>
 
-  return (
-    <RightsCascade
-      options={rightsChoices}
-      value={selectedRights}
-      onChange={handleChange}
-      // label={"Scopes"}
-    />
-  );
 }
+
 
 export default RoleScopePicker

--- a/flowauth/frontend/src/RoleScopePicker.jsx
+++ b/flowauth/frontend/src/RoleScopePicker.jsx
@@ -1,11 +1,8 @@
-/* eslint-disable react/prop-types */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// BUG: If you check a middle-level query, then check a leaf query in a 
-// neighbouring branch, then the mid-query branch you selected first gets
-// flipped
+/* eslint-disable react/prop-types */
 
 import React from "react";
 import {useEffect, useState} from "react"

--- a/flowauth/frontend/src/RoleScopePicker.jsx
+++ b/flowauth/frontend/src/RoleScopePicker.jsx
@@ -34,17 +34,18 @@ function ScopeItem(props) {
 
   const [isChecked, setIsChecked] = useState(init_check)
 
+  useEffect(() => {
+    console.debug(`Initial state of ${scope.name}; ${scope.enabled}`)
+  },[])
+
 
   // When an inner scope item is checked, use flipScopeCallback to
   // flip the scope with scope.key in the root of the component
   const onClick = () => {
-    console.debug(`Flipping single scope ${scope.name} from click`)
-    flipScopeCallback(scope.key, !isChecked)
+    flipScopeCallback(scope.key, !scope.enabled)
   }
 
-  // For some reason, when
   useEffect(() => {
-    console.debug(`${scope.key} flip detected from scope effect`)
     setIsChecked(scope.enabled)
   }, [scope])
 
@@ -66,18 +67,17 @@ function NestedScopeList(props) {
 
   useEffect(() => {
     console.debug(`Inner scopes changed on ${outer_scope}`)
+    console.debug(inner_scopes)
     if (inner_scopes.every(s => s.enabled === true)){
-      console.debug("foo")
       setIsChecked(true)
       setIsIndeterminant(false)
     }
     else if (inner_scopes.every(s => s.enabled === false)){
-      console.debug("bar")
       setIsChecked(false)
       setIsIndeterminant(false)
     }
     else {
-      console.debug("baz")
+      setIsChecked(true)
       setIsIndeterminant(true)
     }
   }, [inner_scopes])
@@ -89,17 +89,14 @@ function NestedScopeList(props) {
   const handleCheckboxClick = () => {
     var is_checked
     if(isIndeterminant){
-      console.debug("blep")
       setIsIndeterminant(false)
       is_checked = true
     } else {
       is_checked = !isChecked
     }
-    console.debug(`Flipping inner scopes of ${outer_scope} to ${is_checked}`)
     inner_scopes.forEach(s => {
       flipScopeCallback(s.key, is_checked)
-      console.log("Flipped:", s.key)
-    })
+    })  
   }
 
   return <ListItem  className={classes[".MuiListItem-root"]}>
@@ -188,7 +185,6 @@ function RoleScopePicker (props) {
             "key":srv_scope.name,
             "enabled":role_scopes.map(y => y.name).includes(srv_scope.name)})
         )
-        console.debug("Inital checked scopes", checked_scopes)
         setCheckedScopes(checked_scopes)
       }
       
@@ -204,7 +200,12 @@ function RoleScopePicker (props) {
     setCheckedScopes(new_scopes)
   }
 
-  useEffect(() => updateScopes(checkedScopes), [checkedScopes])
+  useEffect(
+    () => {
+      updateScopes(checkedScopes)
+      console.debug("Checked scopes:", checkedScopes)
+    }, [checkedScopes]
+  )
 
   return <ScopeList scopes = {checkedScopes} flipScopeCallback = {flipScope} />
 }


### PR DESCRIPTION


### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [ ] Brought the branch up to date with ~master~ permission_rework
- [ ] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

This re-implements `RoleScopePicker`, reimplementing `CascadePicker` within Flowauth. There is also a Cypress component test.