### PR TITLE
Use 'SELECT DISTINCT ON' in LastLocation

### DIFF
--- a/flowmachine/flowmachine/features/subscriber/last_location.py
+++ b/flowmachine/flowmachine/features/subscriber/last_location.py
@@ -111,13 +111,9 @@ class LastLocation(BaseLocation, Query):
         relevant_columns = ",".join(self.spatial_unit.location_id_columns)
 
         sql = """
-        SELECT final_time.subscriber, {rc}
-        FROM
-             (SELECT subscriber_locs.subscriber, time, {rc},
-             row_number() OVER (PARTITION BY subscriber_locs.subscriber ORDER BY time DESC)
-                 AS rank
-             FROM ({subscriber_locs}) AS subscriber_locs) AS final_time
-        WHERE rank = 1
+        SELECT DISTINCT ON (subscriber_locs.subscriber) subscriber_locs.subscriber, {rc}
+        FROM ({subscriber_locs}) AS subscriber_locs
+        ORDER BY subscriber_locs.subscriber, time DESC
         """.format(
             subscriber_locs=self.subscriber_locs.get_query(), rc=relevant_columns
         )

--- a/flowmachine/tests/functional_tests/approved_files/test_sql_strings_and_results.test_daily_location_1_sql.approved.txt
+++ b/flowmachine/tests/functional_tests/approved_files/test_sql_strings_and_results.test_daily_location_1_sql.approved.txt
@@ -1,63 +1,59 @@
-SELECT final_time.subscriber,
-       pcod
-FROM (SELECT subscriber_locs.subscriber,
-             time,
-             pcod,
-             row_number() OVER (PARTITION BY subscriber_locs.subscriber
-                                ORDER BY time DESC) AS rank
-      FROM (SELECT subscriber,
-                   datetime AS time,
-                   pcod
-            FROM (SELECT l.datetime,
-                         l.location_id,
-                         l.subscriber,
-                         sites.pcod
-                  FROM (SELECT events.calls.datetime,
-                               events.calls.location_id,
-                               events.calls.msisdn AS subscriber
-                        FROM events.calls
-                        WHERE events.calls.datetime >= '2016-01-01 00:00:00'
-                          AND events.calls.datetime < '2016-01-02 00:00:00'
+SELECT DISTINCT ON (subscriber_locs.subscriber) subscriber_locs.subscriber,
+                                                pcod
+FROM (SELECT subscriber,
+             datetime AS time,
+             pcod
+      FROM (SELECT l.datetime,
+                   l.location_id,
+                   l.subscriber,
+                   sites.pcod
+            FROM (SELECT events.calls.datetime,
+                         events.calls.location_id,
+                         events.calls.msisdn AS subscriber
+                  FROM events.calls
+                  WHERE events.calls.datetime >= '2016-01-01 00:00:00'
+                    AND events.calls.datetime < '2016-01-02 00:00:00'
 
-                        UNION ALL
+                  UNION ALL
 
-                        SELECT events.sms.datetime,
-                               events.sms.location_id,
-                               events.sms.msisdn AS subscriber
-                        FROM events.sms
-                        WHERE events.sms.datetime >= '2016-01-01 00:00:00'
-                          AND events.sms.datetime < '2016-01-02 00:00:00') AS l
-                       INNER JOIN (SELECT loc_table.id AS location_id,
-                                          loc_table.date_of_first_service,
-                                          loc_table.date_of_last_service,
-                                          geom_table.admin3pcod AS pcod
-                                   FROM infrastructure.cells AS loc_table
-                                        INNER JOIN (SELECT gid,
-                                                           admin0name,
-                                                           admin0pcod,
-                                                           admin1name,
-                                                           admin1pcod,
-                                                           admin2name,
-                                                           admin2pcod,
-                                                           admin3name,
-                                                           admin3pcod,
-                                                           admin3refn,
-                                                           admin3altn,
-                                                           admin3al_1,
-                                                           date,
-                                                           validon,
-                                                           validto,
-                                                           shape_star,
-                                                           shape_stle,
-                                                           shape_leng,
-                                                           shape_area,
-                                                           geom
-                                                    FROM geography.admin3) AS geom_table ON st_within(CAST(loc_table.geom_point AS geometry),
-                                                                                                      CAST(st_setsrid(geom_table.geom, 4326) AS geometry))) AS sites ON l.location_id = sites.location_id
-                                                                                                                                                                    AND CAST(l.datetime AS date) BETWEEN COALESCE(sites.date_of_first_service,
-                                                                                                                                                                                                                  CAST('-infinity' AS timestamptz))
-                                                                                                                                                                                                     AND COALESCE(sites.date_of_last_service,
-                                                                                                                                                                                                                  CAST('infinity' AS timestamptz))) AS foo
-            WHERE location_id IS NOT NULL
-              AND location_id <> '') AS subscriber_locs) AS final_time
-WHERE rank = 1
+                  SELECT events.sms.datetime,
+                         events.sms.location_id,
+                         events.sms.msisdn AS subscriber
+                  FROM events.sms
+                  WHERE events.sms.datetime >= '2016-01-01 00:00:00'
+                    AND events.sms.datetime < '2016-01-02 00:00:00') AS l
+                 INNER JOIN (SELECT loc_table.id AS location_id,
+                                    loc_table.date_of_first_service,
+                                    loc_table.date_of_last_service,
+                                    geom_table.admin3pcod AS pcod
+                             FROM infrastructure.cells AS loc_table
+                                  INNER JOIN (SELECT gid,
+                                                     admin0name,
+                                                     admin0pcod,
+                                                     admin1name,
+                                                     admin1pcod,
+                                                     admin2name,
+                                                     admin2pcod,
+                                                     admin3name,
+                                                     admin3pcod,
+                                                     admin3refn,
+                                                     admin3altn,
+                                                     admin3al_1,
+                                                     date,
+                                                     validon,
+                                                     validto,
+                                                     shape_star,
+                                                     shape_stle,
+                                                     shape_leng,
+                                                     shape_area,
+                                                     geom
+                                              FROM geography.admin3) AS geom_table ON st_within(CAST(loc_table.geom_point AS geometry),
+                                                                                                CAST(st_setsrid(geom_table.geom, 4326) AS geometry))) AS sites ON l.location_id = sites.location_id
+                                                                                                                                                              AND CAST(l.datetime AS date) BETWEEN COALESCE(sites.date_of_first_service,
+                                                                                                                                                                                                            CAST('-infinity' AS timestamptz))
+                                                                                                                                                                                               AND COALESCE(sites.date_of_last_service,
+                                                                                                                                                                                                            CAST('infinity' AS timestamptz))) AS foo
+      WHERE location_id IS NOT NULL
+        AND location_id <> '') AS subscriber_locs
+ORDER BY subscriber_locs.subscriber,
+         time DESC

