### PR TITLE
Fix no poke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- FlowETL sensor `NRowsPresentSensor` which checks for a specified minimum number of rows.
 
 ### Changed
+- `ForeignStagingTableOperator` will now error if the underlying file cannot be read or the command returns an error. [#5763](https://github.com/Flowminder/FlowKit/issues/5763)
 
 ### Fixed
 

--- a/flowetl/flowetl/flowetl/operators/create_foreign_staging_table_operator.py
+++ b/flowetl/flowetl/flowetl/operators/create_foreign_staging_table_operator.py
@@ -66,6 +66,7 @@ class CreateForeignStagingTableOperator(TableNameMacrosMixin, PostgresOperator):
                    escape '{{{{ params.escape }}}}'
                    {{% if params.encoding is defined %}}, {{{{ params.encoding }}}} {{% endif %}} 
                    );
+            SELECT EXISTS(SELECT * FROM {{{{ staging_table }}}} LIMIT 1); 
                 """
         fields_string = ",\n\t".join(
             f"{field_name} {field_type.upper()}"

--- a/flowetl/flowetl/flowetl/sensors/n_rows_present_sensor.py
+++ b/flowetl/flowetl/flowetl/sensors/n_rows_present_sensor.py
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from flowetl.mixins.fixed_sql_with_params_mixin import fixed_sql_operator_with_params
+
+NRowsPresentSensor = fixed_sql_operator_with_params(
+    class_name="NRowsPresentSensor",
+    sql="SELECT EXISTS(SELECT * FROM {{ staging_table }} LIMIT 1 (OFFSET {{ params.minimum_rows }} - 1));",
+    is_sensor=True,
+    params=["minimum_rows"],
+)


### PR DESCRIPTION
Closes #5763

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [ ] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [x] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Identifying _why_ a file fdw table can't be read is as it turns out not possible. That means we can't poke only on missing files. Hence what I've done is to make the foreign table wrapper error if the table can't be read, and add an extra sensor which let's you require some number of rows be present rather than just that there's at least a header.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203701576305848