### PR TITLE
ETL views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- Added views `etl.ingested_state`, `etl.available_dates` and `etl.deduped_post_etl_queries` in FlowDB, for convenient extraction of relevant information from the ETL tables. [#5641](https://github.com/Flowminder/FlowKit/issues/5641)
 
 ### Changed
 - Changed `AIRFLOW__CORE__SQL_ALCHEMY_CONN` env var to `AIRFLOW__DATABASE__SQL_ALCHEMY_CONN`
@@ -16,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed a potential deadlock when using a small connection pool and `store`-ing queries
 - AutoFlow can now be run in a docker container with non-default user. [#5574](https://github.com/Flowminder/FlowKit/issues/5574)
 - Passing an empty list of events tables when creating a query now raises `ValueError: Empty tables list.` instead of a `MissingDateError`. [#436](https://github.com/Flowminder/FlowKit/issues/436)
+- Flowmachine now looks at only the most recent state (per CDR type per CDR date) in `etl.etl_records` to determine available dates. [#5641](https://github.com/Flowminder/FlowKit/issues/5641)
 
 ### Removed
 

--- a/flowdb/bin/build/0020_schema_other.sql
+++ b/flowdb/bin/build/0020_schema_other.sql
@@ -70,3 +70,20 @@ COMMENT ON TABLE etl.post_etl_queries
         IS 'Records outcomes of queries (e.g. simple quality checks) that are run '
            'as part of the regular ETL process, after data has been ingested.';
 
+CREATE VIEW etl.ingest_state AS (
+    SELECT DISTINCT ON (cdr_type, cdr_date)
+           cdr_type, cdr_date, state, timestamp
+    FROM etl.etl_records
+    ORDER BY cdr_type, cdr_date, timestamp DESC
+);
+
+CREATE VIEW etl.deduped_post_etl_queries AS (
+    SELECT DISTINCT ON (cdr_date, cdr_type, type_of_query_or_check)
+           cdr_date, cdr_type, type_of_query_or_check, outcome, optional_comment_or_description, timestamp
+    FROM etl.post_etl_queries
+    INNER JOIN etl.ingest_state
+    USING (cdr_date, cdr_type)
+    WHERE state = 'ingested'
+    ORDER BY cdr_date, cdr_type, type_of_query_or_check, timestamp DESC
+);
+

--- a/flowdb/bin/build/0020_schema_other.sql
+++ b/flowdb/bin/build/0020_schema_other.sql
@@ -81,7 +81,7 @@ CREATE VIEW etl.available_dates AS (
     SELECT cdr_type, cdr_date
     FROM etl.ingest_state
     WHERE state = 'ingested'
-)
+);
 
 CREATE VIEW etl.deduped_post_etl_queries AS (
     SELECT DISTINCT ON (cdr_date, cdr_type, type_of_query_or_check)

--- a/flowdb/bin/build/0020_schema_other.sql
+++ b/flowdb/bin/build/0020_schema_other.sql
@@ -77,13 +77,18 @@ CREATE VIEW etl.ingest_state AS (
     ORDER BY cdr_type, cdr_date, timestamp DESC
 );
 
+CREATE VIEW etl.available_dates AS (
+    SELECT cdr_type, cdr_date
+    FROM etl.ingest_state
+    WHERE state = 'ingested'
+)
+
 CREATE VIEW etl.deduped_post_etl_queries AS (
     SELECT DISTINCT ON (cdr_date, cdr_type, type_of_query_or_check)
            cdr_date, cdr_type, type_of_query_or_check, outcome, optional_comment_or_description, timestamp
     FROM etl.post_etl_queries
-    INNER JOIN etl.ingest_state
+    INNER JOIN etl.available_dates
     USING (cdr_date, cdr_type)
-    WHERE state = 'ingested'
     ORDER BY cdr_date, cdr_type, type_of_query_or_check, timestamp DESC
 );
 

--- a/flowmachine/flowmachine/core/connection.py
+++ b/flowmachine/flowmachine/core/connection.py
@@ -200,7 +200,7 @@ class Connection:
         return defaultdict(
             list,
             self.fetch(
-                "SELECT cdr_type, array_agg(distinct cdr_date) FROM etl.etl_records WHERE state='ingested' GROUP BY cdr_type"
+                "SELECT cdr_type, array_agg(distinct cdr_date) FROM etl.ingest_state WHERE state='ingested' GROUP BY cdr_type"
             ),
         )
 

--- a/flowmachine/flowmachine/core/connection.py
+++ b/flowmachine/flowmachine/core/connection.py
@@ -200,7 +200,7 @@ class Connection:
         return defaultdict(
             list,
             self.fetch(
-                "SELECT cdr_type, array_agg(distinct cdr_date) FROM etl.ingest_state WHERE state='ingested' GROUP BY cdr_type"
+                "SELECT cdr_type, array_agg(cdr_date) FROM etl.available_dates GROUP BY cdr_type"
             ),
         )
 


### PR DESCRIPTION
Closes #5641

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

- Adds a view `etl.ingest_state` to get the current ingested state per CDR type per CDR date
- Adds a view `etl.available_dates` to get the currently-available dates per CDR type (based on the ETL records)
- Adds a view `etl.deduped_post_etl_queries` to get only the most recent result of each post-ETL query per CDR type per CDR date, and only for dates that are currently available.
- Updates `flowmachine.Connection.available_dates` to use the `etl.available_dates` view.

"Available" status for dates can now be updated without overwriting ETL records, by appending a new row to `etl.etl_records` with state different from 'ingested' (e.g. 'dropped') and the time now.