--- a/flowmachine/tests/functional_tests/approved_files/test_sql_strings_and_results.test_daily_location_3_sql.approved.txt
+++ b/flowmachine/tests/functional_tests/approved_files/test_sql_strings_and_results.test_daily_location_3_sql.approved.txt
@@ -1,44 +1,40 @@
-SELECT final_time.subscriber,
-       location_id
-FROM (SELECT subscriber_locs.subscriber,
-             time,
-             location_id,
-             row_number() OVER (PARTITION BY subscriber_locs.subscriber
-                                ORDER BY time DESC) AS rank
-      FROM (SELECT subscriber,
-                   datetime AS time,
-                   location_id
-            FROM (SELECT tbl.datetime,
-                         tbl.location_id,
-                         tbl.subscriber
-                  FROM (SELECT events.calls.datetime AS datetime,
-                               events.calls.location_id AS location_id,
-                               events.calls.msisdn AS subscriber
-                        FROM events.calls
-                        WHERE events.calls.datetime >= '2016-01-05 00:00:00'
-                          AND events.calls.datetime < '2016-01-06 00:00:00'
-                          AND (to_char(events.calls.datetime, 'HH24:MI') < '05:00'
-                            OR to_char(events.calls.datetime, 'HH24:MI') >= '23:00')) AS tbl
-                       INNER JOIN (SELECT DISTINCT msisdn AS subscriber
-                                   FROM events.calls
-                                   WHERE msisdn IN ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')) AS subset_query ON tbl.subscriber = subset_query.subscriber
+SELECT DISTINCT ON (subscriber_locs.subscriber) subscriber_locs.subscriber,
+                                                location_id
+FROM (SELECT subscriber,
+             datetime AS time,
+             location_id
+      FROM (SELECT tbl.datetime,
+                   tbl.location_id,
+                   tbl.subscriber
+            FROM (SELECT events.calls.datetime AS datetime,
+                         events.calls.location_id AS location_id,
+                         events.calls.msisdn AS subscriber
+                  FROM events.calls
+                  WHERE events.calls.datetime >= '2016-01-05 00:00:00'
+                    AND events.calls.datetime < '2016-01-06 00:00:00'
+                    AND (to_char(events.calls.datetime, 'HH24:MI') < '05:00'
+                      OR to_char(events.calls.datetime, 'HH24:MI') >= '23:00')) AS tbl
+                 INNER JOIN (SELECT DISTINCT msisdn AS subscriber
+                             FROM events.calls
+                             WHERE msisdn IN ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')) AS subset_query ON tbl.subscriber = subset_query.subscriber
 
-                  UNION ALL
+            UNION ALL
 
-                  SELECT tbl.datetime,
-                         tbl.location_id,
-                         tbl.subscriber
-                  FROM (SELECT events.sms.datetime AS datetime,
-                               events.sms.location_id AS location_id,
-                               events.sms.msisdn AS subscriber
-                        FROM events.sms
-                        WHERE events.sms.datetime >= '2016-01-05 00:00:00'
-                          AND events.sms.datetime < '2016-01-06 00:00:00'
-                          AND (to_char(events.sms.datetime, 'HH24:MI') < '05:00'
-                            OR to_char(events.sms.datetime, 'HH24:MI') >= '23:00')) AS tbl
-                       INNER JOIN (SELECT DISTINCT msisdn AS subscriber
-                                   FROM events.calls
-                                   WHERE msisdn IN ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')) AS subset_query ON tbl.subscriber = subset_query.subscriber) AS foo
-            WHERE location_id IS NOT NULL
-              AND location_id <> '') AS subscriber_locs) AS final_time
-WHERE rank = 1
+            SELECT tbl.datetime,
+                   tbl.location_id,
+                   tbl.subscriber
+            FROM (SELECT events.sms.datetime AS datetime,
+                         events.sms.location_id AS location_id,
+                         events.sms.msisdn AS subscriber
+                  FROM events.sms
+                  WHERE events.sms.datetime >= '2016-01-05 00:00:00'
+                    AND events.sms.datetime < '2016-01-06 00:00:00'
+                    AND (to_char(events.sms.datetime, 'HH24:MI') < '05:00'
+                      OR to_char(events.sms.datetime, 'HH24:MI') >= '23:00')) AS tbl
+                 INNER JOIN (SELECT DISTINCT msisdn AS subscriber
+                             FROM events.calls
+                             WHERE msisdn IN ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')) AS subset_query ON tbl.subscriber = subset_query.subscriber) AS foo
+      WHERE location_id IS NOT NULL
+        AND location_id <> '') AS subscriber_locs
+ORDER BY subscriber_locs.subscriber,
+         time DESC

--- a/flowmachine/tests/functional_tests/approved_files/test_sql_strings_and_results.test_daily_location_4_sql.approved.txt
+++ b/flowmachine/tests/functional_tests/approved_files/test_sql_strings_and_results.test_daily_location_4_sql.approved.txt
@@ -1,61 +1,57 @@
-SELECT final_time.subscriber,
-       pcod
-FROM (SELECT subscriber_locs.subscriber,
-             time,
-             pcod,
-             row_number() OVER (PARTITION BY subscriber_locs.subscriber
-                                ORDER BY time DESC) AS rank
-      FROM (SELECT subscriber,
-                   datetime AS time,
-                   pcod
-            FROM (SELECT l.datetime,
-                         l.location_id,
-                         l.subscriber,
-                         sites.pcod
-                  FROM (SELECT tbl.datetime,
-                               tbl.location_id,
-                               tbl.subscriber
-                        FROM (SELECT events.calls.datetime AS datetime,
-                                     events.calls.location_id AS location_id,
-                                     events.calls.msisdn AS subscriber
-                              FROM events.calls
-                              WHERE events.calls.datetime >= '2016-01-05 00:00:00'
-                                AND events.calls.datetime < '2016-01-06 00:00:00'
-                                AND (to_char(events.calls.datetime, 'HH24:MI') < '06:00'
-                                  OR to_char(events.calls.datetime, 'HH24:MI') >= '22:00')) AS tbl
-                             INNER JOIN (SELECT *
-                                         FROM ((VALUES ('dr9xNYK006wykgXj'))) AS tmp (subscriber)) AS subset_query ON tbl.subscriber = subset_query.subscriber) AS l
-                       INNER JOIN (SELECT loc_table.id AS location_id,
-                                          loc_table.date_of_first_service,
-                                          loc_table.date_of_last_service,
-                                          geom_table.admin3pcod AS pcod
-                                   FROM infrastructure.cells AS loc_table
-                                        INNER JOIN (SELECT gid,
-                                                           admin0name,
-                                                           admin0pcod,
-                                                           admin1name,
-                                                           admin1pcod,
-                                                           admin2name,
-                                                           admin2pcod,
-                                                           admin3name,
-                                                           admin3pcod,
-                                                           admin3refn,
-                                                           admin3altn,
-                                                           admin3al_1,
-                                                           date,
-                                                           validon,
-                                                           validto,
-                                                           shape_star,
-                                                           shape_stle,
-                                                           shape_leng,
-                                                           shape_area,
-                                                           geom
-                                                    FROM geography.admin3) AS geom_table ON st_within(CAST(loc_table.geom_point AS geometry),
-                                                                                                      CAST(st_setsrid(geom_table.geom, 4326) AS geometry))) AS sites ON l.location_id = sites.location_id
-                                                                                                                                                                    AND CAST(l.datetime AS date) BETWEEN COALESCE(sites.date_of_first_service,
-                                                                                                                                                                                                                  CAST('-infinity' AS timestamptz))
-                                                                                                                                                                                                     AND COALESCE(sites.date_of_last_service,
-                                                                                                                                                                                                                  CAST('infinity' AS timestamptz))) AS foo
-            WHERE location_id IS NOT NULL
-              AND location_id <> '') AS subscriber_locs) AS final_time
-WHERE rank = 1
+SELECT DISTINCT ON (subscriber_locs.subscriber) subscriber_locs.subscriber,
+                                                pcod
+FROM (SELECT subscriber,
+             datetime AS time,
+             pcod
+      FROM (SELECT l.datetime,
+                   l.location_id,
+                   l.subscriber,
+                   sites.pcod
+            FROM (SELECT tbl.datetime,
+                         tbl.location_id,
+                         tbl.subscriber
+                  FROM (SELECT events.calls.datetime AS datetime,
+                               events.calls.location_id AS location_id,
+                               events.calls.msisdn AS subscriber
+                        FROM events.calls
+                        WHERE events.calls.datetime >= '2016-01-05 00:00:00'
+                          AND events.calls.datetime < '2016-01-06 00:00:00'
+                          AND (to_char(events.calls.datetime, 'HH24:MI') < '06:00'
+                            OR to_char(events.calls.datetime, 'HH24:MI') >= '22:00')) AS tbl
+                       INNER JOIN (SELECT *
+                                   FROM ((VALUES ('dr9xNYK006wykgXj'))) AS tmp (subscriber)) AS subset_query ON tbl.subscriber = subset_query.subscriber) AS l
+                 INNER JOIN (SELECT loc_table.id AS location_id,
+                                    loc_table.date_of_first_service,
+                                    loc_table.date_of_last_service,
+                                    geom_table.admin3pcod AS pcod
+                             FROM infrastructure.cells AS loc_table
+                                  INNER JOIN (SELECT gid,
+                                                     admin0name,
+                                                     admin0pcod,
+                                                     admin1name,
+                                                     admin1pcod,
+                                                     admin2name,
+                                                     admin2pcod,
+                                                     admin3name,
+                                                     admin3pcod,
+                                                     admin3refn,
+                                                     admin3altn,
+                                                     admin3al_1,
+                                                     date,
+                                                     validon,
+                                                     validto,
+                                                     shape_star,
+                                                     shape_stle,
+                                                     shape_leng,
+                                                     shape_area,
+                                                     geom
+                                              FROM geography.admin3) AS geom_table ON st_within(CAST(loc_table.geom_point AS geometry),
+                                                                                                CAST(st_setsrid(geom_table.geom, 4326) AS geometry))) AS sites ON l.location_id = sites.location_id
+                                                                                                                                                              AND CAST(l.datetime AS date) BETWEEN COALESCE(sites.date_of_first_service,
+                                                                                                                                                                                                            CAST('-infinity' AS timestamptz))
+                                                                                                                                                                                               AND COALESCE(sites.date_of_last_service,
+                                                                                                                                                                                                            CAST('infinity' AS timestamptz))) AS foo
+      WHERE location_id IS NOT NULL
+        AND location_id <> '') AS subscriber_locs
+ORDER BY subscriber_locs.subscriber,
+         time DESC

--- a/flowmachine/tests/functional_tests/approved_files/test_sql_strings_and_results.test_daily_location_5_sql.approved.txt
+++ b/flowmachine/tests/functional_tests/approved_files/test_sql_strings_and_results.test_daily_location_5_sql.approved.txt
@@ -1,44 +1,40 @@
-SELECT final_time.subscriber,
-       location_id
-FROM (SELECT subscriber_locs.subscriber,
-             time,
-             location_id,
-             row_number() OVER (PARTITION BY subscriber_locs.subscriber
-                                ORDER BY time DESC) AS rank
-      FROM (SELECT subscriber,
-                   datetime AS time,
-                   location_id
-            FROM (SELECT tbl.datetime,
-                         tbl.location_id,
-                         tbl.subscriber
-                  FROM (SELECT events.calls.datetime AS datetime,
-                               events.calls.location_id AS location_id,
-                               events.calls.msisdn AS subscriber
-                        FROM events.calls
-                        WHERE events.calls.datetime >= '2016-01-05 00:00:00'
-                          AND events.calls.datetime < '2016-01-06 00:00:00'
-                          AND (to_char(events.calls.datetime, 'HH24:MI') < '05:00'
-                            OR to_char(events.calls.datetime, 'HH24:MI') >= '23:00')) AS tbl
-                       INNER JOIN (SELECT DISTINCT msisdn AS subscriber
-                                   FROM events.calls
-                                   WHERE msisdn IN ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')) AS subset_query ON tbl.subscriber = subset_query.subscriber
+SELECT DISTINCT ON (subscriber_locs.subscriber) subscriber_locs.subscriber,
+                                                location_id
+FROM (SELECT subscriber,
+             datetime AS time,
+             location_id
+      FROM (SELECT tbl.datetime,
+                   tbl.location_id,
+                   tbl.subscriber
+            FROM (SELECT events.calls.datetime AS datetime,
+                         events.calls.location_id AS location_id,
+                         events.calls.msisdn AS subscriber
+                  FROM events.calls
+                  WHERE events.calls.datetime >= '2016-01-05 00:00:00'
+                    AND events.calls.datetime < '2016-01-06 00:00:00'
+                    AND (to_char(events.calls.datetime, 'HH24:MI') < '05:00'
+                      OR to_char(events.calls.datetime, 'HH24:MI') >= '23:00')) AS tbl
+                 INNER JOIN (SELECT DISTINCT msisdn AS subscriber
+                             FROM events.calls
+                             WHERE msisdn IN ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')) AS subset_query ON tbl.subscriber = subset_query.subscriber
 
-                  UNION ALL
+            UNION ALL
 
-                  SELECT tbl.datetime,
-                         tbl.location_id,
-                         tbl.subscriber
-                  FROM (SELECT events.sms.datetime AS datetime,
-                               events.sms.location_id AS location_id,
-                               events.sms.msisdn AS subscriber
-                        FROM events.sms
-                        WHERE events.sms.datetime >= '2016-01-05 00:00:00'
-                          AND events.sms.datetime < '2016-01-06 00:00:00'
-                          AND (to_char(events.sms.datetime, 'HH24:MI') < '05:00'
-                            OR to_char(events.sms.datetime, 'HH24:MI') >= '23:00')) AS tbl
-                       INNER JOIN (SELECT DISTINCT msisdn AS subscriber
-                                   FROM events.calls
-                                   WHERE msisdn IN ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')) AS subset_query ON tbl.subscriber = subset_query.subscriber) AS foo
-            WHERE location_id IS NOT NULL
-              AND location_id <> '') AS subscriber_locs) AS final_time
-WHERE rank = 1
+            SELECT tbl.datetime,
+                   tbl.location_id,
+                   tbl.subscriber
+            FROM (SELECT events.sms.datetime AS datetime,
+                         events.sms.location_id AS location_id,
+                         events.sms.msisdn AS subscriber
+                  FROM events.sms
+                  WHERE events.sms.datetime >= '2016-01-05 00:00:00'
+                    AND events.sms.datetime < '2016-01-06 00:00:00'
+                    AND (to_char(events.sms.datetime, 'HH24:MI') < '05:00'
+                      OR to_char(events.sms.datetime, 'HH24:MI') >= '23:00')) AS tbl
+                 INNER JOIN (SELECT DISTINCT msisdn AS subscriber
+                             FROM events.calls
+                             WHERE msisdn IN ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')) AS subset_query ON tbl.subscriber = subset_query.subscriber) AS foo
+      WHERE location_id IS NOT NULL
+        AND location_id <> '') AS subscriber_locs
+ORDER BY subscriber_locs.subscriber,
+         time DESC

--- a/flowmachine/tests/functional_tests/approved_files/test_sql_strings_and_results.test_daily_location_6_sql.approved.txt
+++ b/flowmachine/tests/functional_tests/approved_files/test_sql_strings_and_results.test_daily_location_6_sql.approved.txt
@@ -1,64 +1,60 @@
-SELECT final_time.subscriber,
-       pcod
-FROM (SELECT subscriber_locs.subscriber,
-             time,
-             pcod,
-             row_number() OVER (PARTITION BY subscriber_locs.subscriber
-                                ORDER BY time DESC) AS rank
-      FROM (SELECT subscriber,
-                   datetime AS time,
-                   pcod
-            FROM (SELECT l.datetime,
-                         l.location_id,
-                         l.subscriber,
-                         sites.pcod
-                  FROM (SELECT tbl.datetime,
-                               tbl.location_id,
-                               tbl.subscriber
-                        FROM (SELECT events.calls.datetime AS datetime,
-                                     events.calls.location_id AS location_id,
-                                     events.calls.msisdn AS subscriber
-                              FROM events.calls
-                              WHERE events.calls.datetime >= '2016-01-03 00:00:00'
-                                AND events.calls.datetime < '2016-01-04 00:00:00') AS tbl
-                             INNER JOIN (SELECT outgoing,
-                                                datetime,
-                                                duration,
-                                                msisdn AS subscriber
-                                         FROM events.calls
-                                         WHERE CAST(datetime AS date) = '2016-01-01'
-                                           AND duration > 2000) AS subset_query ON tbl.subscriber = subset_query.subscriber) AS l
-                       INNER JOIN (SELECT loc_table.id AS location_id,
-                                          loc_table.date_of_first_service,
-                                          loc_table.date_of_last_service,
-                                          geom_table.admin3pcod AS pcod
-                                   FROM infrastructure.cells AS loc_table
-                                        INNER JOIN (SELECT gid,
-                                                           admin0name,
-                                                           admin0pcod,
-                                                           admin1name,
-                                                           admin1pcod,
-                                                           admin2name,
-                                                           admin2pcod,
-                                                           admin3name,
-                                                           admin3pcod,
-                                                           admin3refn,
-                                                           admin3altn,
-                                                           admin3al_1,
-                                                           date,
-                                                           validon,
-                                                           validto,
-                                                           shape_star,
-                                                           shape_stle,
-                                                           shape_leng,
-                                                           shape_area,
-                                                           geom
-                                                    FROM geography.admin3) AS geom_table ON st_within(CAST(loc_table.geom_point AS geometry),
-                                                                                                      CAST(st_setsrid(geom_table.geom, 4326) AS geometry))) AS sites ON l.location_id = sites.location_id
-                                                                                                                                                                    AND CAST(l.datetime AS date) BETWEEN COALESCE(sites.date_of_first_service,
-                                                                                                                                                                                                                  CAST('-infinity' AS timestamptz))
-                                                                                                                                                                                                     AND COALESCE(sites.date_of_last_service,
-                                                                                                                                                                                                                  CAST('infinity' AS timestamptz))) AS foo
-            WHERE location_id IS NOT NULL
-              AND location_id <> '') AS subscriber_locs) AS final_time
-WHERE rank = 1
+SELECT DISTINCT ON (subscriber_locs.subscriber) subscriber_locs.subscriber,
+                                                pcod
+FROM (SELECT subscriber,
+             datetime AS time,
+             pcod
+      FROM (SELECT l.datetime,
+                   l.location_id,
+                   l.subscriber,
+                   sites.pcod
+            FROM (SELECT tbl.datetime,
+                         tbl.location_id,
+                         tbl.subscriber
+                  FROM (SELECT events.calls.datetime AS datetime,
+                               events.calls.location_id AS location_id,
+                               events.calls.msisdn AS subscriber
+                        FROM events.calls
+                        WHERE events.calls.datetime >= '2016-01-03 00:00:00'
+                          AND events.calls.datetime < '2016-01-04 00:00:00') AS tbl
+                       INNER JOIN (SELECT outgoing,
+                                          datetime,
+                                          duration,
+                                          msisdn AS subscriber
+                                   FROM events.calls
+                                   WHERE CAST(datetime AS date) = '2016-01-01'
+                                     AND duration > 2000) AS subset_query ON tbl.subscriber = subset_query.subscriber) AS l
+                 INNER JOIN (SELECT loc_table.id AS location_id,
+                                    loc_table.date_of_first_service,
+                                    loc_table.date_of_last_service,
+                                    geom_table.admin3pcod AS pcod
+                             FROM infrastructure.cells AS loc_table
+                                  INNER JOIN (SELECT gid,
+                                                     admin0name,
+                                                     admin0pcod,
+                                                     admin1name,
+                                                     admin1pcod,
+                                                     admin2name,
+                                                     admin2pcod,
+                                                     admin3name,
+                                                     admin3pcod,
+                                                     admin3refn,
+                                                     admin3altn,
+                                                     admin3al_1,
+                                                     date,
+                                                     validon,
+                                                     validto,
+                                                     shape_star,
+                                                     shape_stle,
+                                                     shape_leng,
+                                                     shape_area,
+                                                     geom
+                                              FROM geography.admin3) AS geom_table ON st_within(CAST(loc_table.geom_point AS geometry),
+                                                                                                CAST(st_setsrid(geom_table.geom, 4326) AS geometry))) AS sites ON l.location_id = sites.location_id
+                                                                                                                                                              AND CAST(l.datetime AS date) BETWEEN COALESCE(sites.date_of_first_service,
+                                                                                                                                                                                                            CAST('-infinity' AS timestamptz))
+                                                                                                                                                                                               AND COALESCE(sites.date_of_last_service,
+                                                                                                                                                                                                            CAST('infinity' AS timestamptz))) AS foo
+      WHERE location_id IS NOT NULL
+        AND location_id <> '') AS subscriber_locs
+ORDER BY subscriber_locs.subscriber,
+         time DESC

--- a/integration_tests/tests/flowmachine_tests/approved_files/test_daily_location_results.test_daily_location_1_sql.approved.txt
+++ b/integration_tests/tests/flowmachine_tests/approved_files/test_daily_location_results.test_daily_location_1_sql.approved.txt
@@ -1,44 +1,40 @@
-SELECT final_time.subscriber,
-       location_id
-FROM (SELECT subscriber_locs.subscriber,
-             time,
-             location_id,
-             row_number() OVER (PARTITION BY subscriber_locs.subscriber
-                                ORDER BY time DESC) AS rank
-      FROM (SELECT subscriber,
-                   datetime AS time,
-                   location_id
-            FROM (SELECT tbl.datetime,
-                         tbl.location_id,
-                         tbl.subscriber
-                  FROM (SELECT events.calls.datetime AS datetime,
-                               events.calls.location_id AS location_id,
-                               events.calls.msisdn AS subscriber
-                        FROM events.calls
-                        WHERE events.calls.datetime >= '2016-01-05 00:00:00'
-                          AND events.calls.datetime < '2016-01-06 00:00:00'
-                          AND (to_char(events.calls.datetime, 'HH24:MI') < '05:00'
-                            OR to_char(events.calls.datetime, 'HH24:MI') >= '23:00')) AS tbl
-                       INNER JOIN (SELECT DISTINCT msisdn AS subscriber
-                                   FROM events.calls
-                                   WHERE msisdn IN ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')) AS subset_query ON tbl.subscriber = subset_query.subscriber
+SELECT DISTINCT ON (subscriber_locs.subscriber) subscriber_locs.subscriber,
+                                                location_id
+FROM (SELECT subscriber,
+             datetime AS time,
+             location_id
+      FROM (SELECT tbl.datetime,
+                   tbl.location_id,
+                   tbl.subscriber
+            FROM (SELECT events.calls.datetime AS datetime,
+                         events.calls.location_id AS location_id,
+                         events.calls.msisdn AS subscriber
+                  FROM events.calls
+                  WHERE events.calls.datetime >= '2016-01-05 00:00:00'
+                    AND events.calls.datetime < '2016-01-06 00:00:00'
+                    AND (to_char(events.calls.datetime, 'HH24:MI') < '05:00'
+                      OR to_char(events.calls.datetime, 'HH24:MI') >= '23:00')) AS tbl
+                 INNER JOIN (SELECT DISTINCT msisdn AS subscriber
+                             FROM events.calls
+                             WHERE msisdn IN ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')) AS subset_query ON tbl.subscriber = subset_query.subscriber
 
-                  UNION ALL
+            UNION ALL
 
-                  SELECT tbl.datetime,
-                         tbl.location_id,
-                         tbl.subscriber
-                  FROM (SELECT events.sms.datetime AS datetime,
-                               events.sms.location_id AS location_id,
-                               events.sms.msisdn AS subscriber
-                        FROM events.sms
-                        WHERE events.sms.datetime >= '2016-01-05 00:00:00'
-                          AND events.sms.datetime < '2016-01-06 00:00:00'
-                          AND (to_char(events.sms.datetime, 'HH24:MI') < '05:00'
-                            OR to_char(events.sms.datetime, 'HH24:MI') >= '23:00')) AS tbl
-                       INNER JOIN (SELECT DISTINCT msisdn AS subscriber
-                                   FROM events.calls
-                                   WHERE msisdn IN ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')) AS subset_query ON tbl.subscriber = subset_query.subscriber) AS foo
-            WHERE location_id IS NOT NULL
-              AND location_id <> '') AS subscriber_locs) AS final_time
-WHERE rank = 1
+            SELECT tbl.datetime,
+                   tbl.location_id,
+                   tbl.subscriber
+            FROM (SELECT events.sms.datetime AS datetime,
+                         events.sms.location_id AS location_id,
+                         events.sms.msisdn AS subscriber
+                  FROM events.sms
+                  WHERE events.sms.datetime >= '2016-01-05 00:00:00'
+                    AND events.sms.datetime < '2016-01-06 00:00:00'
+                    AND (to_char(events.sms.datetime, 'HH24:MI') < '05:00'
+                      OR to_char(events.sms.datetime, 'HH24:MI') >= '23:00')) AS tbl
+                 INNER JOIN (SELECT DISTINCT msisdn AS subscriber
+                             FROM events.calls
+                             WHERE msisdn IN ('GNLM7eW5J5wmlwRa', 'e6BxY8mAP38GyAQz', '1vGR8kp342yxEpwY')) AS subset_query ON tbl.subscriber = subset_query.subscriber) AS foo
+      WHERE location_id IS NOT NULL
+        AND location_id <> '') AS subscriber_locs
+ORDER BY subscriber_locs.subscriber,
+         time DESC


### PR DESCRIPTION
Closes #6603

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Rewrites the SQL for `LastLocation` to use `SELECT DISTINCT ON` instead of a window function.