### PR TITLE
Prevent divide-by-zero errors in cache_score function

### DIFF
--- a/flowdb/bin/build/0030_utilities.sql
+++ b/flowdb/bin/build/0030_utilities.sql
@@ -247,7 +247,7 @@ $$
           cache_score_multiplier+POWER(1 + ln(2) / cache_half_life(), nextval('cache.cache_touches') - 2)
         END
         WHERE query_id=cached_query_id
-        RETURNING cache_score(cache_score_multiplier, compute_time, greatest(table_size(tablename, schema), 0.00001)) INTO score;
+        RETURNING cache_score(cache_score_multiplier, compute_time, table_size(tablename, schema), 0.00001) INTO score;
         IF NOT FOUND THEN RAISE EXCEPTION 'Cache record % not found', cached_query_id;
         END IF;
   RETURN score;
@@ -267,7 +267,7 @@ CREATE OR REPLACE FUNCTION cache_score(IN cache_score_multiplier numeric, IN com
 	RETURNS float AS
 $$
   BEGIN
-  RETURN cache_score_multiplier*((compute_time/1000)/tablesize);
+  RETURN cache_score_multiplier*((compute_time/1000)/greatest(tablesize, 0.00001));
   END
 $$ LANGUAGE plpgsql
 SECURITY DEFINER


### PR DESCRIPTION

Closes #ISSUE_NUMBER

### I have:

- [ ] Formatted any Python files with [black](https://github.com/ambv/black)
- [ ] Brought the branch up to date with master
- [ ] Added any relevant Github labels
- [ ] Added tests for any new additions
- [ ] Added or updated any relevant documentation
- [ ] Added an Architectural Decision Record (ADR), if appropriate
- [ ] Added an [MPLv2 License Header](https://www.mozilla.org/en-US/MPL/headers/) if appropriate
- [ ] Updated the [Changelog](https://github.com/Flowminder/FlowKit/blob/master/CHANGELOG.md) 

### Description

We already had a safeguard in the FlowDB `touch_cache` function to increase table size to a non-zero value. This PR moves the safeguard into `cache_score`, so that it takes effect everywhere `cache_score` is used.
