### PR TITLE
FlowAuth: surface assigned roles on token list (#7273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- FlowAuth: roles assigned to a token at mint time are now recorded in a `tokens_with_roles` association table and exposed on the user's token list (`GET /tokens/tokens/<server_id>`), so users and admins can see which permissions an existing token carries without decoding the JWT. [#7273](https://github.com/Flowminder/FlowKit/issues/7273)
 
 ### Changed
 

--- a/flowauth/backend/flowauth/migrations/versions/a8c5e1d3f7b2_add_tokens_with_roles_assoc.py
+++ b/flowauth/backend/flowauth/migrations/versions/a8c5e1d3f7b2_add_tokens_with_roles_assoc.py
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Add tokens_with_roles association table
+
+Revision ID: a8c5e1d3f7b2
+Revises: 976c731ff30f
+Create Date: 2026-04-28 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import structlog
+
+
+# revision identifiers, used by Alembic.
+revision = "a8c5e1d3f7b2"
+down_revision = "976c731ff30f"
+branch_labels = None
+depends_on = None
+
+logger = structlog.get_logger("flowauth.migration")
+
+
+def upgrade():
+    logger.info(
+        "Running upgrade.",
+        migration_script=__file__,
+        revision=revision,
+        down_revision=down_revision,
+        branch_labels=branch_labels,
+        depends_on=depends_on,
+    )
+    op.create_table(
+        "tokens_with_roles",
+        sa.Column("token_id", sa.Integer(), nullable=False),
+        sa.Column("role_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["role_id"],
+            ["role.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["token_id"],
+            ["token_history.id"],
+        ),
+        sa.PrimaryKeyConstraint("token_id", "role_id"),
+    )
+
+
+def downgrade():
+    logger.info(
+        "Running downgrade.",
+        migration_script=__file__,
+        revision=revision,
+        down_revision=down_revision,
+        branch_labels=branch_labels,
+        depends_on=depends_on,
+    )
+    op.drop_table("tokens_with_roles")

--- a/flowauth/backend/flowauth/migrations/versions/a8c5e1d3f7b2_add_tokens_with_roles_assoc.py
+++ b/flowauth/backend/flowauth/migrations/versions/a8c5e1d3f7b2_add_tokens_with_roles_assoc.py
@@ -25,6 +25,10 @@ logger = structlog.get_logger("flowauth.migration")
 
 
 def upgrade():
+    """Create the ``tokens_with_roles`` association table linking
+    ``token_history`` rows to the ``role`` rows that were granted at mint
+    time. The table is the source of truth for the roles displayed on the
+    user's token list and reused by the renewal endpoint."""
     logger.info(
         "Running upgrade.",
         migration_script=__file__,
@@ -50,6 +54,9 @@ def upgrade():
 
 
 def downgrade():
+    """Drop the ``tokens_with_roles`` association table. After downgrade,
+    historical role assignments for previously-minted tokens are no longer
+    available for display or for renewal."""
     logger.info(
         "Running downgrade.",
         migration_script=__file__,

--- a/flowauth/backend/flowauth/models.py
+++ b/flowauth/backend/flowauth/models.py
@@ -35,6 +35,14 @@ users_with_roles = db.Table(
     db.Column("role_id", db.Integer, db.ForeignKey("role.id"), primary_key=True),
 )
 
+tokens_with_roles = db.Table(
+    "tokens_with_roles",
+    db.Column(
+        "token_id", db.Integer, db.ForeignKey("token_history.id"), primary_key=True
+    ),
+    db.Column("role_id", db.Integer, db.ForeignKey("role.id"), primary_key=True),
+)
+
 
 class User(db.Model):
     """
@@ -497,6 +505,11 @@ class TokenHistory(db.Model):
     user = db.relationship("User", back_populates="tokens", lazy=True)
     server_id = db.Column(db.Integer, db.ForeignKey("server.id"), nullable=False)
     server = db.relationship("Server", back_populates="tokens", lazy=True)
+    roles = db.relationship(
+        "Role",
+        secondary=tokens_with_roles,
+        lazy="subquery",
+    )
 
     @hybrid_property
     def token(self) -> str:

--- a/flowauth/backend/flowauth/token_management.py
+++ b/flowauth/backend/flowauth/token_management.py
@@ -80,6 +80,7 @@ def list_my_tokens(server):
                 "expires": token.expiry,
                 "server_name": token.server.name,
                 "username": token.user.username,
+                "roles": [{"id": role.id, "name": role.name} for role in token.roles],
             }
             for token in TokenHistory.query.filter(
                 TokenHistory.user == current_user, TokenHistory.server == server
@@ -155,6 +156,7 @@ def add_token(server_id):
         server_id=server.id,
         expiry=token_expiry,
         token=token_string,
+        roles=roles,
     )
 
     db.session.add(history_entry)

--- a/flowauth/backend/tests/test_token_generation.py
+++ b/flowauth/backend/tests/test_token_generation.py
@@ -89,6 +89,39 @@ def test_token_generation(
         assert approx(expiry.timestamp()) == decoded_token["exp"]
 
 
+@pytest.mark.usefixtures("test_data_with_access_rights")
+@freeze_time(datetime.datetime(year=2020, month=12, day=31))
+def test_token_list_includes_assigned_roles(
+    client, auth, app, test_user_with_roles, test_servers
+):
+    """The token list endpoint exposes the roles that were assigned at mint time."""
+    with app.app_context():
+        uid, uname, upass = test_user_with_roles
+        response, csrf_cookie = auth.login(uname, upass)
+        assert response.status_code == 200
+
+        token_req = {
+            "name": "DUMMY_TOKEN",
+            "roles": [{"name": "runner"}, {"name": "reader"}],
+        }
+        mint_response = client.post(
+            "/tokens/tokens/1", headers={"X-CSRF-Token": csrf_cookie}, json=token_req
+        )
+        assert mint_response.status_code == 200
+
+        list_response = client.get(
+            "/tokens/tokens/1", headers={"X-CSRF-Token": csrf_cookie}
+        )
+        assert list_response.status_code == 200
+        tokens = list_response.get_json()
+        assert len(tokens) == 1
+        assert tokens[0]["name"] == "DUMMY_TOKEN"
+        role_names = sorted(role["name"] for role in tokens[0]["roles"])
+        assert role_names == ["reader", "runner"]
+        for role in tokens[0]["roles"]:
+            assert isinstance(role["id"], int)
+
+
 def test_token_rejected_for_expiry(client, auth, app, test_user_with_roles, public_key):
     with app.app_context():
         with freeze_time("2020-12-31") as frozentime:

--- a/flowauth/frontend/src/Token.jsx
+++ b/flowauth/frontend/src/Token.jsx
@@ -45,15 +45,26 @@ class Token extends React.Component {
     element.click();
   };
   render() {
-    const { name, expiry, token, classes } = this.props;
+    const { name, expiry, token, classes, roles } = this.props;
     const { isOpen, copySuccess } = this.state;
     const isExpired = Date.parse(expiry) < Date.parse(new Date());
+    const roleSummary =
+      roles && roles.length > 0 ? roles.map((r) => r.name).join(", ") : null;
     return (
       <React.Fragment>
         <Grid item xs={3}>
           <Typography component="p" className={isExpired ? "expired" : ""}>
             {name}{" "}
           </Typography>
+          {roleSummary && (
+            <Typography
+              variant="caption"
+              color="textSecondary"
+              className={isExpired ? "expired" : ""}
+            >
+              Roles: {roleSummary}
+            </Typography>
+          )}
         </Grid>
         <Grid item xs={3}>
           <Typography component="p" className={isExpired ? "expired" : ""}>

--- a/flowauth/frontend/src/TokenList.jsx
+++ b/flowauth/frontend/src/TokenList.jsx
@@ -104,6 +104,7 @@ class TokenList extends React.Component {
               name={object.name}
               expiry={object.expires}
               token={object.token}
+              roles={object.roles}
               classes={classes}
               editAction={editAction}
             />
@@ -132,6 +133,7 @@ class TokenList extends React.Component {
                 name={object.name}
                 expiry={object.expires}
                 token={object.token}
+                roles={object.roles}
                 classes={classes}
                 editAction={editAction}
               />


### PR DESCRIPTION
Closes #7273.

## Summary

When a user views their tokens in FlowAuth, the response and UI show `id, name, token, expires, server_name, username` — but not the roles that were granted at mint time. The role information was only present inside the gzipped `user_claims` payload of the encrypted JWT, so there was no practical way to look at an existing token and see what permissions it carried.

## Changes

- **`models.py`** — new `tokens_with_roles` association table (mirroring the existing `users_with_roles` pattern) plus a `roles` relationship on `TokenHistory`.
- **`token_management.py`** — `add_token` populates the new association at mint time; `list_my_tokens` includes a `roles` field (`[{id, name}, …]`) in its response.
- **Alembic migration** — `a8c5e1d3f7b2_add_tokens_with_roles_assoc.py` creates the new table. Down-revision is the current head (`976c731ff30f`).
- **Frontend** — `TokenList.jsx` passes `roles` through to `Token.jsx`, which renders a compact `Roles: …` caption under the nickname when present. Layout grid is otherwise unchanged.
- **Test** — `test_token_list_includes_assigned_roles` mints a token and asserts the list endpoint returns the expected role names.
- **CHANGELOG** — entry under `[Unreleased] / Added`.

## Backwards compatibility

Purely additive on the wire. The JWT format is unchanged, so FlowAPI is unaffected. Existing `token_history` rows have no associated roles, so the UI simply omits the caption for them — those tokens get the new info on next reissue.

## Test plan

- [ ] Backend: `pytest flowauth/backend/tests/test_token_generation.py::test_token_list_includes_assigned_roles` passes.
- [ ] Backend: full `flowauth/backend` test suite passes (no regressions).
- [ ] Frontend: log in as a non-admin user, mint a token, confirm the role list appears under the token name.
- [ ] Migration: `flask db upgrade` then `flask db downgrade` round-trips cleanly on a populated database.

## Related work

This is the first of three planned PRs against FlowAuth. The other two are tracked under #7274 (drop the silent absolute-expiry cap so renewals don't require admin-bumps) and #7275 (add a real token renewal endpoint, which depends on this PR's `tokens_with_roles` table).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token mint-time roles are now persisted and included in the token list endpoint, so each token returns its assigned role metadata.
  * Frontend displays assigned roles beneath each token name for clearer visibility.

* **Tests**
  * Added test coverage verifying the token list includes assigned roles and role IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->