### PR TITLE
Calendar activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- New flowmachine query `CalendarActivity`, which retrives subscribers pattern of active days
+- New flowmachine queries `PerValueAggregate` and `RedactedPerValueAggregate`, which group by the value column of another query and apply an aggregate to subscribers with that grouping.
+- New flowapi queries and flowclient functions for `calendar_activity` and `localised_calendar_activity`, which return counts of subscribers per sequence of active days, and per sequence of active days additionally grouped by the subscribers reference location
+- Added new `StringStatistic` enum, which enumerates valid statistics for use with postgres string types
 
 ### Changed
+- `HistogramAggregation` has moved to `flowmachine.features.nonspatial_aggregates`
+- `Statistic` moved to `flowmachine.core.statistic_types`
+- `TotalActivePeriodsSubscriber` no longer returns an extra `inactive_periods` column
 
 ### Fixed
 

--- a/flowclient/flowclient/__init__.py
+++ b/flowclient/flowclient/__init__.py
@@ -80,6 +80,7 @@ from .aggregates import (
     trips_od_matrix,
     labelled_spatial_aggregate,
     labelled_flows,
+    calendar_activity,
 )
 
 __all__ = [
@@ -123,6 +124,7 @@ __all__ = [
     "trips_od_matrix",
     "labelled_spatial_aggregate",
     "labelled_flows",
+    "calendar_activity",
 ]
 
 from . import _version

--- a/flowclient/flowclient/__init__.py
+++ b/flowclient/flowclient/__init__.py
@@ -81,6 +81,7 @@ from .aggregates import (
     labelled_spatial_aggregate,
     labelled_flows,
     calendar_activity,
+    localised_calendar_activity,
 )
 
 __all__ = [
@@ -125,6 +126,7 @@ __all__ = [
     "labelled_spatial_aggregate",
     "labelled_flows",
     "calendar_activity",
+    "localised_calendar_activity",
 ]
 
 from . import _version

--- a/flowclient/flowclient/aggregates.py
+++ b/flowclient/flowclient/aggregates.py
@@ -1749,7 +1749,7 @@ def histogram_aggregate(*, connection: Connection, **kwargs) -> APIQuery:
     return connection.make_api_query(parameters=histogram_aggregate_spec(**kwargs))
 
 
-def calendar_activity_spec(
+def localised_calendar_activity_spec(
     *,
     start_date: str,
     total_periods: int,
@@ -1791,7 +1791,7 @@ def calendar_activity_spec(
         Dict which functions as the query specification
     """
     return dict(
-        query_kind="total_active_periods",
+        query_kind="localised_calendar_activity",
         total_periods=total_periods,
         period_length=period_length,
         period_unit=period_unit,
@@ -1800,6 +1800,100 @@ def calendar_activity_spec(
         subscriber_subset=subscriber_subset,
         hours=None if hours is None else dict(start_hour=hours[0], end_hour=hours[1]),
         reference_location=locations,
+    )
+
+
+@merge_args(location_event_counts_spec)
+def localised_calendar_activity(*, connection: Connection, **kwargs) -> APIQuery:
+    """
+    Return an aggregation of calendar activity patterns grouped spatially.
+    This query returns an array of datetimes per spatial unit, and a count of the number of subscribers who
+    had an activity pattern which matched that sequence of datetimes with a reference location matching
+    that spatial unit.
+
+    Parameters
+    ----------
+    connection : Connection
+        FlowKit API connection
+    start_date : str
+        ISO format date of the first day of the count, e.g. "2016-01-01"
+    end_date : str
+        ISO format date of the day _after_ the final date of the count, e.g. "2016-01-08"
+    aggregation_unit : str
+        Unit of aggregation, e.g. "admin3"
+    count_interval : {"day", "hour", "minute"}
+        Can be one of "day", "hour" or "minute".
+    direction : {"in", "out", "both"}, default "both"
+        Optionally, include only ingoing or outbound calls/texts. Can be one of "in", "out" or "both".
+    event_types : list of {"calls", "sms", "mds", "topups"}, optional
+        Optionally, include only a subset of event types (for example: ["calls", "sms"]).
+        If None, include all event types in the query.
+    subscriber_subset : dict or None, default None
+        Subset of subscribers to include in event counts. Must be None
+        (= all subscribers) or a dictionary with the specification of a
+        subset query.
+    hours : tuple of int
+        Hours of the day to include
+    locations : dict
+        Modal or daily location query to use to localise the metric
+
+    Returns
+    -------
+    APIQuery
+        Calendar activity query
+    """
+    return connection.make_api_query(
+        parameters=localised_calendar_activity_spec(**kwargs)
+    )
+
+
+def calendar_activity_spec(
+    *,
+    start_date: str,
+    total_periods: int,
+    period_unit: str = "days",
+    period_length: int = 1,
+    event_types: Optional[List[str]] = None,
+    subscriber_subset: Optional[Union[dict, str]] = None,
+    hours: Optional[Tuple[int, int]] = None,
+) -> dict:
+    """
+    Return query spec for total active periods.
+
+    Parameters
+    ----------
+    start_date : str
+        ISO format date of the first day of the count, e.g. "2016-01-01"
+    total_periods : int
+        Total number of periods to break your time span into
+    period_length : int, default 1
+        Total number of days per period.
+    period_unit : {'days', 'hours', 'minutes'} default 'days'
+        Split this time frame into hours or days etc.
+    event_types : list of {"calls", "sms", "mds", "topups"}, optional
+        Optionally, include only a subset of event types (for example: ["calls", "sms"]).
+        If None, include all event types in the query.
+    subscriber_subset : dict or None, default None
+        Subset of subscribers to include in event counts. Must be None
+        (= all subscribers) or a dictionary with the specification of a
+        subset query.
+    hours : tuple of int
+        Hours of the day to include
+
+    Returns
+    -------
+    dict
+        Dict which functions as the query specification
+    """
+    return dict(
+        query_kind="calendar_activity",
+        total_periods=total_periods,
+        period_length=period_length,
+        period_unit=period_unit,
+        start_date=start_date,
+        event_types=event_types,
+        subscriber_subset=subscriber_subset,
+        hours=None if hours is None else dict(start_hour=hours[0], end_hour=hours[1]),
     )
 
 
@@ -1833,8 +1927,6 @@ def calendar_activity(*, connection: Connection, **kwargs) -> APIQuery:
         subset query.
     hours : tuple of int
         Hours of the day to include
-    locations : dict
-        Modal or daily location query to use to localise the metric
 
     Returns
     -------

--- a/flowmachine/flowmachine/core/server/query_schemas/calendar_activity.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/calendar_activity.py
@@ -1,0 +1,104 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marshmallow import fields
+from marshmallow.validate import OneOf
+
+from flowmachine.features.nonspatial_aggregates.redacted_per_value_aggregate import (
+    RedactedPerValueAggregate,
+)
+
+from flowmachine.features.subscriber.calendar_activity import CalendarActivity
+
+from .base_query_with_sampling import (
+    BaseQueryWithSamplingSchema,
+    BaseExposedQueryWithSampling,
+)
+from .custom_fields import ISODateTime
+from .field_mixins import (
+    HoursField,
+    EventTypesField,
+    SubscriberSubsetField,
+)
+
+__all__ = ["CalendarActivitySchema", "CalendarActivityExposed"]
+
+
+class CalendarActivityExposed(BaseExposedQueryWithSampling):
+    # query_kind class attribute is required for nesting and serialisation
+    query_kind = "calendar_activity"
+
+    def __init__(
+        self,
+        start_date,
+        total_periods,
+        *,
+        event_types,
+        period_length=1,
+        period_unit="days",
+        subscriber_subset=None,
+        sampling=None,
+        hours=None,
+        reference_location=None
+    ):
+        # Note: all input parameters need to be defined as attributes on `self`
+        # so that marshmallow can serialise the object correctly.
+        self.start_date = start_date
+        self.total_periods = total_periods
+        self.period_length = period_length
+        self.period_unit = period_unit
+        self.event_types = event_types
+        self.subscriber_subset = subscriber_subset
+        self.sampling = sampling
+        self.hours = hours
+        self.reference_location = reference_location
+
+    @property
+    def _unsampled_query_obj(self):
+        """
+        Return the underlying flowmachine calendar activity object.
+
+        Returns
+        -------
+        Query
+        """
+        calendar_query = CalendarActivity(
+            self.start_date,
+            self.total_periods,
+            period_length=self.period_length,
+            period_unit=self.period_unit,
+            table=self.event_types,
+            subscriber_subset=self.subscriber_subset,
+            hours=self.hours,
+        )
+        if self.reference_location is None:
+            return RedactedPerValueAggregate(calendar_query)
+        else:
+            return RedactedLabelledSpatialAggregate(
+                LabelledSpatialAggregate(
+                    locations=self.reference_location,
+                    labels=calendar_query,
+                )
+            )
+
+
+class CalendarActivitySchema(
+    EventTypesField,
+    SubscriberSubsetField,
+    HoursField,
+    BaseQueryWithSamplingSchema,
+):
+    __model__ = CalendarActivityExposed
+
+    query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
+    start_date = ISODateTime(required=True)
+    total_periods = fields.Integer(required=True)
+    period_length = fields.Integer(missing=1, required=False, default=1)
+    period_unit = fields.String(
+        validate=OneOf(CalendarActivity.allowed_units),
+        missing="days",
+        required=False,
+        default="days",
+    )
+    reference_location = fields.Nested(ReferenceLocationSchema, required=False)

--- a/flowmachine/flowmachine/core/server/query_schemas/custom_fields.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/custom_fields.py
@@ -8,7 +8,7 @@ import datetime
 
 from marshmallow import fields, Schema, validates_schema, ValidationError, post_load
 from marshmallow.validate import Range, Length, OneOf
-from flowmachine.utils import Statistic as ValidStats
+from flowmachine.core.statistic_types import Statistic as ValidStats
 
 
 class Hours(Schema):

--- a/flowmachine/flowmachine/core/server/query_schemas/flowmachine_query.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/flowmachine_query.py
@@ -18,6 +18,7 @@ from .active_at_reference_location_counts import ActiveAtReferenceLocationCounts
 from .consecutive_trips_od_matrix import ConsecutiveTripsODMatrixSchema
 from .dummy_query import DummyQuerySchema
 from .flows import FlowsSchema
+from .localised_calendar_activity import LocalisedCalendarActivitySchema
 from .outflows import OutflowsSchema
 from .inflows import InflowsSchema
 from .meaningful_locations import (
@@ -77,6 +78,7 @@ class FlowmachineQuerySchema(OneOfQuerySchema):
         LabelledSpatialAggregateSchema,
         LabelledFlowsSchema,
         CalendarActivitySchema,
+        LocalisedCalendarActivitySchema,
     )
 
 

--- a/flowmachine/flowmachine/core/server/query_schemas/flowmachine_query.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/flowmachine_query.py
@@ -12,6 +12,7 @@ from flowmachine.core.server.query_schemas.joined_spatial_aggregate import (
 from flowmachine.core.server.query_schemas.spatial_aggregate import (
     SpatialAggregateSchema,
 )
+from .calendar_activity import CalendarActivitySchema
 from .histogram_aggregate import HistogramAggregateSchema
 from .active_at_reference_location_counts import ActiveAtReferenceLocationCountsSchema
 from .consecutive_trips_od_matrix import ConsecutiveTripsODMatrixSchema
@@ -75,6 +76,7 @@ class FlowmachineQuerySchema(OneOfQuerySchema):
         TripsODMatrixSchema,
         LabelledSpatialAggregateSchema,
         LabelledFlowsSchema,
+        CalendarActivitySchema,
     )
 
 

--- a/flowmachine/flowmachine/core/server/query_schemas/histogram_aggregate.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/histogram_aggregate.py
@@ -24,7 +24,9 @@ from flowmachine.core.server.query_schemas.pareto_interactions import (
 )
 from flowmachine.core.server.query_schemas.topup_balance import TopUpBalanceSchema
 
-from flowmachine.features import HistogramAggregation
+from flowmachine.features.nonspatial_aggregates.histogram_aggregation import (
+    HistogramAggregation,
+)
 from .base_exposed_query import BaseExposedQuery
 
 

--- a/flowmachine/flowmachine/core/server/query_schemas/joined_spatial_aggregate.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/joined_spatial_aggregate.py
@@ -30,7 +30,7 @@ from flowmachine.features.location.joined_spatial_aggregate import (
 from flowmachine.features.location.redacted_joined_spatial_aggregate import (
     RedactedJoinedSpatialAggregate,
 )
-from flowmachine.utils import Statistic
+from ...statistic_types import Statistic
 from .base_exposed_query import BaseExposedQuery
 from .aggregation_unit import AggregationUnitKind
 

--- a/flowmachine/flowmachine/core/server/query_schemas/localised_calendar_activity.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/localised_calendar_activity.py
@@ -5,34 +5,45 @@
 from marshmallow import fields
 from marshmallow.validate import OneOf
 
+from flowmachine.features import TotalActivePeriodsSubscriber
+from flowmachine.features.location.labelled_spatial_aggregate import (
+    LabelledSpatialAggregate,
+)
+from flowmachine.features.location.redacted_labelled_spatial_aggregate import (
+    RedactedLabelledSpatialAggregate,
+)
 from flowmachine.features.nonspatial_aggregates.redacted_per_value_aggregate import (
     RedactedPerValueAggregate,
 )
-
 from flowmachine.features.subscriber.calendar_activity import CalendarActivity
-
+from .aggregation_unit import AggregationUnitMixin, AggregationUnitKind
 from .base_query_with_sampling import (
     BaseQueryWithSamplingSchema,
     BaseExposedQueryWithSampling,
 )
+from .calendar_activity import CalendarActivitySchema
 from .custom_fields import ISODateTime
 from .field_mixins import (
     HoursField,
+    StartAndEndField,
     EventTypesField,
     SubscriberSubsetField,
 )
 
-__all__ = ["CalendarActivitySchema", "CalendarActivityExposed"]
+__all__ = ["LocalisedCalendarActivitySchema", "LocalisedCalendarActivityExposed"]
+
+from .reference_location import ReferenceLocationSchema
 
 
-class CalendarActivityExposed(BaseExposedQueryWithSampling):
+class LocalisedCalendarActivityExposed(BaseExposedQueryWithSampling):
     # query_kind class attribute is required for nesting and serialisation
-    query_kind = "calendar_activity"
+    query_kind = "localised_calendar_activity"
 
     def __init__(
         self,
         start_date,
         total_periods,
+        reference_location,
         *,
         event_types,
         period_length=1,
@@ -51,15 +62,20 @@ class CalendarActivityExposed(BaseExposedQueryWithSampling):
         self.subscriber_subset = subscriber_subset
         self.sampling = sampling
         self.hours = hours
+        self.reference_location = reference_location
 
     @property
-    def _unsampled_query_obj(self) -> RedactedPerValueAggregate:
+    def aggregation_unit(self):
+        return self.reference_location.aggregation_unit
+
+    @property
+    def _unsampled_query_obj(self) -> RedactedLabelledSpatialAggregate:
         """
         Return the underlying flowmachine calendar activity object.
 
         Returns
         -------
-        RedactedPerValueAggregate
+        RedactedLabelledSpatialAggregate
         """
         calendar_query = CalendarActivity(
             self.start_date,
@@ -70,24 +86,17 @@ class CalendarActivityExposed(BaseExposedQueryWithSampling):
             subscriber_subset=self.subscriber_subset,
             hours=self.hours,
         )
-        return RedactedPerValueAggregate(calendar_query)
+        return RedactedLabelledSpatialAggregate(
+            labelled_spatial_aggregate=LabelledSpatialAggregate(
+                locations=self.reference_location._flowmachine_query_obj,
+                labels=calendar_query,
+            )
+        )
 
 
-class CalendarActivitySchema(
-    EventTypesField,
-    SubscriberSubsetField,
-    HoursField,
-    BaseQueryWithSamplingSchema,
-):
-    __model__ = CalendarActivityExposed
+class LocalisedCalendarActivitySchema(CalendarActivitySchema):
+    __model__ = LocalisedCalendarActivityExposed
 
     query_kind = fields.String(validate=OneOf([__model__.query_kind]), required=True)
-    start_date = ISODateTime(required=True)
-    total_periods = fields.Integer(required=True)
-    period_length = fields.Integer(missing=1, required=False, default=1)
-    period_unit = fields.String(
-        validate=OneOf(CalendarActivity.allowed_units),
-        missing="days",
-        required=False,
-        default="days",
-    )
+    aggregation_unit = AggregationUnitKind(dump_only=True)
+    reference_location = fields.Nested(ReferenceLocationSchema, required=False)

--- a/flowmachine/flowmachine/core/statistic_types.py
+++ b/flowmachine/flowmachine/core/statistic_types.py
@@ -1,0 +1,68 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from enum import Enum
+
+
+class Statistic(str, Enum):
+    """
+    Valid statistics for use with postgres.
+
+    Convert a column name to a stat by doing f"{statistic:column_name}".
+
+    For columns defined as a variable, do f"{statistic:'{column_name_variable}'}"
+    """
+
+    COUNT = "count"
+    SUM = "sum"
+    AVG = "avg"
+    MAX = "max"
+    MIN = "min"
+    MEDIAN = "median"
+    STDDEV = "stddev"
+    VARIANCE = "variance"
+    MODE = "mode"
+
+    def __format__(self, column_name=""):
+        """
+        Get a postgres statistics function by name.
+
+        Parameters
+        ----------
+        column_name : str
+            Column to aggregate
+
+        Returns
+        -------
+        str
+            A postgres format function call string
+
+        """
+        if column_name == "":
+            return str(self.value)
+        if self == "mode":
+            return f"pg_catalog.mode() WITHIN GROUP (ORDER BY {column_name})"
+        elif self == "mode":
+            return f"pg_catalog.mode() WITHIN GROUP (ORDER BY {column_name}"
+        elif self == "median":
+            return f"percentile_cont(0.5) WITHIN GROUP (ORDER BY {column_name})"
+        else:
+            return f"{self}({column_name})"
+
+
+class StringAggregate(str, Enum):
+    COUNT = "count"
+    MODE = "mode"
+    ARRAY = "array"
+    ARRAY_DESC = "array desc"
+
+    def __format__(self, column_name=""):
+        if column_name == "":
+            return str(self.value)
+        elif self == "array":
+            return f"array_agg({column_name} ORDER BY {column_name})"
+        elif self == "array desc":
+            return f"array_agg({column_name} ORDER BY {column_name} DESC)"
+        else:
+            return f"{Statistic(self):{column_name}}"

--- a/flowmachine/flowmachine/core/union_with_fixed_values.py
+++ b/flowmachine/flowmachine/core/union_with_fixed_values.py
@@ -1,0 +1,63 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import warnings
+
+from typing import List, Any
+
+from .query import Query
+
+from psycopg2.extensions import adapt
+
+
+class UnionWithFixedValues(Query):
+    """
+    Represents concatenating two tables on top of each other, with an added column
+    with a fixed value per table.
+
+    Parameters
+    ----------
+    queries : List[flowmachine.Query object]
+        Queries to union
+    fixed_value : List[Any]
+        Fixed value to use, converted to postgres type using psycopg2 adapter. Must be the same type.
+    fixed_value_column_name : str
+        Name of the column to add
+    all : bool, default: True
+        If False, queries will be deduped, if set to True, duplicate rows will be preserved.
+    """
+
+    def __init__(
+        self,
+        queries: List[Query],
+        fixed_value: List[Any],
+        fixed_value_column_name: str,
+        all: bool = True,
+    ):
+        self.queries = queries
+        self.all = all
+        if not len(set(type(val) for val in fixed_value)) == 1:
+            raise ValueError("Types of all fixed values must be the same.")
+        if not len(fixed_value) == len(queries):
+            raise ValueError("Must supply a fixed value for each table/query.")
+        self.fixed_value = [f"{adapt(val)}" for val in fixed_value]
+        self.fixed_value_column_name = fixed_value_column_name
+        column_set = set(tuple(query.column_names) for query in queries)
+        if len(column_set) > 1:
+            raise ValueError("Inconsistent columns.")
+        if len(queries) < 1:
+            raise ValueError("Union requires at least one query.")
+        if (len(queries) == 1) and (not all):
+            warnings.warn("Single queries are not deduped by Union.")
+
+        super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return [*self.queries[0].column_names, self.fixed_value_column_name]
+
+    def _make_query(self):
+        return (" UNION ALL " if self.all else " UNION ").join(
+            f"(SELECT *, {fixed} AS {self.fixed_value_column_name} FROM ({query.get_query()}) _)"
+            for query, fixed in zip(self.queries, self.fixed_value)
+        )

--- a/flowmachine/flowmachine/features/__init__.py
+++ b/flowmachine/flowmachine/features/__init__.py
@@ -103,6 +103,14 @@ ut = [
     "EventTableSubset",
 ]
 
-sub_modules = ["location", "subscriber", "network", "utilities", "raster", "spatial"]
+sub_modules = [
+    "location",
+    "subscriber",
+    "network",
+    "utilities",
+    "raster",
+    "spatial",
+    "nonspatial_aggregates",
+]
 
 __all__ = loc + nw + subs + rast + ut + spat + sub_modules

--- a/flowmachine/flowmachine/features/location/joined_spatial_aggregate.py
+++ b/flowmachine/flowmachine/features/location/joined_spatial_aggregate.py
@@ -7,7 +7,8 @@ from typing import List, Union
 
 from flowmachine.core import Query
 from flowmachine.core.mixins import GeoDataMixin
-from flowmachine.utils import parse_datestring, Statistic
+from flowmachine.utils import parse_datestring
+from flowmachine.core.statistic_types import Statistic
 
 
 class JoinedSpatialAggregate(GeoDataMixin, Query):

--- a/flowmachine/flowmachine/features/network/total_network_objects.py
+++ b/flowmachine/flowmachine/features/network/total_network_objects.py
@@ -19,8 +19,8 @@ from ...core import location_joined_query, make_spatial_unit
 from ...core.spatial_unit import AnySpatialUnit
 from ...core.query import Query
 from ..utilities import EventsTablesUnion
-from flowmachine.utils import standardise_date, Statistic
-
+from flowmachine.utils import standardise_date
+from ...core.statistic_types import Statistic
 
 valid_periods = ["second", "minute", "hour", "day", "month", "year"]
 

--- a/flowmachine/flowmachine/features/nonspatial_aggregates/histogram_aggregation.py
+++ b/flowmachine/flowmachine/features/nonspatial_aggregates/histogram_aggregation.py
@@ -74,8 +74,8 @@ class HistogramAggregation(Query):
 
     Examples
     --------
-    >>>from flowmachine.features import RadiusOfGyration
-    >>>from flowmachine.features.utilities.histogram_aggregation import HistogramAggregation
+    >>>from flowmachine.features.subscriber.radius_of_gyration import RadiusOfGyration
+    >>>from flowmachine.features.nonspatial_aggregates.histogram_aggregation import HistogramAggregation
     >>>radius_of_gyration = RadiusOfGyration("2016-01-01", "2016-01-02")
     >>>histogram = HistogramAggregation(metric=radius_of_gyration, bins=5, censor=False)
     >>>histogram.head()

--- a/flowmachine/flowmachine/features/nonspatial_aggregates/per_value_aggregate.py
+++ b/flowmachine/flowmachine/features/nonspatial_aggregates/per_value_aggregate.py
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from typing import List
+
+from flowmachine.core import Query
+from flowmachine.core.statistic_types import StringAggregate
+
+
+class PerValueAggregate(Query):
+    """
+    Class representing an aggregate over values, for example a count of subscribers who
+    have each value.
+
+    Parameters
+    ----------
+    query : Query
+        Any query with a subscriber and value column
+    aggregation : StringAggregate, default StringAggregate.COUNT
+        The aggregation to apply
+
+    """
+
+    def __init__(
+        self, query: Query, aggregation: StringAggregate = StringAggregate.COUNT
+    ):
+        if "subscriber" not in query.column_names:
+            raise ValueError(f"Query must have a subscriber column.")
+        if "value" not in query.column_names:
+            raise ValueError(f"Query must have a value column.")
+
+        self.query_to_agg = query
+        self.aggregation = StringAggregate(aggregation.lower())
+
+        super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["grp", "value"]
+
+    def _make_query(self):
+        return f"""
+            SELECT
+                value as grp, {self.aggregation:subscriber} AS value
+            FROM 
+                ({self.query_to_agg.get_query()}) AS agg
+            GROUP BY
+                value
+            """

--- a/flowmachine/flowmachine/features/nonspatial_aggregates/redacted_per_value_aggregate.py
+++ b/flowmachine/flowmachine/features/nonspatial_aggregates/redacted_per_value_aggregate.py
@@ -1,0 +1,54 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from typing import List
+
+from flowmachine.core import Query
+from flowmachine.core.statistic_types import StringAggregate
+
+
+class RedactedPerValueAggregate(Query):
+    """
+    Class representing a redacted aggregate over values, for example a count of subscribers who
+    have each value, where groups with fewer than 16 subscribers are not returned.
+
+    Parameters
+    ----------
+    query : Query
+        Any query with a subscriber and value column
+    aggregation : StringAggregate, default StringAggregate.COUNT
+        The aggregation to apply
+    redaction_threshold: int, default 15
+        If any grouping reveals this number of subscribers or fewer, that grouping is dropped
+    """
+
+    def __init__(
+        self,
+        query: Query,
+        aggregation: StringAggregate = StringAggregate.COUNT,
+        redaction_threshold: int = 15,
+    ):
+        if "subscriber" not in query.column_names:
+            raise ValueError(f"Query must have a subscriber column.")
+        if "value" not in query.column_names:
+            raise ValueError(f"Query must have a value column.")
+
+        self.query_to_agg = query
+        self.aggregation = StringAggregate(aggregation.lower())
+        self.redaction_threshold = redaction_threshold
+        super().__init__()
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["grp", "value"]
+
+    def _make_query(self):
+        return f"""
+            SELECT
+                value as grp, {self.aggregation:subscriber} AS value
+            FROM 
+                ({self.query_to_agg.get_query()}) AS agg
+            GROUP BY
+                value
+            HAVING COUNT(*) > {self.redaction_threshold}
+            """

--- a/flowmachine/flowmachine/features/subscriber/calendar_activity.py
+++ b/flowmachine/flowmachine/features/subscriber/calendar_activity.py
@@ -1,0 +1,102 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# -*- coding: utf-8 -*-
+"""
+A subscriber's activity calendar - an array of datetimes they had some activity in.
+"""
+
+from typing import List, Union as UnionType, Optional, Tuple
+
+from .. import TotalActivePeriodsSubscriber, UniqueSubscribers
+from ...core import Query
+from ...core.union_with_fixed_values import UnionWithFixedValues
+from ...utils import standardise_date_to_datetime
+
+
+class CalendarActivity(TotalActivePeriodsSubscriber):
+    """
+    Class representing the calendar days that a subscriber was active
+    in some period.
+
+    Parameters
+    ----------
+    start : str
+         iso-format start datetime
+    hours : 2-tuple of floats, default 'all'
+        Restrict the analysis to only a certain set
+        of hours within each day.
+    subscriber_identifier : {'msisdn', 'imei'}, default 'msisdn'
+        Either msisdn, or imei, the column that identifies the subscriber.
+    subscriber_subset : str, list, flowmachine.core.Query, flowmachine.core.Table, default None
+        If provided, string or list of string which are msisdn or imeis to limit
+        results to; or, a query or table which has a column with a name matching
+        subscriber_identifier (typically, msisdn), to limit results to.
+    table : str or list of strings, default 'all'
+        Can be a string of a single table (with the schema)
+        or a list of these. The keyword all is to select all
+        subscriber tables
+    total_periods : int
+        Total number of periods to break your time span into
+    period_length : int, default 1
+        Total number of days per period.
+    period_unit : {'days', 'hours', 'minutes'} default 'days'
+        Split this time frame into hours or days etc.
+
+    See Also
+    --------
+    flowmachine.features.subscriber.call_days
+    flowmachine.features.subscriber.total_active_periods
+    """
+
+    def _get_unioned_subscribers_list(
+        self,
+        hours: UnionType[str, Tuple[int, int]] = "all",
+        table: UnionType[str, List[str]] = "all",
+        subscriber_identifier: str = "msisdn",
+        subscriber_subset: Optional[Query] = None,
+    ):
+        """
+        Constructs a list of UniqueSubscribers for each time period.
+        They will be unique within each time period. Joins
+        these lists into one long list and returns the result
+        (as a query)
+        """
+
+        return UnionWithFixedValues(
+            queries=[
+                UniqueSubscribers(
+                    start,
+                    stop,
+                    hours=hours,
+                    table=table,
+                    subscriber_identifier=subscriber_identifier,
+                    subscriber_subset=subscriber_subset,
+                )
+                for start, stop in zip(self.starts, self.stops)
+            ],
+            fixed_value=[standardise_date_to_datetime(dt) for dt in self.starts],
+            fixed_value_column_name="dt",
+        )
+
+    @property
+    def column_names(self) -> List[str]:
+        return ["subscriber", "value"]
+
+    def _make_query(self):
+        # In theory one could do this by doing date_trunc on the events tables union, but
+        # the plan ends up being pretty agressively bad, so we're going to presuppose
+        # that we want to visit every day and get the unique subscribers
+        sql = f"""
+            SELECT
+                ul.subscriber,
+                array_agg(dt ORDER BY dt ASC) as value
+            FROM
+                ({self.unique_subscribers_table.get_query()}) AS ul
+            GROUP BY
+                ul.subscriber
+            ORDER BY value DESC
+              """
+
+        return sql

--- a/flowmachine/flowmachine/features/subscriber/contact_reference_locations_stats.py
+++ b/flowmachine/flowmachine/features/subscriber/contact_reference_locations_stats.py
@@ -10,7 +10,7 @@ location and its contacts' modal location.
 from typing import Union
 
 from .metaclasses import SubscriberFeature
-from ...utils import Statistic
+from ...core.statistic_types import Statistic
 
 
 class ContactReferenceLocationStats(SubscriberFeature):

--- a/flowmachine/flowmachine/features/subscriber/day_trajectories.py
+++ b/flowmachine/flowmachine/features/subscriber/day_trajectories.py
@@ -16,7 +16,6 @@ from typing import List
 from flowmachine.core import Query
 from flowmachine.features.utilities.subscriber_locations import BaseLocation
 from ..utilities.multilocation import MultiLocation
-from flowmachine.core.union import Union
 
 
 class DayTrajectories(MultiLocation, BaseLocation, Query):
@@ -54,14 +53,13 @@ class DayTrajectories(MultiLocation, BaseLocation, Query):
         # This query represents the concatenated locations of the
         # subscribers. Similar to the first step when calculating
         # ModalLocations. See modal_locations.py
-        all_locs = Union(*[self._append_date(dl) for dl in self._all_dls])
 
         sql = f"""
         SELECT 
             all_locs.subscriber, 
             {location_columns_string},
             all_locs.date
-        FROM ({all_locs.get_query()}) AS all_locs
+        FROM ({self.unioned.get_query()}) AS all_locs
         ORDER BY all_locs.subscriber, all_locs.date
         """
 

--- a/flowmachine/flowmachine/features/subscriber/displacement.py
+++ b/flowmachine/flowmachine/features/subscriber/displacement.py
@@ -12,7 +12,8 @@ from flowmachine.features.spatial import DistanceMatrix
 from .metaclasses import SubscriberFeature
 from ..utilities.subscriber_locations import SubscriberLocations, BaseLocation
 from flowmachine.core import Query
-from flowmachine.utils import standardise_date, Statistic
+from flowmachine.utils import standardise_date
+from ...core.statistic_types import Statistic
 
 
 class Displacement(SubscriberFeature):

--- a/flowmachine/flowmachine/features/subscriber/distance_counterparts.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_counterparts.py
@@ -12,7 +12,8 @@ from flowmachine.features.utilities.events_tables_union import EventsTablesUnion
 from flowmachine.features.spatial.distance_matrix import DistanceMatrix
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where, standardise_date, Statistic
+from flowmachine.utils import make_where, standardise_date
+from flowmachine.core.statistic_types import Statistic
 
 
 class DistanceCounterparts(SubscriberFeature):

--- a/flowmachine/flowmachine/features/subscriber/distance_series.py
+++ b/flowmachine/flowmachine/features/subscriber/distance_series.py
@@ -11,8 +11,8 @@ from typing import List, Optional, Union, Tuple
 from flowmachine.features.spatial import DistanceMatrix
 from .metaclasses import SubscriberFeature
 from ..utilities.subscriber_locations import SubscriberLocations, BaseLocation
-from flowmachine.utils import standardise_date, Statistic
-
+from flowmachine.utils import standardise_date
+from ...core.statistic_types import Statistic
 
 valid_time_buckets = [
     "second",

--- a/flowmachine/flowmachine/features/subscriber/handset_stats.py
+++ b/flowmachine/flowmachine/features/subscriber/handset_stats.py
@@ -5,8 +5,7 @@
 # -*- coding: utf-8 -*-
 from typing import Union
 
-from ...utils import Statistic
-
+from ...core.statistic_types import Statistic
 
 valid_characteristics = {
     "width",

--- a/flowmachine/flowmachine/features/subscriber/interevent_interval.py
+++ b/flowmachine/flowmachine/features/subscriber/interevent_interval.py
@@ -14,7 +14,8 @@ from flowmachine.core import Query
 from flowmachine.features.utilities import EventsTablesUnion
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where, standardise_date, Statistic
+from flowmachine.utils import make_where, standardise_date
+from flowmachine.core.statistic_types import Statistic
 
 
 class IntereventInterval(SubscriberFeature):

--- a/flowmachine/flowmachine/features/subscriber/interevent_period.py
+++ b/flowmachine/flowmachine/features/subscriber/interevent_period.py
@@ -13,7 +13,7 @@ from flowmachine.core import Query
 from flowmachine.features.subscriber.interevent_interval import IntereventInterval
 from .metaclasses import SubscriberFeature
 from ..utilities.direction_enum import Direction
-from ...utils import Statistic
+from ...core.statistic_types import Statistic
 
 time_resolutions = dict(
     second=1, minute=60, hour=3600, day=86400, month=2592000, year=31557600

--- a/flowmachine/flowmachine/features/subscriber/mds_volume.py
+++ b/flowmachine/flowmachine/features/subscriber/mds_volume.py
@@ -10,7 +10,8 @@ from typing import Optional, Tuple
 
 from ..utilities.sets import EventsTablesUnion
 from .metaclasses import SubscriberFeature
-from flowmachine.utils import standardise_date, Statistic
+from flowmachine.utils import standardise_date
+from ...core.statistic_types import Statistic
 
 
 class MDSVolume(SubscriberFeature):

--- a/flowmachine/flowmachine/features/subscriber/modal_location.py
+++ b/flowmachine/flowmachine/features/subscriber/modal_location.py
@@ -12,12 +12,10 @@ The modal daily location of a subscriber.
 """
 from typing import List
 
-from functools import reduce
 
 from flowmachine.core import Query
 from flowmachine.features.utilities.subscriber_locations import BaseLocation
 from ..utilities.multilocation import MultiLocation
-from ...core.union import Union
 
 
 class ModalLocation(MultiLocation, BaseLocation, Query):
@@ -39,13 +37,9 @@ class ModalLocation(MultiLocation, BaseLocation, Query):
         """
         location_columns_string = ", ".join(self.spatial_unit.location_id_columns)
 
-        # This query represents the concatenated locations of the
-        # subscribers
-        all_locs = Union(*[self._append_date(dl) for dl in self._all_dls])
-
         times_visited = f"""
         SELECT all_locs.subscriber, {location_columns_string}, count(*) AS total, max(all_locs.date) as date
-        FROM ({all_locs.get_query()}) AS all_locs
+        FROM ({self.unioned.get_query()}) AS all_locs
         GROUP BY all_locs.subscriber, {location_columns_string}
         """
 

--- a/flowmachine/flowmachine/features/subscriber/per_contact_event_stats.py
+++ b/flowmachine/flowmachine/features/subscriber/per_contact_event_stats.py
@@ -6,7 +6,7 @@
 
 from .metaclasses import SubscriberFeature
 from flowmachine.features.subscriber.contact_balance import ContactBalance
-from flowmachine.utils import Statistic
+from ...core.statistic_types import Statistic
 
 
 class PerContactEventStats(SubscriberFeature):

--- a/flowmachine/flowmachine/features/subscriber/per_location_event_stats.py
+++ b/flowmachine/flowmachine/features/subscriber/per_location_event_stats.py
@@ -10,7 +10,8 @@ from flowmachine.core.spatial_unit import AnySpatialUnit, make_spatial_unit
 from flowmachine.features.utilities.events_tables_union import EventsTablesUnion
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where, standardise_date, Statistic
+from flowmachine.utils import make_where, standardise_date
+from flowmachine.core.statistic_types import Statistic
 
 
 class PerLocationEventStats(SubscriberFeature):

--- a/flowmachine/flowmachine/features/subscriber/per_subscriber_aggregate.py
+++ b/flowmachine/flowmachine/features/subscriber/per_subscriber_aggregate.py
@@ -6,7 +6,7 @@
 
 from typing import List
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
-from flowmachine.utils import Statistic
+from flowmachine.core.statistic_types import Statistic
 
 
 class PerSubscriberAggregate(SubscriberFeature):

--- a/flowmachine/flowmachine/features/subscriber/subscriber_call_durations.py
+++ b/flowmachine/flowmachine/features/subscriber/subscriber_call_durations.py
@@ -17,7 +17,8 @@ from flowmachine.core.spatial_unit import AnySpatialUnit, make_spatial_unit
 from flowmachine.features.utilities.events_tables_union import EventsTablesUnion
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.direction_enum import Direction
-from flowmachine.utils import make_where, standardise_date, Statistic
+from flowmachine.utils import make_where, standardise_date
+from flowmachine.core.statistic_types import Statistic
 
 
 class SubscriberCallDurations(SubscriberFeature):

--- a/flowmachine/flowmachine/features/subscriber/subscriber_stay_lengths.py
+++ b/flowmachine/flowmachine/features/subscriber/subscriber_stay_lengths.py
@@ -7,7 +7,7 @@ from typing import List
 from flowmachine.features.subscriber.metaclasses import SubscriberFeature
 from flowmachine.features.utilities.subscriber_locations import BaseLocation
 from flowmachine.core.errors import InvalidSpatialUnitError
-from flowmachine.utils import Statistic
+from flowmachine.core.statistic_types import Statistic
 
 
 class SubscriberStayLengths(SubscriberFeature):

--- a/flowmachine/flowmachine/features/subscriber/topup_amount.py
+++ b/flowmachine/flowmachine/features/subscriber/topup_amount.py
@@ -12,7 +12,8 @@ import warnings
 
 from ..utilities.sets import EventsTablesUnion
 from .metaclasses import SubscriberFeature
-from flowmachine.utils import standardise_date, Statistic
+from flowmachine.utils import standardise_date
+from ...core.statistic_types import Statistic
 
 
 class TopUpAmount(SubscriberFeature):

--- a/flowmachine/flowmachine/features/subscriber/topup_balance.py
+++ b/flowmachine/flowmachine/features/subscriber/topup_balance.py
@@ -12,7 +12,8 @@ import warnings
 
 from ..utilities.sets import EventsTablesUnion
 from .metaclasses import SubscriberFeature
-from flowmachine.utils import standardise_date, Statistic
+from flowmachine.utils import standardise_date
+from ...core.statistic_types import Statistic
 
 
 class TopUpBalance(SubscriberFeature):

--- a/flowmachine/flowmachine/features/subscriber/total_active_periods.py
+++ b/flowmachine/flowmachine/features/subscriber/total_active_periods.py
@@ -62,7 +62,7 @@ class TotalActivePeriodsSubscriber(SubscriberFeature):
     --------
 
     >>> TotalActivePeriods('2016-01-01', 10, 3).get_dataframe()
-        subscriber     total_periods
+        subscriber     value
         subscriberA       10
         subscriberB       3
         subscriberC       7
@@ -156,14 +156,13 @@ class TotalActivePeriodsSubscriber(SubscriberFeature):
 
     @property
     def column_names(self) -> List[str]:
-        return ["subscriber", "value", "inactive_periods"]
+        return ["subscriber", "value"]
 
     def _make_query(self):
         sql = """
             SELECT
                 ul.subscriber,
-                count(*) AS value,
-                {total_periods} - count(*) AS inactive_periods
+                count(*) AS value
             FROM
                 ({unique_subscribers_table}) AS ul
             GROUP BY

--- a/flowmachine/flowmachine/features/utilities/__init__.py
+++ b/flowmachine/flowmachine/features/utilities/__init__.py
@@ -13,4 +13,3 @@ from .feature_collection import feature_collection
 from .sets import UniqueSubscribers, SubscriberLocationSubset
 from .event_table_subset import EventTableSubset
 from .events_tables_union import EventsTablesUnion
-from .histogram_aggregation import HistogramAggregation

--- a/flowmachine/flowmachine/utils.py
+++ b/flowmachine/flowmachine/utils.py
@@ -6,7 +6,6 @@
 """
 Various simple utilities.
 """
-from enum import Enum
 
 import datetime
 import re
@@ -15,50 +14,7 @@ from functools import singledispatch
 from pglast import prettify
 from psycopg2._psycopg import adapt
 from time import sleep
-from typing import Union, Tuple
-
-
-class Statistic(str, Enum):
-    """
-    Valid statistics for use with postgres.
-
-    Convert a column name to a stat by doing f"{statistic:column_name}".
-
-    For columns defined as a variable, do f"{statistic:'{column_name_variable}'}"
-    """
-
-    COUNT = "count"
-    SUM = "sum"
-    AVG = "avg"
-    MAX = "max"
-    MIN = "min"
-    MEDIAN = "median"
-    STDDEV = "stddev"
-    VARIANCE = "variance"
-    MODE = "mode"
-
-    def __format__(self, column_name=""):
-        """
-        Get a postgres statistics function by name.
-
-        Parameters
-        ----------
-        column_name : str
-            Column to aggregate
-        Returns
-        -------
-        str
-            A postgres format function call string
-
-        """
-        if column_name == "":
-            return str(self.value)
-        if self == "mode":
-            return f"pg_catalog.mode() WITHIN GROUP (ORDER BY {column_name})"
-        elif self == "median":
-            return f"percentile_cont(0.5) WITHIN GROUP (ORDER BY {column_name})"
-        else:
-            return f"{self}({column_name})"
+from typing import Union, Tuple, Literal
 
 
 def parse_datestring(

--- a/flowmachine/tests/test_histogram_aggregations.py
+++ b/flowmachine/tests/test_histogram_aggregations.py
@@ -7,7 +7,9 @@ import pytest
 
 from flowmachine.core import CustomQuery
 from flowmachine.features import RadiusOfGyration
-from flowmachine.features.utilities.histogram_aggregation import HistogramAggregation
+from flowmachine.features.nonspatial_aggregates.histogram_aggregation import (
+    HistogramAggregation,
+)
 
 
 def test_non_default_value_column(get_dataframe):

--- a/flowmachine/tests/test_per_subscriber_aggregate.py
+++ b/flowmachine/tests/test_per_subscriber_aggregate.py
@@ -14,7 +14,7 @@ from flowmachine.core.dummy_query import DummyQuery
 
 import pytest
 
-from flowmachine.utils import Statistic
+from flowmachine.core.statistic_types import Statistic
 
 
 @pytest.fixture()

--- a/flowmachine/tests/test_per_value_aggregate.py
+++ b/flowmachine/tests/test_per_value_aggregate.py
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from flowmachine.features import EventCount
+from flowmachine.features.nonspatial_aggregates.per_value_aggregate import (
+    PerValueAggregate,
+)
+
+
+def test_per_value_aggregate(get_dataframe):
+    test_query = EventCount("2016-01-01", "2016-01-02")
+    per_val = PerValueAggregate(test_query)
+    per_val_df = get_dataframe(per_val)
+    test_query_df = get_dataframe(test_query)
+    assert all(
+        test_query_df.groupby("value").count().rename(columns=dict(subscriber="value"))
+        == per_val_df.set_index("grp").sort_index()
+    )

--- a/flowmachine/tests/test_query_object_construction.test_construct_query.approved.txt
+++ b/flowmachine/tests/test_query_object_construction.test_construct_query.approved.txt
@@ -42,7 +42,7 @@
     "event_types": null,
     "subscriber_subset": null
   },
-  "ea5d819b0128448732785dea44bcd866": {
+  "b48d02838163766771eeed8cd8aafd98": {
     "query_kind": "spatial_aggregate",
     "locations": {
       "query_kind": "modal_location",
@@ -371,7 +371,7 @@
     },
     "join_type": "left outer"
   },
-  "30efc8b5452d126750a5ed2ac68095a7": {
+  "95fbc18554e15733df47bfd5cbaa3f87": {
     "query_kind": "flows",
     "from_location": {
       "query_kind": "majority_location",
@@ -418,7 +418,7 @@
       }
     }
   },
-  "1a526dd5bde9f228414aabde34f83dad": {
+  "a90f42148e62634e1dfc611fd4a81144": {
     "query_kind": "labelled_spatial_aggregate",
     "locations": {
       "query_kind": "coalesced_location",
@@ -640,7 +640,7 @@
       "stay_length_threshold": 2
     }
   },
-  "40f9ca28db8087ceb3c5a1036b681979": {
+  "7d993133723f53a73dd068a9cf399018": {
     "query_kind": "labelled_flows",
     "from_location": {
       "query_kind": "coalesced_location",

--- a/flowmachine/tests/test_redacted_per_value_aggregate.py
+++ b/flowmachine/tests/test_redacted_per_value_aggregate.py
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from flowmachine.features import EventCount
+from flowmachine.features.nonspatial_aggregates.redacted_per_value_aggregate import (
+    RedactedPerValueAggregate,
+)
+
+
+def test_redacted_per_value_aggregate(get_dataframe):
+    test_query = EventCount("2016-01-01", "2016-01-02")
+    per_val = RedactedPerValueAggregate(test_query)
+    per_val_df = get_dataframe(per_val)
+    test_query_df = get_dataframe(test_query)
+    aggregated_with_pandas = (
+        test_query_df.groupby("value").count().rename(columns=dict(subscriber="value"))
+    ).query("value > 15")
+    assert all(per_val_df.set_index("grp").value > 15)
+    assert all(aggregated_with_pandas == per_val_df.set_index("grp").sort_index())

--- a/flowmachine/tests/test_subscriber_calendar_activity.py
+++ b/flowmachine/tests/test_subscriber_calendar_activity.py
@@ -1,0 +1,52 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Tests for the class flowmachine.TotalActivePeriodsSubscriber
+"""
+import datetime
+import pytest
+
+from flowmachine.features.subscriber.calendar_activity import CalendarActivity
+
+
+def test_certain_results(get_dataframe):
+    """
+    calendar activity gives correct results.
+    """
+    tap = CalendarActivity("2016-01-01", 3, 1)
+    # This subscriber should have only 2 active time periods
+    subscriber_with_2 = "rmb4PG9gx1ZqBE01"
+    # and this one three
+    subscriber_with_3 = "dXogRAnyg1Q9lE3J"
+
+    df = get_dataframe(tap).set_index("subscriber")
+    assert df.loc[subscriber_with_2].value == [
+        datetime.datetime(2016, 1, 1, 0, 0),
+        datetime.datetime(2016, 1, 3, 0, 0),
+    ]
+    assert df.loc[subscriber_with_3].value == [
+        datetime.datetime(2016, 1, 1, 0, 0),
+        datetime.datetime(2016, 1, 2, 0, 0),
+        datetime.datetime(2016, 1, 3, 0, 0),
+    ]
+
+
+def test_non_standard_units(get_dataframe):
+    """
+    calendar activity is able to handle a period_unit other
+    than the default 'days'.
+    """
+
+    df = (
+        CalendarActivity("2016-01-01", 5, period_unit="hours")
+        .get_dataframe()
+        .set_index("subscriber")
+    )
+
+    assert df.loc["VkzMxYjv7mYn53oK"].value == [
+        datetime.datetime(2016, 1, 1, 0, 0),
+        datetime.datetime(2016, 1, 1, 2, 0),
+        datetime.datetime(2016, 1, 1, 4, 0),
+    ]

--- a/flowmachine/tests/test_subscriber_call_durations.py
+++ b/flowmachine/tests/test_subscriber_call_durations.py
@@ -5,7 +5,7 @@
 import pytest
 
 from flowmachine.features.subscriber.subscriber_call_durations import *
-from flowmachine.utils import Statistic
+from flowmachine.core.statistic_types import Statistic
 
 
 @pytest.mark.parametrize(

--- a/flowmachine/tests/test_total_active_periods_subscriber.py
+++ b/flowmachine/tests/test_total_active_periods_subscriber.py
@@ -23,8 +23,6 @@ def test_certain_results(get_dataframe):
     df = get_dataframe(tap).set_index("subscriber")
     assert df.loc[subscriber_with_2].value == 2
     assert df.loc[subscriber_with_3].value == 3
-    assert df.loc[subscriber_with_2].inactive_periods == 1
-    assert df.loc[subscriber_with_3].inactive_periods == 0
 
 
 def test_multiple_day_periods(get_dataframe):
@@ -43,7 +41,6 @@ def test_multiple_day_periods(get_dataframe):
     # For good measure assert that no subscriber has more than the
     # max number of periods
     assert df.value.max() == 3
-    assert df.inactive_periods.max() == 0
 
 
 def test_raises_value_error_bad_unit():
@@ -70,5 +67,3 @@ def test_non_standard_units(get_dataframe):
 
     assert df.loc["VkzMxYjv7mYn53oK"].value == 3
     assert df.loc["DzpZJ2EaVQo2X5vM"].value == 1
-    assert df.loc["VkzMxYjv7mYn53oK"].inactive_periods == 2
-    assert df.loc["DzpZJ2EaVQo2X5vM"].inactive_periods == 4

--- a/flowmachine/tests/test_union_with_fixed_values.py
+++ b/flowmachine/tests/test_union_with_fixed_values.py
@@ -1,0 +1,83 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import datetime
+
+import pytest
+import numpy
+
+from flowmachine.core import Table
+from flowmachine.core.union_with_fixed_values import UnionWithFixedValues
+
+
+def test_union_column_names():
+    """Test that Union's column_names property is accurate"""
+    union = UnionWithFixedValues(
+        [Table("events.calls_20160101"), Table("events.calls_20160102")],
+        ["extra_val", "extra_val"],
+        fixed_value_column_name="extra_col",
+    )
+    assert union.head(0).columns.tolist() == union.column_names
+    assert union.column_names == [*Table("events.calls_20160101").columns, "extra_col"]
+
+
+def test_union_all(get_dataframe):
+    """
+    Test default union behaviour keeps duplicates.
+    """
+    q1 = Table(schema="events", name="calls")
+    union_all = q1.union(q1)
+    union_all_df = get_dataframe(union_all)
+    single_id = union_all_df[union_all_df.id == "5wNJA-PdRJ4-jxEdG-yOXpZ"]
+    assert len(single_id) == 4
+
+
+def test_union(get_dataframe):
+    """
+    Test union adds extra columns.
+    """
+    union = UnionWithFixedValues(
+        [Table("events.calls_20160101"), Table("events.calls_20160101")],
+        ["extra_val", "extra_val_1"],
+        fixed_value_column_name="extra_col",
+    )
+    df = get_dataframe(union)
+    assert df["extra_col"].nunique() == 2
+    assert set(df["extra_col"].values) == set(["extra_val", "extra_val_1"])
+
+
+def test_union_date_type(get_dataframe):
+    """
+    Test union casts types correctly for datetimes.
+    """
+    union = UnionWithFixedValues(
+        [Table("events.calls_20160101"), Table("events.calls_20160101")],
+        [datetime.datetime(2016, 1, 1), datetime.datetime(2016, 1, 2)],
+        fixed_value_column_name="extra_col",
+    )
+    df = get_dataframe(union)
+    assert df["extra_col"].dtype == numpy.dtype("datetime64[ns]")
+
+
+def test_union_raises_with_mismatched_extras_types():
+    """
+    Test that unioning queries with inconsistent types for extra values raises an error.
+    """
+    with pytest.raises(ValueError):
+        UnionWithFixedValues(
+            [Table("events.calls_20160101"), Table("events.calls_20160101")],
+            [datetime.date(2016, 1, 1), "NOT A DATE"],
+            fixed_value_column_name="extra_col",
+        )
+
+
+def test_union_raises_with_not_enough_extras():
+    """
+    Test that unioning empty list raises an error.
+    """
+    with pytest.raises(ValueError):
+        UnionWithFixedValues(
+            [Table("events.calls_20160101"), Table("events.calls_20160101")],
+            [datetime.date(2016, 1, 1)],
+            fixed_value_column_name="extra_col",
+        )

--- a/flowmachine/tests/test_utils.py
+++ b/flowmachine/tests/test_utils.py
@@ -9,6 +9,7 @@ import pytest
 import pglast
 
 from flowmachine.core.context import get_db
+from flowmachine.core.statistic_types import Statistic
 from flowmachine.utils import *
 from flowmachine.utils import _makesafe
 

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_json_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_json_spec.approved.txt
@@ -138,6 +138,78 @@
         ],
         "type": "object"
       },
+      "CalendarActivity": {
+        "properties": {
+          "event_types": {
+            "default": null,
+            "items": {
+              "enum": [
+                "calls",
+                "mds",
+                "sms",
+                "topups"
+              ],
+              "type": "string"
+            },
+            "minItems": 1,
+            "nullable": true,
+            "type": "array"
+          },
+          "hours": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Hours"
+              }
+            ],
+            "default": null,
+            "nullable": true
+          },
+          "period_length": {
+            "default": 1,
+            "type": "integer"
+          },
+          "period_unit": {
+            "default": "days",
+            "enum": [
+              "days",
+              "hours",
+              "minutes"
+            ],
+            "type": "string"
+          },
+          "query_kind": {
+            "enum": [
+              "calendar_activity"
+            ],
+            "type": "string"
+          },
+          "sampling": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RandomSample"
+              }
+            ],
+            "nullable": true
+          },
+          "start_date": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "subscriber_subset": {
+            "nullable": true,
+            "type": "string"
+          },
+          "total_periods": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query_kind",
+          "start_date",
+          "total_periods"
+        ],
+        "type": "object"
+      },
       "CoalescedLocation": {
         "properties": {
           "fallback_location": {
@@ -580,6 +652,7 @@
           "mapping": {
             "active_at_reference_location_counts": "#/components/schemas/ActiveAtReferenceLocationCounts",
             "aggregate_network_objects": "#/components/schemas/AggregateNetworkObjects",
+            "calendar_activity": "#/components/schemas/CalendarActivity",
             "consecutive_trips_od_matrix": "#/components/schemas/ConsecutiveTripsODMatrix",
             "dfs_metric_total_amount": "#/components/schemas/DFSTotalMetricAmount",
             "dummy_query": "#/components/schemas/DummyQuery",
@@ -590,6 +663,7 @@
             "joined_spatial_aggregate": "#/components/schemas/JoinedSpatialAggregate",
             "labelled_flows": "#/components/schemas/LabelledFlows",
             "labelled_spatial_aggregate": "#/components/schemas/LabelledSpatialAggregate",
+            "localised_calendar_activity": "#/components/schemas/LocalisedCalendarActivity",
             "location_event_counts": "#/components/schemas/LocationEventCounts",
             "location_introversion": "#/components/schemas/LocationIntroversion",
             "meaningful_locations_aggregate": "#/components/schemas/MeaningfulLocationsAggregate",
@@ -612,6 +686,9 @@
           },
           {
             "$ref": "#/components/schemas/AggregateNetworkObjects"
+          },
+          {
+            "$ref": "#/components/schemas/CalendarActivity"
           },
           {
             "$ref": "#/components/schemas/ConsecutiveTripsODMatrix"
@@ -642,6 +719,9 @@
           },
           {
             "$ref": "#/components/schemas/LabelledSpatialAggregate"
+          },
+          {
+            "$ref": "#/components/schemas/LocalisedCalendarActivity"
           },
           {
             "$ref": "#/components/schemas/LocationEventCounts"
@@ -1228,6 +1308,92 @@
           "labels",
           "locations",
           "query_kind"
+        ],
+        "type": "object"
+      },
+      "LocalisedCalendarActivity": {
+        "properties": {
+          "aggregation_unit": {
+            "enum": [
+              "admin0",
+              "admin1",
+              "admin2",
+              "admin3",
+              "lon-lat"
+            ],
+            "readOnly": true,
+            "type": "string"
+          },
+          "event_types": {
+            "default": null,
+            "items": {
+              "enum": [
+                "calls",
+                "mds",
+                "sms",
+                "topups"
+              ],
+              "type": "string"
+            },
+            "minItems": 1,
+            "nullable": true,
+            "type": "array"
+          },
+          "hours": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Hours"
+              }
+            ],
+            "default": null,
+            "nullable": true
+          },
+          "period_length": {
+            "default": 1,
+            "type": "integer"
+          },
+          "period_unit": {
+            "default": "days",
+            "enum": [
+              "days",
+              "hours",
+              "minutes"
+            ],
+            "type": "string"
+          },
+          "query_kind": {
+            "enum": [
+              "localised_calendar_activity"
+            ],
+            "type": "string"
+          },
+          "reference_location": {
+            "$ref": "#/components/schemas/ReferenceLocation"
+          },
+          "sampling": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RandomSample"
+              }
+            ],
+            "nullable": true
+          },
+          "start_date": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "subscriber_subset": {
+            "nullable": true,
+            "type": "string"
+          },
+          "total_periods": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query_kind",
+          "start_date",
+          "total_periods"
         ],
         "type": "object"
       },
