### PR TITLE
Add invalid_cell_info table and change exclude constraint on cell_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- Added FlowDB table `infrastructure.invalid_cell_info` for recording cell information that could not be included in `infrastructure.cell_info` (including cells with null or duplicate cell IDs). [#6627](https://github.com/Flowminder/FlowKit/issues/6627)
 
 ### Changed
 - FlowDB now triggers an ANALYZE on newly created cache tables to generate statistics rather than waiting for autovacuum
@@ -20,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - FlowDB now enables partitionwise aggregation planning by default
 - FlowDB now uses a default fillfactor of 100 for cache table indexes
+- `EXCLUDE` constraint on FlowDB `infrastructure.cell_info` table requires unique `mno_cell_id` across _all_ simultaneously-valid cells per `cells_table_version`, regardless of `to_include`. [#6627](https://github.com/Flowminder/FlowKit/issues/6627)
 
 ### Fixed
 - Queries that have multiple of the same subquery with different parameters no longer cause duplicate scopes in tokens. [#6580](https://github.com/Flowminder/FlowKit/issues/6580)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-- Added FlowDB table `infrastructure.invalid_cell_info` for recording cell information that could not be included in `infrastructure.cell_info` (including cells with null or duplicate cell IDs). [#6627](https://github.com/Flowminder/FlowKit/issues/6627)
+- Added FlowDB table `infrastructure.invalid_cell_info` for recording cell information that could not be included in `infrastructure.cell_info` (including cells with null or duplicate cell IDs). [#6626](https://github.com/Flowminder/FlowKit/issues/6626)
 
 ### Changed
 - FlowDB now triggers an ANALYZE on newly created cache tables to generate statistics rather than waiting for autovacuum
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - FlowDB now enables partitionwise aggregation planning by default
 - FlowDB now uses a default fillfactor of 100 for cache table indexes
-- `EXCLUDE` constraint on FlowDB `infrastructure.cell_info` table requires unique `mno_cell_id` across _all_ simultaneously-valid cells per `cells_table_version`, regardless of `to_include`. [#6627](https://github.com/Flowminder/FlowKit/issues/6627)
+- `EXCLUDE` constraint on FlowDB `infrastructure.cell_info` table requires unique `mno_cell_id` across _all_ simultaneously-valid cells per `cells_table_version`, regardless of `to_include`. [#6626](https://github.com/Flowminder/FlowKit/issues/6626)
 
 ### Fixed
 - Queries that have multiple of the same subquery with different parameters no longer cause duplicate scopes in tokens. [#6580](https://github.com/Flowminder/FlowKit/issues/6580)


### PR DESCRIPTION

Closes #6626

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

- Changes the exclude constraint on `infrastructure.cell_info` to ensure cell ID is unique across _all_ simultaneously-valid cells, not just `WHERE to_include`.
- Adds a new table `infrastructure.invalid_cell_info`, with similar structure to `infrastructure.cell_info` but fewer constraints, to hold any rows from cell information files that are not valid entries in `infrastructure.cell_info` (including cells with null or duplicate cell IDs).

<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c837b579942d793b3309a46531a6c7506dd70049  | 
|--------|--------|

### Summary:
This PR modifies the exclusion constraint on `infrastructure.cell_info` and introduces a new table `infrastructure.invalid_cell_info` to enhance data integrity and tracking of invalid cell records.

**Key points**:
- Modified `EXCLUDE` constraint on `infrastructure.cell_info` for cell ID uniqueness across all valid cells.
- Introduced `infrastructure.invalid_cell_info` table for storing invalid cell records.
- Updated `CHANGELOG.md`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->
