### PR TITLE
Change order of grouping columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed 
+- Modified FlowETL `count_duplicates` and `count_duplicated` QA check queries to improve performance, without changing the results. [#6935](https://github.com/Flowminder/FlowKit/issues/6935)
 
 ### Fixed
 

--- a/flowetl/flowetl/flowetl/qa_checks/qa_checks/count_duplicated.sql
+++ b/flowetl/flowetl/flowetl/qa_checks/qa_checks/count_duplicated.sql
@@ -2,14 +2,20 @@ SELECT count(*) FROM
   (SELECT count(*) as n_dupes
     FROM {{ final_table }}
     GROUP BY
+        msisdn,
+        datetime,
+        imsi,
+        imei,
+        tac,
+        location_id,
     {% if cdr_type == 'calls' %}
+        msisdn_counterpart,
         outgoing,
         duration,
-        msisdn_counterpart,
         network,
     {% elif cdr_type == 'sms' %}
-        outgoing,
         msisdn_counterpart,
+        outgoing,
         network,
     {% elif cdr_type == 'mds' %}
         duration,
@@ -24,12 +30,6 @@ SELECT count(*) FROM
         pre_event_balance,
         post_event_balance,
     {% endif %}
-        datetime,
-        msisdn,
-        location_id,
-        imsi,
-        imei,
-        tac,
         operator_code,
         country_code
     HAVING count(*) > 1) tableWithCount

--- a/flowetl/flowetl/flowetl/qa_checks/qa_checks/count_duplicates.sql
+++ b/flowetl/flowetl/flowetl/qa_checks/qa_checks/count_duplicates.sql
@@ -2,14 +2,20 @@ SELECT COALESCE(sum(n_dupes), 0) FROM
   (SELECT count(*) - 1 as n_dupes
     FROM {{ final_table }}
     GROUP BY
+        msisdn,
+        datetime,
+        imsi,
+        imei,
+        tac,
+        location_id,
     {% if cdr_type == 'calls' %}
+        msisdn_counterpart,
         outgoing,
         duration,
-        msisdn_counterpart,
         network,
     {% elif cdr_type == 'sms' %}
-        outgoing,
         msisdn_counterpart,
+        outgoing,
         network,
     {% elif cdr_type == 'mds' %}
         duration,
@@ -24,12 +30,6 @@ SELECT COALESCE(sum(n_dupes), 0) FROM
         pre_event_balance,
         post_event_balance,
     {% endif %}
-        datetime,
-        msisdn,
-        location_id,
-        imsi,
-        imei,
-        tac,
         operator_code,
         country_code
     HAVING count(*) > 1) tableWithCount


### PR DESCRIPTION

Closes #6935

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [x] Brought the branch up to date with master
- [x] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

Changes the order of grouping fileds in the FlowETL `count_duplicates` and `count_duplicated` checks, to hopefully improve performance on tables that are pre-sorted by (`msisdn`, `datetime`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced duplicate counting logic in SQL queries.
	- Refined grouping criteria for different call detail record types.
	- Adjusted column selection for improved accuracy in duplicate identification.

These changes optimise the performance of duplicate detection across various telecommunications record types, ensuring more precise data quality checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->