### PR TITLE
Move jest to dev deps 

### DIFF
--- a/flowauth/frontend/package-lock.json
+++ b/flowauth/frontend/package-lock.json
@@ -15,7 +15,6 @@
         "classnames": "^2.3.2",
         "date-fns": "^2.29.3",
         "generate-password": "^1.7.0",
-        "jest": "^26.6.0",
         "react": "^17.0.0",
         "react-dom": "^17.0.2",
         "react-qr-svg": "^2.4.0",
@@ -26,6 +25,7 @@
       "devDependencies": {
         "cypress": "^12.5.1",
         "husky": "^8.0.3",
+        "jest": "^26.6.0",
         "otp-cli": "^0.2.0",
         "prettier": "^2.8.3",
         "pretty-quick": "^3.1.3"

--- a/flowauth/frontend/package.json
+++ b/flowauth/frontend/package.json
@@ -10,7 +10,6 @@
     "classnames": "^2.3.2",
     "date-fns": "^2.29.3",
     "generate-password": "^1.7.0",
-    "jest": "^26.6.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.2",
     "react-qr-svg": "^2.4.0",
@@ -33,7 +32,8 @@
     "husky": "^8.0.3",
     "otp-cli": "^0.2.0",
     "prettier": "^2.8.3",
-    "pretty-quick": "^3.1.3"
+    "pretty-quick": "^3.1.3",
+    "jest": "^26.6.0"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
Closes #5836

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Moves jest out of main dependencies for flowauth so it isn't in the final image builds.