### PR TITLE
Cell info table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added new FlowDB tables `infrastructure.cell_info` and `infrastructure.cells_table_versions` to keep track of changes to the cell info over time (note: the new tables have not yet replaced `infrastructure.cells` as the source of cell information for FlowKit queries). [#6184](https://github.com/Flowminder/FlowKit/issues/6184)
+
 ### Changed
 
 ### Fixed

--- a/flowdb/bin/build/0010_create_extensions.sh
+++ b/flowdb/bin/build/0010_create_extensions.sh
@@ -14,7 +14,7 @@ export PGUSER="$POSTGRES_USER"
 EXTENSIONS=('postgis' 'postgis_raster' 'postgis_topology' 'fuzzystrmatch' \
             'file_fdw' 'uuid-ossp' 'plpython3u' \
             'tsm_system_rows' 'pgrouting' 'pldbgapi' 'pg_median_utils'\
-            'ogr_fdw' 'tds_fdw')
+            'ogr_fdw' 'tds_fdw' 'btree_gist')
 
 #
 #  Create the 'template_postgis' template db

--- a/flowdb/bin/build/0020_schema_infrastructure.sql
+++ b/flowdb/bin/build/0020_schema_infrastructure.sql
@@ -182,7 +182,7 @@ CREATE SCHEMA IF NOT EXISTS infrastructure;
         ingested_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
         source_filename TEXT,
         file_hash TEXT,
-        file_date DATE,
+        file_date DATE
     );
 
     -- Table to keep records of all cells (including those excluded due to data quality issues, and old versions of cells that have moved/changed).

--- a/flowdb/bin/build/0020_schema_infrastructure.sql
+++ b/flowdb/bin/build/0020_schema_infrastructure.sql
@@ -176,14 +176,24 @@ CREATE SCHEMA IF NOT EXISTS infrastructure;
 
         );
 
+    -- Table to record each time the cell info is updated
+    CREATE TABLE IF NOT EXISTS infrastructure.cells_table_versions (
+        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+        ingested_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        source_filename TEXT,
+    );
+
     -- Table to keep records of all cells (including those excluded due to data quality issues, and old versions of cells that have moved/changed).
     -- Keeping all cell info in this table allows us to reconstruct the cells table as it was at a previous point in time, if necessary.
     CREATE TABLE IF NOT EXISTS infrastructure.cell_info(
-        cell_id TEXT, -- 'id' in infrastructure.cells
-        version INTEGER,
+        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+        cells_table_version INTEGER NOT NULL REFERENCES infrastructure.cells_table_versions (id),
+        mno_cell_id TEXT NOT NULL, -- 'id' in infrastructure.cells
+        dates_of_service TSTZRANGE NOT NULL, -- [date_of_first_service,date_of_last_service) in infrastructure.cells
+        to_include BOOLEAN NOT NULL, -- Flag to indicate whether or not cell should be used in analysis
         longitude DOUBLE PRECISION, -- x component of 'geom_point' in infrastructure.cells
         latitude DOUBLE PRECISION, -- y component of 'geom_point' in infrastructure.cells
-        dates_of_service TSTZRANGE, -- [date_of_first_service,date_of_last_service) in infrastructure.cells
+        geom_point geometry(Point, 4326) GENERATED ALWAYS AS ( ST_SetSRID(ST_Point(longitude, latitude), 4326) ) STORED,
         technology TEXT, -- 'type' in infrastructure.cells
         cell_name TEXT, -- 'name' in infrastructure.cells
         mno_site_id TEXT, -- 'site_id' in infrastructure.cells
@@ -199,14 +209,9 @@ CREATE SCHEMA IF NOT EXISTS infrastructure;
         min_range NUMERIC,
         electrical_tilt NUMERIC,
         mechanical_downtilt NUMERIC,
-        to_include BOOLEAN, -- Flag to indicate whether or not cell should be used in analysis
-        first_received DATE, -- Date of first cell info file to include this cell
-        last_received DATE, -- Date of last cell info file to include this cell
-        ingested_at TIMESTAMPTZ, -- Date/time at which this cell was first ingested
-        excluded_at TIMESTAMPTZ, -- Date/time at which this cell was first marked as excluded from analysis
-        notes TEXT, -- Free text field for adding notes related to this cell (e.g. reason for exclusion)
+        included_in_latest_file BOOLEAN NOT NULL, -- True if cell was included in latest cell info file; false if it was copied over from previous cells table and not in latest file
         additional_metadata JSONB, -- JSON field to catch any fields provided in cell info files that don't fit into the infrastructure.cells table structure
-        PRIMARY KEY (cell_id, version),
-        EXCLUDE USING GIST (cell_id WITH =, dates_of_service WITH &&) WHERE (to_include) -- ensure cell ID is unique across simultaneously-valid cells
+        notes TEXT, -- Free text field for adding notes related to this cell (e.g. reason for exclusion)
+        EXCLUDE USING GIST (cells_table_version WITH =, mno_cell_id WITH =, dates_of_service WITH &&) WHERE (to_include) -- ensure cell ID is unique across simultaneously-valid cells (so a CDR event can never map to multiple cells)
             -- Note: this exclude constraint requires btree_gist extension (https://dba.stackexchange.com/questions/37351/postgresql-exclude-using-error-data-type-integer-has-no-default-operator-class)
     );

--- a/flowdb/bin/build/0020_schema_infrastructure.sql
+++ b/flowdb/bin/build/0020_schema_infrastructure.sql
@@ -181,6 +181,8 @@ CREATE SCHEMA IF NOT EXISTS infrastructure;
         id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
         ingested_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
         source_filename TEXT,
+        file_hash TEXT,
+        file_date DATE,
     );
 
     -- Table to keep records of all cells (including those excluded due to data quality issues, and old versions of cells that have moved/changed).