@@ -3253,6 +3419,14 @@
           "admin0:labelled_spatial_aggregate:majority_location",
           "admin0:labelled_spatial_aggregate:mobility_classification",
           "admin0:labelled_spatial_aggregate:modal_location",
+          "admin0:localised_calendar_activity:coalesced_location",
+          "admin0:localised_calendar_activity:daily_location",
+          "admin0:localised_calendar_activity:localised_calendar_activity",
+          "admin0:localised_calendar_activity:location_visits",
+          "admin0:localised_calendar_activity:majority_location",
+          "admin0:localised_calendar_activity:modal_location",
+          "admin0:localised_calendar_activity:most_frequent_location",
+          "admin0:localised_calendar_activity:visited_most_days",
           "admin0:location_event_counts:location_event_counts",
           "admin0:location_introversion:location_introversion",
           "admin0:meaningful_locations_aggregate:meaningful_locations_aggregate",
@@ -3366,6 +3540,14 @@
           "admin1:labelled_spatial_aggregate:majority_location",
           "admin1:labelled_spatial_aggregate:mobility_classification",
           "admin1:labelled_spatial_aggregate:modal_location",
+          "admin1:localised_calendar_activity:coalesced_location",
+          "admin1:localised_calendar_activity:daily_location",
+          "admin1:localised_calendar_activity:localised_calendar_activity",
+          "admin1:localised_calendar_activity:location_visits",
+          "admin1:localised_calendar_activity:majority_location",
+          "admin1:localised_calendar_activity:modal_location",
+          "admin1:localised_calendar_activity:most_frequent_location",
+          "admin1:localised_calendar_activity:visited_most_days",
           "admin1:location_event_counts:location_event_counts",
           "admin1:location_introversion:location_introversion",
           "admin1:meaningful_locations_aggregate:meaningful_locations_aggregate",
