### PR TITLE
Test qa data rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- Test QA check IDs are now of the right format. [#6472](https://github.com/Flowminder/FlowKit/issues/6472)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
-- Test QA check IDs are now of the right format. [#6472](https://github.com/Flowminder/FlowKit/issues/6472)
+- Test QA check IDs are now of the same format as those produced by FlowETL. [#6472](https://github.com/Flowminder/FlowKit/issues/6472)
 
 ### Removed
 

--- a/flowdb/testdata/bin/run_qa_checks.py
+++ b/flowdb/testdata/bin/run_qa_checks.py
@@ -107,13 +107,13 @@ if __name__ == "__main__":
 
     templates = (
         QaTemplate(
-            (
-                ".".join(Path(t).stem, Path(t).parent)
+            display_name=(
+                ".".join((Path(t).stem, Path(t).parent.stem))
                 if Path(t).parent != Path(".")
                 else Path(t).stem
             ),
-            env.get_template(t),
-            Path(t).parent if Path(t).parent != Path(".") else "any",
+            template=env.get_template(t),
+            event_type=Path(t).parent.stem if Path(t).parent != Path(".") else "any",
         )
         for t in env.list_templates(".sql")
     )

--- a/flowdb/testdata/bin/run_qa_checks.py
+++ b/flowdb/testdata/bin/run_qa_checks.py
@@ -107,7 +107,11 @@ if __name__ == "__main__":
 
     templates = (
         QaTemplate(
-            Path(t).name,
+            (
+                ".".join(Path(t).stem, Path(t).parent)
+                if Path(t).parent != Path(".")
+                else Path(t).stem
+            ),
             env.get_template(t),
             Path(t).parent if Path(t).parent != Path(".") else "any",
         )


### PR DESCRIPTION
Closes #6472 

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description
Renames test QA data to be of the `{qa_check_name}.{cdr_type}` format. 