### PR TITLE
Fix slow displacement test

### DIFF
--- a/flowmachine/tests/test_displacement.py
+++ b/flowmachine/tests/test_displacement.py
@@ -136,15 +136,23 @@ def test_subscriber_with_home_loc_but_no_calls_is_nan(get_dataframe):
     p2 = ("2016-01-01 12:01:00", "2016-01-01 15:20:00")
     subscriber = "OdM7np8LYEp1mkvP"
 
-    rl = daily_location("2016-01-01", spatial_unit=make_spatial_unit("lon-lat"))
+    rl = daily_location(
+        "2016-01-01",
+        spatial_unit=make_spatial_unit("lon-lat"),
+        subscriber_subset=[subscriber],
+    )
     rl.store()
     d = Displacement(
-        p2[0], p2[1], reference_location=rl, return_subscribers_not_seen=True
+        p2[0],
+        p2[1],
+        reference_location=rl,
+        return_subscribers_not_seen=True,
+        subscriber_subset=[subscriber],
     )
 
     df = get_dataframe(d).set_index("subscriber")
-
-    assert isnan(df.loc[subscriber].value)
+    sub = df.loc[subscriber].value
+    assert sub is None
 
 
 def test_subscriber_with_home_loc_but_no_calls_is_ommitted(get_dataframe):

--- a/flowmachine/tests/test_displacement.py
+++ b/flowmachine/tests/test_displacement.py
@@ -116,6 +116,7 @@ def test_get_all_users_in_reference_location(get_dataframe):
     p2 = ("2016-01-01 12:01:00", "2016-01-01 15:20:00")
 
     rl = daily_location("2016-01-01", spatial_unit=make_spatial_unit("lon-lat"))
+    rl.store()
     d = Displacement(
         p2[0], p2[1], reference_location=rl, return_subscribers_not_seen=True
     )
@@ -136,6 +137,7 @@ def test_subscriber_with_home_loc_but_no_calls_is_nan(get_dataframe):
     subscriber = "OdM7np8LYEp1mkvP"
 
     rl = daily_location("2016-01-01", spatial_unit=make_spatial_unit("lon-lat"))
+    rl.store()
     d = Displacement(
         p2[0], p2[1], reference_location=rl, return_subscribers_not_seen=True
     )


### PR DESCRIPTION

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Makes a couple of changes to the tests for the `Displacement` class, which speed up the tests substantially. Namely, storing the reused reference location, and supplying a subscriber subset.
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0df973660c18371e9a2dacb8cd73a553cda3e302  | 
|--------|--------|

### Summary:
Optimized `Displacement` class tests by caching reference locations and limiting data scope, with modifications to specific tests and methods.

**Key points**:
- Optimized `Displacement` class tests by caching reference locations and limiting data scope.
- Modified `test_get_all_users_in_reference_location` and `test_subscriber_with_home_loc_but_no_calls_is_nan` in `flowmachine/tests/test_displacement.py`.
- Added `store()` method to cache `daily_location` results.
- Introduced `subscriber_subset` to limit data scope in tests.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->