@@ -3479,6 +3661,14 @@
           "admin2:labelled_spatial_aggregate:majority_location",
           "admin2:labelled_spatial_aggregate:mobility_classification",
           "admin2:labelled_spatial_aggregate:modal_location",
+          "admin2:localised_calendar_activity:coalesced_location",
+          "admin2:localised_calendar_activity:daily_location",
+          "admin2:localised_calendar_activity:localised_calendar_activity",
+          "admin2:localised_calendar_activity:location_visits",
+          "admin2:localised_calendar_activity:majority_location",
+          "admin2:localised_calendar_activity:modal_location",
+          "admin2:localised_calendar_activity:most_frequent_location",
+          "admin2:localised_calendar_activity:visited_most_days",
           "admin2:location_event_counts:location_event_counts",
           "admin2:location_introversion:location_introversion",
           "admin2:meaningful_locations_aggregate:meaningful_locations_aggregate",
@@ -3592,6 +3782,14 @@
           "admin3:labelled_spatial_aggregate:majority_location",
           "admin3:labelled_spatial_aggregate:mobility_classification",
           "admin3:labelled_spatial_aggregate:modal_location",
+          "admin3:localised_calendar_activity:coalesced_location",
+          "admin3:localised_calendar_activity:daily_location",
+          "admin3:localised_calendar_activity:localised_calendar_activity",
+          "admin3:localised_calendar_activity:location_visits",
+          "admin3:localised_calendar_activity:majority_location",
+          "admin3:localised_calendar_activity:modal_location",
+          "admin3:localised_calendar_activity:most_frequent_location",
+          "admin3:localised_calendar_activity:visited_most_days",
           "admin3:location_event_counts:location_event_counts",
           "admin3:location_introversion:location_introversion",
           "admin3:meaningful_locations_aggregate:meaningful_locations_aggregate",