### PR DESCRIPTION
Closes #6184

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Creates a new table `infrastructure.cell_info`, designed to contain not only the current set of cell location/metadata records but also all previous versions and any cells that we have excluded due to data quality issues.

Differences from `infrastructure.cells` are:
- I've renamed a few fields to make their intention clearer (at least to me)
- Separate 'longitude' and 'latitude' fields instead of 'geom_point' (purely because I'm thinking of this table as being closer to the source cell info files than `infrastructure.cells` - no strong reason we couldn't have 'geom_point' instead / as well)
- 'date_of_first_service' and 'date_of_last_service' are combined into a 'dates_of_service' `TSTZRANGE` field, which allows us to add an exclude constraint to ensure each CDR record (i.e. each (cell_id, timestamp)) can never map to more than one valid cell
- 'to_include' boolean field - cells with `to_include = FALSE` should not be used in analysis, which allows us to keep records of excluded cells (which can help, for example, to ensure we don't re-ingest previously-excluded cells). If any cell locations or metadata change from one cell info update file to the next, the intention would be to mark the old cell as excluded, and add a new row (with same cell ID and incremented version) with the new location/metadata.
- 'first_received'/'last_received' fields to record when each cell was first/last included in files provided by the MNO
- 'ingested_at' field (should be set as the time at which the record was added to the table) and 'excluded_at' field (should be set as the time at which 'to_include' was first set to False) - these fields allow us to extract the set of cells that were "included" (and would have been used in queries) at any previous point in time
- 'notes' field, for adding helpful human-readable notes about a cell record (e.g. reason for exclusion)
- 'additional_metadata' JSON field, for catching any fields provided in the files form the MNO that don't fit into the structure of `infrastructure.cells`
- (cell_id, version) are set as the primary key, instead of an additional internally-generated auto-incrementing ID field

When ingesting new cell info, the intention would be to update `infrastructure.cell_info` first, and then re-populate `infrastructure.cells` from `infrastructure.cell_info`. I'll add a FlowETL workflow for ingesting new cell info in a later PR. `infrastructure.cells` can be re-populated like this:
```
DELETE FROM infrastructure.cells;

INSERT INTO infrastructure.cells ( id,
                                   version,
                                   site_id,
                                   name,
                                   type,
                                   msc,
                                   bsc_rnc,
                                   antenna_type,
                                   status,
                                   lac,
                                   height,
                                   azimuth,
                                   transmitter,
                                   max_range,
                                   min_range,
                                   electrical_tilt,
                                   mechanical_downtilt,
                                   date_of_first_service,
                                   date_of_last_service,
                                   geom_point
                                 )
SELECT cell_id AS id,
       version,
       site_id,
       cell_name AS name,
       technology AS type,
       msc,
       bsc_rnc,
       antenna_type,
       status,
       lac,
       height,
       azimuth,
       transmitter,
       max_range,
       min_range,
       electrical_tilt,
       mechanical_downtilt,
       lower(dates_of_service) AS date_of_first_service,
       upper(dates_of_service) AS date_of_last_service,
       ST_SetSRID( ST_Point( longitude, latitude), 4326) AS geom_point
FROM infrastructure.cell_info
WHERE to_include;
```

In the future we could consider making `infrastructure.cells` a materialized view on `infrastructure.cell_info` to aid the update process. Alternatively, we could use `infrastructure.cell_info` directly, if an appropriate index on `to_include` was sufficient to alleviate any performance impacts. Although from an ETL point of view there's something to be said for ingesting into a separate table and then updating `infrastructure.cells` in one hit at the end, to avoid race conditions without having to squeeze the entire ETL process into a single transaction.