### PR TITLE
Automatically re-run the slightly flakey frontend tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,6 +552,7 @@ jobs:
       - run:
           name: Run Cypress end-to-end tests
           command: DEBUG="cypress:*" npx cypress run --record --reporter junit --reporter-options "mochaFile=results/flowauth-frontend.[hash].xml"
+          max_auto_reruns: 5
       - run:
           name: Run Cypress component tests
           command: DEBUG="cypress:*" npx cypress run --component --record --reporter junit --reporter-options "mochaFile=results/flowauth-component.[hash].xml"


### PR DESCRIPTION
Turns on a setting to automatically retry the flakey flowauth frontend tests, which should lead to less failing ci runs.