@@ -3708,6 +3906,14 @@
           "lon-lat:labelled_spatial_aggregate:majority_location",
           "lon-lat:labelled_spatial_aggregate:mobility_classification",
           "lon-lat:labelled_spatial_aggregate:modal_location",
+          "lon-lat:localised_calendar_activity:coalesced_location",
+          "lon-lat:localised_calendar_activity:daily_location",
+          "lon-lat:localised_calendar_activity:localised_calendar_activity",
+          "lon-lat:localised_calendar_activity:location_visits",
+          "lon-lat:localised_calendar_activity:majority_location",
+          "lon-lat:localised_calendar_activity:modal_location",
+          "lon-lat:localised_calendar_activity:most_frequent_location",
+          "lon-lat:localised_calendar_activity:visited_most_days",
           "lon-lat:location_event_counts:location_event_counts",
           "lon-lat:location_introversion:location_introversion",
           "lon-lat:meaningful_locations_aggregate:meaningful_locations_aggregate",
@@ -3755,6 +3961,7 @@
           "lon-lat:unmoving_at_reference_location_counts:visited_most_days",
           "lon-lat:unmoving_counts:unique_locations",
           "lon-lat:unmoving_counts:unmoving_counts",
+          "nonspatial:calendar_activity:calendar_activity",
           "nonspatial:histogram_aggregate:coalesced_location",
           "nonspatial:histogram_aggregate:daily_location",
           "nonspatial:histogram_aggregate:displacement",

