### PR TITLE
Allow setting max locks, make default much higher than normal pg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Quickstart script now supports arbitrary countries via `EXAMPLE_COUNTRY` env var. [#5796](https://github.com/Flowminder/FlowKit/issues/5796)
+- FlowDB's maximum locks per transaction setting can now be controlled using the `MAX_LOCKS` env var. [#5157](https://github.com/Flowminder/FlowKit/issues/5157)
+
+### Changed
+
+- Increased FlowDB's default maximum locks per transaction to 365 * 5 * 4 * (1 + 4). [#5157](https://github.com/Flowminder/FlowKit/issues/5157)
 
 ## [1.18.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Quickstart script now supports arbitrary countries via `EXAMPLE_COUNTRY` env var. [#5796](https://github.com/Flowminder/FlowKit/issues/5796)
-- FlowDB's maximum locks per transaction setting can now be controlled using the `MAX_LOCKS` env var. [#5157](https://github.com/Flowminder/FlowKit/issues/5157)
+- FlowDB's maximum locks per transaction setting can now be controlled using the `MAX_LOCKS_PER_TRANSACTION` env var. [#5157](https://github.com/Flowminder/FlowKit/issues/5157)
 
 ### Changed
 
-- Increased FlowDB's default maximum locks per transaction to 365 * 5 * 4 * (1 + 4). [#5157](https://github.com/Flowminder/FlowKit/issues/5157)
+- Increased FlowDB's default maximum locks per transaction to `365 * 5 * 4 * (1 + 4)`. [#5157](https://github.com/Flowminder/FlowKit/issues/5157)
 
 ## [1.18.2]
 

--- a/docs/source/administrator/deployment.md
+++ b/docs/source/administrator/deployment.md
@@ -29,24 +29,24 @@ FlowDB is distributed as a docker container. To run it, you will need to provide
 
 You may also provide the following environment variables:
 
-| Variable name | Purpose | Default value |
-| ------------- | ------- | ------------- |
-| CACHE_SIZE | Maximum size of the cache schema | 1 tenth of available space in pgdata directory |
-| CACHE_PROTECTED_PERIOD | Amount of time to protect cache tables from being cleaned up | 86400 (24 hours) |
-| CACHE_HALF_LIFE | Speed at which cache tables expire when not used | 1000 |
-| MAX_CPUS | Maximum number of CPUs that may be used for parallelising queries | The greater of 1 or 1 less than all CPUs |
-| SHARED_BUFFERS_SIZE | Size of shared buffers | 16GB |
-| MAX_WORKERS |  Maximum number of CPUs that may be used for parallelising one query | MAX_CPUS/2 |
-| MAX_WORKERS_PER_GATHER |  Maximum number of CPUs that may be used for parallelising part of one query | MAX_CPUS/2 |
-| EFFECTIVE_CACHE_SIZE | Postgres cache size | 25% of total RAM |
+| Variable name                     | Purpose | Default value |
+|-----------------------------------| ------- | ------------- |
+| CACHE_SIZE                        | Maximum size of the cache schema | 1 tenth of available space in pgdata directory |
+| CACHE_PROTECTED_PERIOD            | Amount of time to protect cache tables from being cleaned up | 86400 (24 hours) |
+| CACHE_HALF_LIFE                   | Speed at which cache tables expire when not used | 1000 |
+| MAX_CPUS                          | Maximum number of CPUs that may be used for parallelising queries | The greater of 1 or 1 less than all CPUs |
+| SHARED_BUFFERS_SIZE               | Size of shared buffers | 16GB |
+| MAX_WORKERS                       |  Maximum number of CPUs that may be used for parallelising one query | MAX_CPUS/2 |
+| MAX_WORKERS_PER_GATHER            |  Maximum number of CPUs that may be used for parallelising part of one query | MAX_CPUS/2 |
+| EFFECTIVE_CACHE_SIZE              | Postgres cache size | 25% of total RAM |
 | FLOWDB_ENABLE_POSTGRES_DEBUG_MODE | When set to TRUE, enables use of the [pgadmin debugger](https://www.pgadmin.org/docs/pgadmin4/4.13/debugger.html) | FALSE |
- | MAX_LOCKS | Controls the maximum number of locks one transaction can take, you may wish to reduce this on low-memory servers. | 36500 | 
+ | MAX_LOCKS_PER_TRANSACTION         | Controls the maximum number of locks one transaction can take, you may wish to reduce this on low-memory servers. | 36500 | 
 
 However in most cases, the defaults will be adequate.
 
 ##### Shared memory
 
-You will typically need to increase the default shared memory available to docker containers when running FlowDB. You can do this either by setting `shm_size` for the FlowDB container in your compose or stack file, or by passing the `--shm-size` argument to the `docker run` command.
+You will typically need to increase the default shared memory available to docker containers when running FlowDB. You can do this either by setting `shm_size` for the FlowDB container in your compose or stack file, or by passing the `--shm-size` argument to the `docker run` command. In particular it should be more than `SHARED_BUFFERS_SIZE + MAX_LOCKS * (max_connections + max_prepared_transactions) * (sizeof(LOCK) + sizeof(LOCKTAG))`.
 
 ##### Bind Mounts and user permissions
 

--- a/docs/source/administrator/deployment.md
+++ b/docs/source/administrator/deployment.md
@@ -40,6 +40,7 @@ You may also provide the following environment variables:
 | MAX_WORKERS_PER_GATHER |  Maximum number of CPUs that may be used for parallelising part of one query | MAX_CPUS/2 |
 | EFFECTIVE_CACHE_SIZE | Postgres cache size | 25% of total RAM |
 | FLOWDB_ENABLE_POSTGRES_DEBUG_MODE | When set to TRUE, enables use of the [pgadmin debugger](https://www.pgadmin.org/docs/pgadmin4/4.13/debugger.html) | FALSE |
+ | MAX_LOCKS | Controls the maximum number of locks one transaction can take, you may wish to reduce this on low-memory servers. | 36500 | 
 
 However in most cases, the defaults will be adequate.
 

--- a/flowdb/bin/build/configurate.py
+++ b/flowdb/bin/build/configurate.py
@@ -69,6 +69,8 @@ use_jit = "off" if bool_env("NO_USE_JIT") else "on"
 stats_target = int(
     os.getenv("STATS_TARGET", 10000)
 )  # Default to higher than pg default
+max_locks = int(os.getenv("MAX_LOCKS", 365 * 5 * 4 * (1 + 4)))
+
 
 config_path = os.getenv(
     "AUTO_CONFIG_PATH", "/var/lib/postgresql/data/postgresql.configurator.conf"
@@ -89,6 +91,7 @@ with open("/docker-entrypoint-initdb.d/pg_config_template.conf") as fin:
         gendate=datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         stats_target=stats_target,
         use_jit=use_jit,
+        max_locks=max_locks,
     )
 
 print("Writing config file to", config_path)

--- a/flowdb/bin/build/configurate.py
+++ b/flowdb/bin/build/configurate.py
@@ -69,7 +69,7 @@ use_jit = "off" if bool_env("NO_USE_JIT") else "on"
 stats_target = int(
     os.getenv("STATS_TARGET", 10000)
 )  # Default to higher than pg default
-max_locks = int(os.getenv("MAX_LOCKS", 365 * 5 * 4 * (1 + 4)))
+max_locks = int(os.getenv("MAX_LOCKS_PER_TRANSACTION", 365 * 5 * 4 * (1 + 4)))
 
 
 config_path = os.getenv(

--- a/flowdb/bin/build/pg_config_template.conf
+++ b/flowdb/bin/build/pg_config_template.conf
@@ -73,6 +73,7 @@ random_page_cost = 3.0
 # Locking options
 #
 deadlock_timeout = 300000
+max_locks_per_transaction = {max_locks}
 
 # Shared libraries
 shared_preload_libraries = '{preloads}'

--- a/secrets_quickstart/flowdb.yml
+++ b/secrets_quickstart/flowdb.yml
@@ -26,6 +26,7 @@ services:
           #- MAX_WORKERS_PER_GATHER # Defaults to half max_cpus
           #- EFFECTIVE_CACHE_SIZE # Defaults to 25% of total RAM
           #- FLOWDB_ENABLE_POSTGRES_DEBUG_MODE # False by default
+          #- MAX_LOCKS_PER_TRANSACTION # Defaults to 365 * 5 * 4 * (1 + 4)
         ports:
           - ${FLOWDB_HOST_PORT:?}:5432
         user: ${FLOWDB_HOST_USER_ID:?}:${FLOWDB_HOST_GROUP_ID:?}
@@ -39,7 +40,7 @@ services:
           - type: tmpfs
             target: /dev/shm
             tmpfs:
-              size: 1000000000
+              size: 1000000000 # Should be greater than SHARED_BUFFERS_SIZE + MAX_LOCKS * (max_connections + max_prepared_transactions) * (sizeof(LOCK) + sizeof(LOCKTAG))
           - ${FLOWDB_DATA_DIR:?}:/var/lib/postgresql/data:rw
           - ${FLOWDB_ETL_DIR:?}:/etl:ro
         stdin_open: true


### PR DESCRIPTION
Closes #5157

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Adds a new env var that can control Postgres' max_locks_per_transaction setting to the configure script, and increases the default value.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202306260479520