### PR TITLE
Switch to bitnamilegacy for redis image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ executors:
           EFFECTIVE_CACHE_SIZE: "1GB"
           STATS_TARGET: 100
           FLOWDB_LOG_DEST: stderr
-      - image: bitnami/redis:latest
+      - image: bitnamilegacy/redis:latest
         environment:
           REDIS_PASSWORD: "fm_redis"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,7 +186,7 @@ services:
 
   flowmachine_query_locker:
     container_name: flowmachine_query_locker
-    image: bitnami/redis
+    image: bitnamilegacy/redis
     ports:
       - ${REDIS_PORT:?Must set REDIS_PORT env var}:6379
     environment:
@@ -229,7 +229,7 @@ services:
 
   flowetl_redis:
     container_name: flowetl_redis
-    image: bitnami/redis:latest
+    image: bitnamilegacy/redis:latest
     environment:
       - REDIS_PASSWORD=${FLOWETL_REDIS_PASSWORD:?Must set FLOWETL_REDIS_PASSWORD env var}
     expose:

--- a/docs/source/developer/dev_environment_setup.md
+++ b/docs/source/developer/dev_environment_setup.md
@@ -125,7 +125,7 @@ CONTAINER ID        IMAGE                               COMMAND                 
 e57c8eeb7d38        flowminder/flowmachine:latest       "/bin/sh -c 'pipenv …"   5 minutes ago       Up 5 minutes        0.0.0.0:5555->5555/tcp             flowmachine
 3d54ce0c4484        flowminder/flowapi:latest           "/bin/sh -c 'pipenv …"   5 minutes ago       Up 5 minutes        0.0.0.0:9090->9090/tcp             flowapi
 89e9575c8d42        flowminder/flowauth:latest          "/entrypoint.sh /sta…"   5 minutes ago       Up 5 minutes        443/tcp, 0.0.0.0:8080->80/tcp      flowauth
-384355e94ae6        bitnami/redis                       "/entrypoint.sh /run…"   5 minutes ago       Up 5 minutes        0.0.0.0:6379->6379/tcp             flowmachine_query_locker
+384355e94ae6        bitnamilegacy/redis                       "/entrypoint.sh /run…"   5 minutes ago       Up 5 minutes        0.0.0.0:6379->6379/tcp             flowmachine_query_locker
 ```
 
 **Note:** _Currently there is a glitch which means that `flowmachine` may not start up correctly if `flowdb_testdata`

--- a/flowauth/docker-compose.yml
+++ b/flowauth/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - flowauth_database
 
   flowauth_redis:
-    image: bitnami/redis
+    image: bitnamilegacy/redis
     secrets:
       - FLOWAUTH_REDIS_PASSWORD
     environment:

--- a/secrets_quickstart/flowetl.yml
+++ b/secrets_quickstart/flowetl.yml
@@ -106,7 +106,7 @@ services:
           - flowetl_db
 
   flowetl_redis:
-    image: bitnami/redis:latest
+    image: bitnamilegacy/redis:latest
     secrets:
       - FLOWETL_REDIS_PASSWORD
     environment:

--- a/secrets_quickstart/flowmachine.yml
+++ b/secrets_quickstart/flowmachine.yml
@@ -59,7 +59,7 @@ services:
         - flowdb
         - redis
     flowmachine_query_locker:
-        image: bitnami/redis:latest
+        image: bitnamilegacy/redis:latest
         environment:
           REDIS_PASSWORD_FILE: /run/secrets/REDIS_PASSWORD
         ports:


### PR DESCRIPTION
Because bitnami have removed their regular redis image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing feature changes in this release.
- Chores
  - Standardised Redis container image across local and CI environments to bitnamilegacy/redis for consistency.
  - Updated Docker-based services to use the new Redis image without altering configuration or behaviour.
- Documentation
  - Refreshed developer setup guide to reference the new Redis image in examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->