--- a/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_yaml_spec.approved.txt
+++ b/integration_tests/tests/flowapi_tests/test_api_spec.test_generated_openapi_yaml_spec.approved.txt
@@ -138,6 +138,78 @@
         ],
         "type": "object"
       },
+      "CalendarActivity": {
+        "properties": {
+          "event_types": {
+            "default": null,
+            "items": {
+              "enum": [
+                "calls",
+                "mds",
+                "sms",
+                "topups"
+              ],
+              "type": "string"
+            },
+            "minItems": 1,
+            "nullable": true,
+            "type": "array"
+          },
+          "hours": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Hours"
+              }
+            ],
+            "default": null,
+            "nullable": true
+          },
+          "period_length": {
+            "default": 1,
+            "type": "integer"
+          },
+          "period_unit": {
+            "default": "days",
+            "enum": [
+              "days",
+              "hours",
+              "minutes"
+            ],
+            "type": "string"
+          },
+          "query_kind": {
+            "enum": [
+              "calendar_activity"
+            ],
+            "type": "string"
+          },
+          "sampling": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RandomSample"
+              }
+            ],
+            "nullable": true
+          },
+          "start_date": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "subscriber_subset": {
+            "nullable": true,
+            "type": "string"
+          },
+          "total_periods": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query_kind",
+          "start_date",
+          "total_periods"
+        ],
+        "type": "object"
+      },
       "CoalescedLocation": {
         "properties": {
           "fallback_location": {
@@ -580,6 +652,7 @@
           "mapping": {
             "active_at_reference_location_counts": "#/components/schemas/ActiveAtReferenceLocationCounts",
             "aggregate_network_objects": "#/components/schemas/AggregateNetworkObjects",
+            "calendar_activity": "#/components/schemas/CalendarActivity",
             "consecutive_trips_od_matrix": "#/components/schemas/ConsecutiveTripsODMatrix",
             "dfs_metric_total_amount": "#/components/schemas/DFSTotalMetricAmount",
             "dummy_query": "#/components/schemas/DummyQuery",
@@ -590,6 +663,7 @@
             "joined_spatial_aggregate": "#/components/schemas/JoinedSpatialAggregate",
             "labelled_flows": "#/components/schemas/LabelledFlows",
             "labelled_spatial_aggregate": "#/components/schemas/LabelledSpatialAggregate",
+            "localised_calendar_activity": "#/components/schemas/LocalisedCalendarActivity",
             "location_event_counts": "#/components/schemas/LocationEventCounts",
             "location_introversion": "#/components/schemas/LocationIntroversion",
             "meaningful_locations_aggregate": "#/components/schemas/MeaningfulLocationsAggregate",
@@ -612,6 +686,9 @@
           },
           {
             "$ref": "#/components/schemas/AggregateNetworkObjects"
+          },
+          {
+            "$ref": "#/components/schemas/CalendarActivity"
           },
           {
             "$ref": "#/components/schemas/ConsecutiveTripsODMatrix"
@@ -642,6 +719,9 @@
           },
           {
             "$ref": "#/components/schemas/LabelledSpatialAggregate"
+          },
+          {
+            "$ref": "#/components/schemas/LocalisedCalendarActivity"
           },
           {
             "$ref": "#/components/schemas/LocationEventCounts"
@@ -1228,6 +1308,92 @@
           "labels",
           "locations",
           "query_kind"
+        ],
+        "type": "object"
+      },
+      "LocalisedCalendarActivity": {
+        "properties": {
+          "aggregation_unit": {
+            "enum": [
+              "admin0",
+              "admin1",
+              "admin2",
+              "admin3",
+              "lon-lat"
+            ],
+            "readOnly": true,
+            "type": "string"
+          },
+          "event_types": {
+            "default": null,
+            "items": {
+              "enum": [
+                "calls",
+                "mds",
+                "sms",
+                "topups"
+              ],
+              "type": "string"
+            },
+            "minItems": 1,
+            "nullable": true,
+            "type": "array"
+          },
+          "hours": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Hours"
+              }
+            ],
+            "default": null,
+            "nullable": true
+          },
+          "period_length": {
+            "default": 1,
+            "type": "integer"
+          },
+          "period_unit": {
+            "default": "days",
+            "enum": [
+              "days",
+              "hours",
+              "minutes"
+            ],
+            "type": "string"
+          },
+          "query_kind": {
+            "enum": [
+              "localised_calendar_activity"
+            ],
+            "type": "string"
+          },
+          "reference_location": {
+            "$ref": "#/components/schemas/ReferenceLocation"
+          },
+          "sampling": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RandomSample"
+              }
+            ],
+            "nullable": true
+          },
+          "start_date": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "subscriber_subset": {
+            "nullable": true,
+            "type": "string"
+          },
+          "total_periods": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query_kind",
+          "start_date",
+          "total_periods"
         ],
         "type": "object"
       },
