### PR TITLE
Look for COUNT instead of just first row in data_present_sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Null values in first column of first row of ingested data no longer cause flowetl to skip ingestion [#5090](https://github.com/Flowminder/FlowKit/issues/5090)
+
 ## [1.18.2]
 
 ## Fixed

--- a/flowetl/flowetl/flowetl/sensors/data_present_sensor.py
+++ b/flowetl/flowetl/flowetl/sensors/data_present_sensor.py
@@ -6,6 +6,6 @@ from flowetl.mixins.fixed_sql_mixin import fixed_sql_operator
 
 DataPresentSensor = fixed_sql_operator(
     class_name="DataPresentSensor",
-    sql="SELECT COUNT (*) FROM {{ staging_table }} LIMIT 100;",
+    sql="SELECT EXISTS(SELECT * FROM {{ staging_table }} LIMIT 1);",
     is_sensor=True,
 )

--- a/flowetl/flowetl/flowetl/sensors/data_present_sensor.py
+++ b/flowetl/flowetl/flowetl/sensors/data_present_sensor.py
@@ -6,6 +6,6 @@ from flowetl.mixins.fixed_sql_mixin import fixed_sql_operator
 
 DataPresentSensor = fixed_sql_operator(
     class_name="DataPresentSensor",
-    sql="SELECT * FROM {{ staging_table }} LIMIT 1;",
+    sql="SELECT COUNT (*) FROM {{ staging_table }} LIMIT 100;",
     is_sensor=True,
 )


### PR DESCRIPTION
Closes #5090 

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [ ] Brought the branch up to date with master
- [ ] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description
Instead of `SELECT` ing the first row in `staging_table` in `data_present_sensor`, this PR uses COUNT to check for data presence. This would still fail if no records are present (COUNT (*) would return 0 in the first cell), but would work if there's any data present in the first 100 records (arbitarily selected)