### PR TITLE
Make mode available for categorical metrics 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- Mode is now available for use with categorical metrics when running joined spatial aggregates via api. [#2021](https://github.com/Flowminder/FlowKit/issues/2021) 
 
 ### Fixed
 

--- a/flowmachine/flowmachine/core/server/query_schemas/joined_spatial_aggregate.py
+++ b/flowmachine/flowmachine/core/server/query_schemas/joined_spatial_aggregate.py
@@ -122,7 +122,7 @@ class JoinedSpatialAggregateSchema(BaseSchema):
         if data["metric"].query_kind in continuous_metrics:
             validate = OneOf([f"{stat}" for stat in Statistic])
         elif data["metric"].query_kind in categorical_metrics:
-            validate = OneOf(["distr"])
+            validate = OneOf(["distr", "mode"])
         else:
             raise ValidationError(
                 f"{data['metric'].query_kind} does not have a valid metric type."


### PR DESCRIPTION
Closes #2021

### I have:

- [x] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [x] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Adds mode to the list of valid methods for categorical metrics.