@@ -3253,6 +3419,14 @@
           "admin0:labelled_spatial_aggregate:majority_location",
           "admin0:labelled_spatial_aggregate:mobility_classification",
           "admin0:labelled_spatial_aggregate:modal_location",
+          "admin0:localised_calendar_activity:coalesced_location",
+          "admin0:localised_calendar_activity:daily_location",
+          "admin0:localised_calendar_activity:localised_calendar_activity",
+          "admin0:localised_calendar_activity:location_visits",
+          "admin0:localised_calendar_activity:majority_location",
+          "admin0:localised_calendar_activity:modal_location",
+          "admin0:localised_calendar_activity:most_frequent_location",
+          "admin0:localised_calendar_activity:visited_most_days",
           "admin0:location_event_counts:location_event_counts",
           "admin0:location_introversion:location_introversion",
           "admin0:meaningful_locations_aggregate:meaningful_locations_aggregate",
@@ -3366,6 +3540,14 @@
           "admin1:labelled_spatial_aggregate:majority_location",
           "admin1:labelled_spatial_aggregate:mobility_classification",
           "admin1:labelled_spatial_aggregate:modal_location",
+          "admin1:localised_calendar_activity:coalesced_location",
+          "admin1:localised_calendar_activity:daily_location",
+          "admin1:localised_calendar_activity:localised_calendar_activity",
+          "admin1:localised_calendar_activity:location_visits",
+          "admin1:localised_calendar_activity:majority_location",
+          "admin1:localised_calendar_activity:modal_location",
+          "admin1:localised_calendar_activity:most_frequent_location",
+          "admin1:localised_calendar_activity:visited_most_days",
           "admin1:location_event_counts:location_event_counts",
           "admin1:location_introversion:location_introversion",
           "admin1:meaningful_locations_aggregate:meaningful_locations_aggregate",
