### PR TITLE
Update GADM download URL

### DIFF
--- a/flowdb/testdata/bin/9900_ingest_synthetic_data.sh
+++ b/flowdb/testdata/bin/9900_ingest_synthetic_data.sh
@@ -53,7 +53,7 @@ if [ -f /opt/synthetic_data/generate_synthetic_data.py ] && [  "$SYNTHETIC_DATA_
       --output-root-dir ${OUTPUT_ROOT_DIR}
 elif [ -f /opt/synthetic_data/generate_synthetic_data_sql.py ] && [  "$SYNTHETIC_DATA_GENERATOR" = "sql" ]; then
   COUNTRY=${COUNTRY:-"NPL"}
-  wget --retry-connrefused -t=5 "https://data.biogeo.ucdavis.edu/data/gadm3.6/shp/gadm36_${COUNTRY}_shp.zip" -O /docker-entrypoint-initdb.d/data/geo.zip
+  wget --retry-connrefused -t=5 "https://geodata.ucdavis.edu/gadm/gadm3.6/shp/gadm36_${COUNTRY}_shp.zip" -O /docker-entrypoint-initdb.d/data/geo.zip
   unzip /docker-entrypoint-initdb.d/data/geo.zip -d /docker-entrypoint-initdb.d/data/geo
   echo $(ls /docker-entrypoint-initdb.d/data/)
   pipenv run python /opt/synthetic_data/generate_synthetic_data_sql.py \


### PR DESCRIPTION

Closes #6588

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Updates download URL for GADM boundaries in FlowDB synthetic data generator.

I haven't updated to a newer GADM version, because we'd then need to update the population distributions as well, and if we're doing that we probably want to move to geoboundaries instead (#3100).