@@ -3479,6 +3661,14 @@
           "admin2:labelled_spatial_aggregate:majority_location",
           "admin2:labelled_spatial_aggregate:mobility_classification",
           "admin2:labelled_spatial_aggregate:modal_location",
+          "admin2:localised_calendar_activity:coalesced_location",
+          "admin2:localised_calendar_activity:daily_location",
+          "admin2:localised_calendar_activity:localised_calendar_activity",
+          "admin2:localised_calendar_activity:location_visits",
+          "admin2:localised_calendar_activity:majority_location",
+          "admin2:localised_calendar_activity:modal_location",
+          "admin2:localised_calendar_activity:most_frequent_location",
+          "admin2:localised_calendar_activity:visited_most_days",
           "admin2:location_event_counts:location_event_counts",
           "admin2:location_introversion:location_introversion",
           "admin2:meaningful_locations_aggregate:meaningful_locations_aggregate",
@@ -3592,6 +3782,14 @@
           "admin3:labelled_spatial_aggregate:majority_location",
           "admin3:labelled_spatial_aggregate:mobility_classification",
           "admin3:labelled_spatial_aggregate:modal_location",
+          "admin3:localised_calendar_activity:coalesced_location",
+          "admin3:localised_calendar_activity:daily_location",
+          "admin3:localised_calendar_activity:localised_calendar_activity",
+          "admin3:localised_calendar_activity:location_visits",
+          "admin3:localised_calendar_activity:majority_location",
+          "admin3:localised_calendar_activity:modal_location",
+          "admin3:localised_calendar_activity:most_frequent_location",
+          "admin3:localised_calendar_activity:visited_most_days",
           "admin3:location_event_counts:location_event_counts",
           "admin3:location_introversion:location_introversion",
           "admin3:meaningful_locations_aggregate:meaningful_locations_aggregate",
@@ -3708,6 +3906,14 @@
           "lon-lat:labelled_spatial_aggregate:majority_location",
           "lon-lat:labelled_spatial_aggregate:mobility_classification",
           "lon-lat:labelled_spatial_aggregate:modal_location",
+          "lon-lat:localised_calendar_activity:coalesced_location",
+          "lon-lat:localised_calendar_activity:daily_location",
+          "lon-lat:localised_calendar_activity:localised_calendar_activity",
+          "lon-lat:localised_calendar_activity:location_visits",
+          "lon-lat:localised_calendar_activity:majority_location",
+          "lon-lat:localised_calendar_activity:modal_location",
+          "lon-lat:localised_calendar_activity:most_frequent_location",
+          "lon-lat:localised_calendar_activity:visited_most_days",
           "lon-lat:location_event_counts:location_event_counts",
           "lon-lat:location_introversion:location_introversion",
           "lon-lat:meaningful_locations_aggregate:meaningful_locations_aggregate",
@@ -3755,6 +3961,7 @@
           "lon-lat:unmoving_at_reference_location_counts:visited_most_days",
           "lon-lat:unmoving_counts:unique_locations",
           "lon-lat:unmoving_counts:unmoving_counts",
+          "nonspatial:calendar_activity:calendar_activity",
           "nonspatial:histogram_aggregate:coalesced_location",
           "nonspatial:histogram_aggregate:daily_location",
           "nonspatial:histogram_aggregate:displacement",

--- a/integration_tests/tests/flowmachine_server_tests/test_server.py
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.py
@@ -82,6 +82,8 @@ def test_get_available_queries(zmq_host, zmq_port):
                 "trips_od_matrix",
                 "labelled_spatial_aggregate",
                 "labelled_flows",
+                "calendar_activity",
+                "localised_calendar_activity",
             ]
         },
     }

--- a/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
+++ b/integration_tests/tests/flowmachine_server_tests/test_server.test_api_spec_of_flowmachine_query_schemas.approved.txt
@@ -136,6 +136,78 @@
     ],
     "type": "object"
   },
+  "CalendarActivity": {
+    "properties": {
+      "event_types": {
+        "default": null,
+        "items": {
+          "enum": [
+            "calls",
+            "mds",
+            "sms",
+            "topups"
+          ],
+          "type": "string"
+        },
+        "minItems": 1,
+        "nullable": true,
+        "type": "array"
+      },
+      "hours": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Hours"
+          }
+        ],
+        "default": null,
+        "nullable": true
+      },
+      "period_length": {
+        "default": 1,
+        "type": "integer"
+      },
+      "period_unit": {
+        "default": "days",
+        "enum": [
+          "days",
+          "hours",
+          "minutes"
+        ],
+        "type": "string"
+      },
+      "query_kind": {
+        "enum": [
+          "calendar_activity"
+        ],
+        "type": "string"
+      },
+      "sampling": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RandomSample"
+          }
+        ],
+        "nullable": true
+      },
+      "start_date": {
+        "format": "date-time",
+        "type": "string"
+      },
+      "subscriber_subset": {
+        "nullable": true,
+        "type": "string"
+      },
+      "total_periods": {
+        "type": "integer"
+      }
+    },
+    "required": [
+      "query_kind",
+      "start_date",
+      "total_periods"
+    ],
+    "type": "object"
+  },
   "CoalescedLocation": {
     "properties": {
       "fallback_location": {
@@ -578,6 +650,7 @@
       "mapping": {
         "active_at_reference_location_counts": "#/components/schemas/ActiveAtReferenceLocationCounts",
         "aggregate_network_objects": "#/components/schemas/AggregateNetworkObjects",
+        "calendar_activity": "#/components/schemas/CalendarActivity",
         "consecutive_trips_od_matrix": "#/components/schemas/ConsecutiveTripsODMatrix",
         "dfs_metric_total_amount": "#/components/schemas/DFSTotalMetricAmount",
         "dummy_query": "#/components/schemas/DummyQuery",
@@ -588,6 +661,7 @@
         "joined_spatial_aggregate": "#/components/schemas/JoinedSpatialAggregate",
         "labelled_flows": "#/components/schemas/LabelledFlows",
         "labelled_spatial_aggregate": "#/components/schemas/LabelledSpatialAggregate",
+        "localised_calendar_activity": "#/components/schemas/LocalisedCalendarActivity",
         "location_event_counts": "#/components/schemas/LocationEventCounts",
         "location_introversion": "#/components/schemas/LocationIntroversion",
         "meaningful_locations_aggregate": "#/components/schemas/MeaningfulLocationsAggregate",
@@ -610,6 +684,9 @@
       },
       {
         "$ref": "#/components/schemas/AggregateNetworkObjects"
+      },
+      {
+        "$ref": "#/components/schemas/CalendarActivity"
       },
       {
         "$ref": "#/components/schemas/ConsecutiveTripsODMatrix"
@@ -640,6 +717,9 @@
       },
       {
         "$ref": "#/components/schemas/LabelledSpatialAggregate"
+      },
+      {
+        "$ref": "#/components/schemas/LocalisedCalendarActivity"
       },
       {
         "$ref": "#/components/schemas/LocationEventCounts"
@@ -1226,6 +1306,92 @@
       "labels",
       "locations",
       "query_kind"
+    ],
+    "type": "object"
+  },
+  "LocalisedCalendarActivity": {
+    "properties": {
+      "aggregation_unit": {
+        "enum": [
+          "admin0",
+          "admin1",
+          "admin2",
+          "admin3",
+          "lon-lat"
+        ],
+        "readOnly": true,
+        "type": "string"
+      },
+      "event_types": {
+        "default": null,
+        "items": {
+          "enum": [
+            "calls",
+            "mds",
+            "sms",
+            "topups"
+          ],
+          "type": "string"
+        },
+        "minItems": 1,
+        "nullable": true,
+        "type": "array"
+      },
+      "hours": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Hours"
+          }
+        ],
+        "default": null,
+        "nullable": true
+      },
+      "period_length": {
+        "default": 1,
+        "type": "integer"
+      },
+      "period_unit": {
+        "default": "days",
+        "enum": [
+          "days",
+          "hours",
+          "minutes"
+        ],
+        "type": "string"
+      },
+      "query_kind": {
+        "enum": [
+          "localised_calendar_activity"
+        ],
+        "type": "string"
+      },
+      "reference_location": {
+        "$ref": "#/components/schemas/ReferenceLocation"
+      },
+      "sampling": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RandomSample"
+          }
+        ],
+        "nullable": true
+      },
+      "start_date": {
+        "format": "date-time",
+        "type": "string"
+      },
+      "subscriber_subset": {
+        "nullable": true,
+        "type": "string"
+      },
+      "total_periods": {
+        "type": "integer"
+      }
+    },
+    "required": [
+      "query_kind",
+      "start_date",
+      "total_periods"
     ],
     "type": "object"
   },

--- a/integration_tests/tests/query_tests/test_queries.py
+++ b/integration_tests/tests/query_tests/test_queries.py
@@ -10,6 +10,23 @@ import pytest
 
 queries = [
     partial(
+        flowclient.calendar_activity,
+        start_date="2016-01-01",
+        total_periods=1,
+        event_types=["calls", "sms"],
+    ),
+    partial(
+        flowclient.calendar_activity,
+        start_date="2016-01-01",
+        total_periods=1,
+        event_types=["calls", "sms"],
+        locations=flowclient.daily_location_spec(
+            date="2016-01-01",
+            aggregation_unit="admin3",
+            method="last",
+        ),
+    ),
+    partial(
         flowclient.joined_spatial_aggregate,
         locations=flowclient.daily_location_spec(
             date="2016-01-01",

--- a/integration_tests/tests/query_tests/test_queries.py
+++ b/integration_tests/tests/query_tests/test_queries.py
@@ -16,7 +16,7 @@ queries = [
         event_types=["calls", "sms"],
     ),
     partial(
-        flowclient.calendar_activity,
+        flowclient.localised_calendar_activity,
         start_date="2016-01-01",
         total_periods=1,
         event_types=["calls", "sms"],


### PR DESCRIPTION

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [x] Added tests for any new additions
- [x] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [x] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Adds calendar activity, which is designed to allow the user to produce counts of subscribers who have the same pattern of activity per day (or arbitrary time period really). 

Also makes some changes to facilitate that, including adding a new union type which splices on an extra column, applies that in place of the slightly kludgy custom query approach for making modal locations and the like, creates a new submodule to hold nonspatial aggregates, adds a non spatial version of LabelledAggregate.