### PR TITLE
FlowAuth: drop the silent absolute-expiry cap (#7274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - FlowAuth: roles assigned to a token at mint time are now recorded in a `tokens_with_roles` association table and exposed on the user's token list (`GET /tokens/tokens/<server_id>`), so users and admins can see which permissions an existing token carries without decoding the JWT. [#7273](https://github.com/Flowminder/FlowKit/issues/7273)
 - FlowAuth: new `POST /tokens/tokens/<token_id>/renew` endpoint mints a fresh JWT reusing the original token's name and roles. The original `TokenHistory` row is left intact so its JWT remains valid until its own `exp` claim passes, giving consumers a natural overlap window. The token list UI gains a "Renew" button on each active token. [#7275](https://github.com/Flowminder/FlowKit/issues/7275)
+- FlowAuth: token mint endpoint accepts an optional `lifetime_minutes` so users can request a token shorter than the maximum permitted by the selected server and roles. [#7274](https://github.com/Flowminder/FlowKit/issues/7274)
 
 ### Changed
+- FlowAuth: `Server.latest_token_expiry` and `Role.latest_token_expiry` are now nullable. A `NULL` value means the row imposes no absolute expiry cap on tokens; only `longest_token_life_minutes` then bounds the lifetime. Existing rows keep their non-null values, so behaviour is unchanged until an operator nulls the column out. This removes the silent-cap footgun that required an admin to bump expiry datetimes ahead of every long-lived-token renewal. [#7274](https://github.com/Flowminder/FlowKit/issues/7274)
 
 ### Fixed
+- FlowAuth: `User.token_limits` now correctly filters by the current user when computing role-derived caps. Previously the join did not constrain by user id, so the function returned the most-permissive role on the server across *all* users. [#7274](https://github.com/Flowminder/FlowKit/issues/7274)
 
 ### Removed
 

--- a/flowauth/backend/flowauth/migrations/versions/c1d4e7b9a2f3_nullable_latest_token_expiry.py
+++ b/flowauth/backend/flowauth/migrations/versions/c1d4e7b9a2f3_nullable_latest_token_expiry.py
@@ -1,0 +1,77 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Make latest_token_expiry nullable on server and role
+
+A NULL ``latest_token_expiry`` means the row imposes no absolute expiry
+cap on tokens; only ``longest_token_life_minutes`` then bounds the token
+lifetime. Existing non-null rows are left as-is so behaviour is unchanged
+until an operator nulls them out explicitly.
+
+Revision ID: c1d4e7b9a2f3
+Revises: a8c5e1d3f7b2
+Create Date: 2026-04-28 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import structlog
+
+
+# revision identifiers, used by Alembic.
+revision = "c1d4e7b9a2f3"
+down_revision = "a8c5e1d3f7b2"
+branch_labels = None
+depends_on = None
+
+logger = structlog.get_logger("flowauth.migration")
+
+
+def upgrade():
+    """Make ``latest_token_expiry`` nullable on ``server`` and ``role``. A
+    NULL value means the row imposes no absolute expiry cap on tokens; only
+    ``longest_token_life_minutes`` then bounds the token lifetime.
+    Existing rows keep their non-null values, so behaviour is unchanged
+    until an operator nulls the column out explicitly."""
+    logger.info(
+        "Running upgrade.",
+        migration_script=__file__,
+        revision=revision,
+        down_revision=down_revision,
+        branch_labels=branch_labels,
+        depends_on=depends_on,
+    )
+    with op.batch_alter_table("server", schema=None) as batch_op:
+        batch_op.alter_column(
+            "latest_token_expiry", existing_type=sa.DateTime(), nullable=True
+        )
+    with op.batch_alter_table("role", schema=None) as batch_op:
+        batch_op.alter_column(
+            "latest_token_expiry", existing_type=sa.DateTime(), nullable=True
+        )
+
+
+def downgrade():
+    """Restore the NOT NULL constraint on ``latest_token_expiry``. Will fail
+    if any rows currently have NULL in those columns; operators must
+    populate them with a sentinel datetime first."""
+    logger.info(
+        "Running downgrade.",
+        migration_script=__file__,
+        revision=revision,
+        down_revision=down_revision,
+        branch_labels=branch_labels,
+        depends_on=depends_on,
+    )
+    # NOTE: downgrade will fail if any rows have NULL in these columns.
+    # Operators must populate them with a sentinel datetime first.
+    with op.batch_alter_table("role", schema=None) as batch_op:
+        batch_op.alter_column(
+            "latest_token_expiry", existing_type=sa.DateTime(), nullable=False
+        )
+    with op.batch_alter_table("server", schema=None) as batch_op:
+        batch_op.alter_column(
+            "latest_token_expiry", existing_type=sa.DateTime(), nullable=False
+        )

--- a/flowauth/backend/flowauth/models.py
+++ b/flowauth/backend/flowauth/models.py
@@ -111,8 +111,10 @@ class User(db.Model):
     def latest_token_expiry(self, server: "Server") -> datetime.datetime:
         """
         Get the latest datetime a token can be valid until on a server.
-        Returns the soonest of either the server's expiry date or the
-        current time + the servers maximum lifetime.
+        Returns the soonest of either the absolute expiry cap (server or
+        any of the user's roles, whichever is sooner) or the current time
+        plus the maximum permitted lifetime. When neither the server nor
+        any role sets an absolute cap, returns ``now + longest_life``.
 
         Parameters
         ----------
@@ -128,40 +130,68 @@ class User(db.Model):
         life = limits["longest_life"]
         end = limits["latest_end"]
         hypothetical_max = datetime.datetime.now() + datetime.timedelta(minutes=life)
+        if end is None:
+            return hypothetical_max
         return min(end, hypothetical_max)
 
     def token_limits(
         self, server: "Server"
-    ) -> Dict[str, Union[datetime.datetime, int]]:
+    ) -> Dict[str, Union[datetime.datetime, int, None]]:
         """
         Get the maximum lifetime and latest expiry date a token can be
         created for on this user on a server.
 
+        ``latest_end`` is ``None`` when neither the server nor any of
+        the user's roles on this server impose an absolute expiry cap.
+        Otherwise it is the soonest of the role cap (most permissive
+        across the user's roles, treating ``NULL`` as no cap) and the
+        server cap.
+
         Returns
         -------
         dict
-            Dict {"latest_end": datetime, "longest_life":int}
+            Dict {"latest_end": datetime | None, "longest_life": int}
         """
 
-        latest = db.session.execute(
-            db.select(Role.latest_token_expiry)
-            .where(Role.server_id == server.id)
-            .join(User.roles)
-            .order_by(Role.latest_token_expiry.desc())
-        ).scalar()
+        role_expiries = (
+            db.session.execute(
+                db.select(Role.latest_token_expiry)
+                .where(Role.server_id == server.id)
+                .join(User.roles)
+                .where(User.id == self.id)
+            )
+            .scalars()
+            .all()
+        )
 
         longest = db.session.execute(
             db.select(Role.longest_token_life_minutes)
             .where(Role.server_id == server.id)
             .join(User.roles)
+            .where(User.id == self.id)
             .order_by(Role.longest_token_life_minutes.desc())
         ).scalar()
 
-        if not latest or not longest:
-            raise Unauthorized(f"No roles for {self.username} on {Server.name}")
+        if not role_expiries or longest is None:
+            raise Unauthorized(f"No roles for {self.username} on {server.name}")
+
+        if any(expiry is None for expiry in role_expiries):
+            roles_latest = None
+        else:
+            roles_latest = max(role_expiries)
+
+        server_latest = server.latest_token_expiry
+        if roles_latest is None and server_latest is None:
+            latest_end = None
+        elif roles_latest is None:
+            latest_end = server_latest
+        elif server_latest is None:
+            latest_end = roles_latest
+        else:
+            latest_end = min(server_latest, roles_latest)
 
         return {
-            "latest_end": min(server.latest_token_expiry, latest),
+            "latest_end": latest_end,
             "longest_life": min(server.longest_token_life_minutes, longest),
         }
 
@@ -388,7 +418,7 @@ class Server(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(75), unique=True, nullable=False)
-    latest_token_expiry = db.Column(db.DateTime, nullable=False)
+    latest_token_expiry = db.Column(db.DateTime, nullable=True)
     longest_token_life_minutes = db.Column(db.Integer, nullable=False)
 
     roles = db.relationship(
@@ -404,11 +434,12 @@ class Server(db.Model):
     )
 
     def next_expiry(self) -> datetime.datetime:
-        return min(
-            self.latest_token_expiry,
-            datetime.datetime.now()
-            + datetime.timedelta(minutes=self.longest_token_life_minutes),
+        relative_max = datetime.datetime.now() + datetime.timedelta(
+            minutes=self.longest_token_life_minutes
         )
+        if self.latest_token_expiry is None:
+            return relative_max
+        return min(self.latest_token_expiry, relative_max)
 
     def __repr__(self) -> str:
         return f"<Server {self.name}>"
@@ -424,7 +455,7 @@ class Role(db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     name = db.Column(db.String(75), nullable=False)
     server_id = db.Column(db.Integer, db.ForeignKey("server.id"))
-    latest_token_expiry = db.Column(db.DateTime, nullable=False)
+    latest_token_expiry = db.Column(db.DateTime, nullable=True)
     longest_token_life_minutes = db.Column(db.Integer, nullable=False)
 
     scopes = db.relationship(
@@ -435,11 +466,12 @@ class Role(db.Model):
     )
 
     def next_expiry(self) -> datetime.datetime:
-        return min(
-            self.latest_token_expiry,
-            datetime.datetime.now()
-            + datetime.timedelta(minutes=self.longest_token_life_minutes),
+        relative_max = datetime.datetime.now() + datetime.timedelta(
+            minutes=self.longest_token_life_minutes
         )
+        if self.latest_token_expiry is None:
+            return relative_max
+        return min(self.latest_token_expiry, relative_max)
 
     def allowed_claims(self) -> List[str]:
         """
@@ -468,8 +500,10 @@ class Role(db.Model):
             "id": self.id,
             "name": self.name,
             "scopes": sorted([scope.id for scope in self.scopes]),
-            "latest_token_expiry": self.latest_token_expiry.strftime(
-                "%Y-%m-%dT%H:%M:%S.%fZ"
+            "latest_token_expiry": (
+                self.latest_token_expiry.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                if self.latest_token_expiry is not None
+                else None
             ),
             "longest_token_life_minutes": self.longest_token_life_minutes,
             "server": self.server_id,

--- a/flowauth/backend/flowauth/roles.py
+++ b/flowauth/backend/flowauth/roles.py
@@ -53,8 +53,11 @@ def get_role(role_id):
 @admin_permission.require(http_exception=401)
 def add_role():
     json = request.get_json()
-    json["latest_token_expiry"] = datetime.datetime.strptime(
-        json["latest_token_expiry"], "%Y-%m-%dT%H:%M:%S.%fZ"
+    raw_latest = json.get("latest_token_expiry")
+    json["latest_token_expiry"] = (
+        datetime.datetime.strptime(raw_latest, "%Y-%m-%dT%H:%M:%S.%fZ")
+        if raw_latest
+        else None
     )
     server = Server.query.filter(Server.id == json["server_id"]).first_or_404()
     role_scopes = Scope.query.filter(Scope.id.in_(json["scopes"])).all()
@@ -65,7 +68,11 @@ def add_role():
     except KeyError:
         role_users = []
 
-    if json["latest_token_expiry"] > server.latest_token_expiry:
+    if (
+        json["latest_token_expiry"] is not None
+        and server.latest_token_expiry is not None
+        and json["latest_token_expiry"] > server.latest_token_expiry
+    ):
         raise InvalidUsage("Role cannot exist past latest token in server")
     if int(json["longest_token_life_minutes"]) > server.longest_token_life_minutes:
         raise InvalidUsage("Role cannot have a maximum lifetime greater than server")
@@ -109,8 +116,16 @@ def edit_role(role_id):
             for scope in value:
                 _validate_scope_server(scope, server)
         elif key == "latest_token_expiry":
-            value = datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
-            if value > server.latest_token_expiry:
+            value = (
+                datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+                if value
+                else None
+            )
+            if (
+                value is not None
+                and server.latest_token_expiry is not None
+                and value > server.latest_token_expiry
+            ):
                 raise InvalidUsage("Role cannot exist past latest token in server")
         elif key == "longest_token_life_minutes":
             value = int(value)

--- a/flowauth/backend/flowauth/servers.py
+++ b/flowauth/backend/flowauth/servers.py
@@ -44,8 +44,10 @@ def get_server(server_id):
             "id": server.id,
             "name": server.name,
             "longest_token_life_minutes": server.longest_token_life_minutes,
-            "latest_token_expiry": server.latest_token_expiry.strftime(
-                "%Y-%m-%dT%H:%M:%S.%fZ"
+            "latest_token_expiry": (
+                server.latest_token_expiry.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                if server.latest_token_expiry is not None
+                else None
             ),
         }
     )
@@ -69,8 +71,10 @@ def get_roles(server_id):
                 "id": role.id,
                 "name": role.name,
                 "scopes": [scope.name for scope in role.scopes],
-                "latest_token_expiry": role.latest_token_expiry.strftime(
-                    "%Y-%m-%dT%H:%M:%S.%fZ"
+                "latest_token_expiry": (
+                    role.latest_token_expiry.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    if role.latest_token_expiry is not None
+                    else None
                 ),
                 "longest_token_life_minutes": role.longest_token_life_minutes,
             }
@@ -177,12 +181,20 @@ def add_server():
 
     Notes
     -----
-    Expects json of the form {"latest_token_expiry":<%Y-%m-%dT%H:%M:%S.%fZ>, "secret_key":<key>,
-    "longest_token_life_minutes":<int>, "name":<server_name>, "scopes":[<list of scope strings>], "role":[<list of role IDs>]}
+    Expects json of the form {"latest_token_expiry":<%Y-%m-%dT%H:%M:%S.%fZ> or null,
+    "secret_key":<key>, "longest_token_life_minutes":<int>, "name":<server_name>,
+    "scopes":[<list of scope strings>], "role":[<list of role IDs>]}.
+
+    ``latest_token_expiry`` may be ``null`` (or omitted) to indicate no
+    absolute expiry cap; in that case ``longest_token_life_minutes`` is the
+    sole ceiling on token lifetime.
     """
     json = request.get_json()
-    json["latest_token_expiry"] = datetime.datetime.strptime(
-        json["latest_token_expiry"], "%Y-%m-%dT%H:%M:%S.%fZ"
+    raw_latest = json.get("latest_token_expiry")
+    json["latest_token_expiry"] = (
+        datetime.datetime.strptime(raw_latest, "%Y-%m-%dT%H:%M:%S.%fZ")
+        if raw_latest
+        else None
     )
     if "name" not in json:
         raise InvalidUsage("Must provide server name", payload={"bad_field": "name"})
@@ -238,9 +250,13 @@ def edit_server(server_id):
     """
     server = Server.query.filter(Server.id == server_id).first_or_404()
     json = request.get_json()
-    json["latest_token_expiry"] = datetime.datetime.strptime(
-        json["latest_token_expiry"], "%Y-%m-%dT%H:%M:%S.%fZ"
-    )
+    if "latest_token_expiry" in json:
+        raw_latest = json["latest_token_expiry"]
+        json["latest_token_expiry"] = (
+            datetime.datetime.strptime(raw_latest, "%Y-%m-%dT%H:%M:%S.%fZ")
+            if raw_latest
+            else None
+        )
     for key, val in json.items():
         if key == "roles":
             server.roles = Role.query.filter(Role.id.in_(val)).all()

--- a/flowauth/backend/flowauth/token_management.py
+++ b/flowauth/backend/flowauth/token_management.py
@@ -102,8 +102,11 @@ def add_token(server_id):
 
     Notes
     -----
-    Expects json with "name", and "roles" keys, where "name" is a string,
-    and roles is a list of role names.
+    Expects json with "name" and "roles" keys, where "name" is a string and
+    "roles" is a list of role names. Optionally accepts "lifetime_minutes"
+    (positive integer) to request a token shorter than the maximum permitted
+    by the server and selected roles. When omitted, the token is issued at
+    the maximum permitted lifetime.
 
     Responds with a json object {"token":<token_string>, "id":<token_id>}.
 
@@ -132,15 +135,30 @@ def add_token(server_id):
                 f"Role '{requested_role['name']}' is not permitted for the current user"
             )
         roles.append(Role.query.filter(Role.name == requested_role["name"]).first())
-    token_expiry = min(server.next_expiry(), min(rr.next_expiry() for rr in roles))
-    # The role expiry date doesn't beat the server expiry date
-    # The role longest lifetime doesn't beat the server longest lifetime
-    # If you request token with a role with a expiry past the server final expiry, then issue the token with the server's final expiry
-    # feature todo: flag this to the user
-    # This isn't about the user, so get these values from the server
+    max_token_expiry = min(server.next_expiry(), min(rr.next_expiry() for rr in roles))
 
-    if token_expiry < datetime.datetime.now():
+    if max_token_expiry < datetime.datetime.now():
         raise Unauthorized(f"Token for {current_user.username} expired")
+
+    requested_lifetime = json.get("lifetime_minutes")
+    if requested_lifetime is None:
+        token_expiry = max_token_expiry
+    else:
+        if not isinstance(requested_lifetime, int) or requested_lifetime <= 0:
+            raise InvalidUsage(
+                "lifetime_minutes must be a positive integer",
+                payload={"bad_field": "lifetime_minutes"},
+            )
+        requested_expiry = datetime.datetime.now() + datetime.timedelta(
+            minutes=requested_lifetime
+        )
+        if requested_expiry > max_token_expiry:
+            raise InvalidUsage(
+                "Requested lifetime exceeds the maximum permitted by the "
+                "selected server and roles",
+                payload={"bad_field": "lifetime_minutes"},
+            )
+        token_expiry = requested_expiry
 
     token_string = generate_token(
         flowapi_identifier=server.name,

--- a/flowauth/backend/tests/test_token_generation.py
+++ b/flowauth/backend/tests/test_token_generation.py
@@ -239,6 +239,101 @@ def test_token_renewal_rejects_when_role_revoked(
         assert "runner" in renew.get_json()["message"]
 
 
+@pytest.mark.usefixtures("test_data_with_access_rights")
+@freeze_time(datetime.datetime(year=2020, month=12, day=31))
+def test_token_honours_requested_lifetime(
+    client, auth, app, test_user_with_roles, public_key
+):
+    """A user-supplied lifetime_minutes shorter than the cap is honoured."""
+    with app.app_context():
+        uid, uname, upass = test_user_with_roles
+        response, csrf_cookie = auth.login(uname, upass)
+
+        token_req = {
+            "name": "DUMMY_TOKEN",
+            "roles": [{"name": "reader"}],
+            "lifetime_minutes": 2,
+        }
+        response = client.post(
+            "/tokens/tokens/1", headers={"X-CSRF-Token": csrf_cookie}, json=token_req
+        )
+        assert response.status_code == 200
+
+        decoded = jwt.decode(
+            jwt=response.get_json()["token"].encode(),
+            key=public_key,
+            algorithms=["RS256"],
+            audience="DUMMY_SERVER_A",
+        )
+        expected_expiry = datetime.datetime(
+            year=2020, month=12, day=31
+        ) + datetime.timedelta(minutes=2)
+        assert approx(expected_expiry.timestamp()) == decoded["exp"]
+
+
+@pytest.mark.usefixtures("test_data_with_access_rights")
+@freeze_time(datetime.datetime(year=2020, month=12, day=31))
+def test_token_rejects_lifetime_above_cap(client, auth, app, test_user_with_roles):
+    """A lifetime longer than the role/server cap is rejected."""
+    with app.app_context():
+        uid, uname, upass = test_user_with_roles
+        response, csrf_cookie = auth.login(uname, upass)
+
+        # Cap is 5 minutes (set in test_roles fixture); ask for 10.
+        token_req = {
+            "name": "DUMMY_TOKEN",
+            "roles": [{"name": "reader"}],
+            "lifetime_minutes": 10,
+        }
+        response = client.post(
+            "/tokens/tokens/1", headers={"X-CSRF-Token": csrf_cookie}, json=token_req
+        )
+        assert response.status_code == 400
+        assert response.get_json()["bad_field"] == "lifetime_minutes"
+
+
+@pytest.mark.usefixtures("test_data_with_access_rights")
+@freeze_time(datetime.datetime(year=2020, month=12, day=31))
+def test_token_mint_with_no_absolute_caps(
+    client, auth, app, test_user_with_roles, public_key, test_servers, test_roles
+):
+    """When server and roles have NULL latest_token_expiry, mint succeeds and
+    the token's expiry is bounded only by longest_token_life_minutes."""
+    from flowauth.models import db, Server, Role
+
+    with app.app_context():
+        server_a = db.session.get(Server, 1)
+        server_a.latest_token_expiry = None
+        for role in db.session.execute(
+            db.select(Role).where(Role.server_id == 1)
+        ).scalars():
+            role.latest_token_expiry = None
+        db.session.commit()
+
+        uid, uname, upass = test_user_with_roles
+        response, csrf_cookie = auth.login(uname, upass)
+
+        token_req = {
+            "name": "DUMMY_TOKEN",
+            "roles": [{"name": "reader"}],
+        }
+        response = client.post(
+            "/tokens/tokens/1", headers={"X-CSRF-Token": csrf_cookie}, json=token_req
+        )
+        assert response.status_code == 200
+        decoded = jwt.decode(
+            jwt=response.get_json()["token"].encode(),
+            key=public_key,
+            algorithms=["RS256"],
+            audience="DUMMY_SERVER_A",
+        )
+        # longest_token_life_minutes is 24 * 60 * 2 = 2880
+        expected_expiry = datetime.datetime(
+            year=2020, month=12, day=31
+        ) + datetime.timedelta(minutes=24 * 60 * 2)
+        assert approx(expected_expiry.timestamp()) == decoded["exp"]
+
+
 def test_token_rejected_for_expiry(client, auth, app, test_user_with_roles, public_key):
     with app.app_context():
         with freeze_time("2020-12-31") as frozentime:

--- a/flowauth/frontend/src/TokenBuilder.jsx
+++ b/flowauth/frontend/src/TokenBuilder.jsx
@@ -46,6 +46,7 @@ function TokenBuilder(props) {
   const [roles, setRoleState] = useState([]);
   const [activeRoles, setActiveRoles] = useState([]);
   const [checked, setChecked] = useState([]);
+  const [lifetimeMinutes, setLifetimeMinutes] = useState("");
   const [tokenErrorOpen, setTokenErrorOpen] = useState(false);
   const [tokenError, setTokenError] = useState("");
   const [tokenWarningOpen, setTokenWarningOpen] = useState(false);
@@ -101,7 +102,7 @@ function TokenBuilder(props) {
   };
 
   const requestToken = () => {
-    createToken(name, activeServer, activeRoles).then(
+    createToken(name, activeServer, activeRoles, lifetimeMinutes).then(
       (token) => {
         console.log("Token got");
         console.log(token);
@@ -151,6 +152,11 @@ function TokenBuilder(props) {
     setName(event.target.value);
   };
 
+  //Handles the requested lifetime being changed
+  const handleLifetimeChange = (event) => {
+    setLifetimeMinutes(event.target.value);
+  };
+
   return (
     <Fragment>
       <Dialog open={tokenErrorOpen} onClose={closeTokenError}>
@@ -179,6 +185,18 @@ function TokenBuilder(props) {
             margin="normal"
             error={!nameIsValid}
             helperText={nameHelperText}
+          />
+        </Grid>
+        <Grid item>
+          <TextField
+            id="lifetime_minutes"
+            label="Lifetime (minutes)"
+            type="number"
+            inputProps={{ min: 1 }}
+            value={lifetimeMinutes}
+            onChange={handleLifetimeChange}
+            margin="normal"
+            helperText="Optional. Leave empty to issue at the maximum permitted by the selected roles."
           />
         </Grid>
         <Grid container xs={8}>

--- a/flowauth/frontend/src/util/api.js
+++ b/flowauth/frontend/src/util/api.js
@@ -395,10 +395,14 @@ export async function editRoleScopes(role_id, new_scopes) {
   return await getResponse("/roles/" + role_id, dat);
 }
 
-export async function createToken(name, server_id, roles) {
+export async function createToken(name, server_id, roles, lifetime_minutes) {
+  const body = { name: name, roles: roles };
+  if (lifetime_minutes != null && lifetime_minutes !== "") {
+    body.lifetime_minutes = parseInt(lifetime_minutes, 10);
+  }
   var dat = {
     method: "POST",
-    body: JSON.stringify({ name: name, roles: roles }),
+    body: JSON.stringify(body),
   };
   return await getResponse("/tokens/tokens/" + server_id, dat);
 }


### PR DESCRIPTION
Closes #7274.

## Summary

`Server` and `Role` carry an absolute `latest_token_expiry` datetime that ratchets the token-expiry cap downward over time. Renewing a long-lived token therefore requires an admin to log in first and bump those datetimes on the server *and* every role used by the token — and if they forget, the new token is silently capped at the old (near-expired) date with no UI warning. Wiki-documented runbook, the `# feature todo: flag this to the user` at `token_management.py:138`, and #6454 are all symptoms of the same bug.

This PR makes the column nullable as the first half of a two-release deprecation. A `NULL` value means "no absolute expiry cap, only `longest_token_life_minutes` bounds the lifetime". Operators opt in per server/role by nulling the column. The actual column drop is a follow-up for a later release once both production deployments have been on the nullable schema for a while.

The mint endpoint also gains an optional `lifetime_minutes` so users can request a shorter token (addressing the lifetime-half of #5719). Without it, tokens are still issued at the maximum permitted lifetime.

## Changes

### Backend

- **`models.py`**
  - `Server.latest_token_expiry` and `Role.latest_token_expiry` are now `nullable=True`.
  - `Server.next_expiry()` and `Role.next_expiry()` return `now + longest_token_life_minutes` when `latest_token_expiry` is `NULL`.
  - `User.token_limits()` rewritten to handle `NULL` role/server caps. If any of the user's roles on the server has `NULL`, that side imposes no cap; otherwise the most-permissive role wins. Server's value (or `NULL`) caps that. Returns `latest_end: None` when there is no cap from either side.
  - `User.latest_token_expiry()` falls back to `now + longest_life` when `latest_end` is `None`.
  - `Role.to_dict()` serialises `NULL` as JSON `null`.
  - **Bonus fix**: `token_limits` previously did not filter by user id, so it returned the most-permissive role on the server across *all* users. Now correctly filters by `User.id == self.id`.
- **`token_management.py / add_token`** accepts optional `lifetime_minutes` (positive integer). Validated against `min(server.next_expiry(), role.next_expiry())`. Returns 400 with `bad_field: lifetime_minutes` if invalid or above the cap.
- **`servers.py`** — `add_server`, `edit_server`, `get_server`, `get_roles` all tolerate / serialise `NULL`.
- **`roles.py`** — `add_role`, `edit_role` tolerate `NULL`. The "role cap can't exceed server cap" check is skipped when either side is `NULL`.
- **Alembic migration** — `c1d4e7b9a2f3_nullable_latest_token_expiry.py` runs `ALTER COLUMN ... DROP NOT NULL` on both tables. Down-revision is the current head (`976c731ff30f`).

### Frontend

- **`TokenBuilder.jsx`** gains an optional "Lifetime (minutes)" field. Empty = "issue at the maximum permitted by the selected roles" (existing behaviour).
- **`util/api.js`** — `createToken` accepts optional `lifetime_minutes` and includes it in the request body when set.

### Tests

- `test_token_honours_requested_lifetime` — short lifetime is honoured.
- `test_token_rejects_lifetime_above_cap` — over-cap lifetime → 400.
- `test_token_mint_with_no_absolute_caps` — server and roles with `NULL` latest_token_expiry mint at `now + longest_token_life_minutes`.

### Changelog

Entries under `[Unreleased]` `Added`, `Changed`, and `Fixed` referencing #7274.

## Backwards compatibility

- Existing rows keep their non-null `latest_token_expiry` values, so on first deploy of this version nothing changes operationally.
- JWT contract is unchanged → FlowAPI is unaffected.
- The Ghana flowauth deployment (separate `ghana-flowauth` repo, pinned to its own image tag) keeps working until its operator chooses to bump tags.
- Existing admin endpoints accept the same JSON they did before; they additionally now accept `null` (or omitted) for `latest_token_expiry`.

## Test plan

- [ ] Backend: `pytest flowauth/backend/tests/test_token_generation.py` — three new tests pass and existing ones don't regress.
- [ ] Backend: `pytest flowauth/backend/tests/test_access_reflects_server_limits.py` — still green.
- [ ] Migration: `flask db upgrade` then `flask db downgrade` round-trips on a populated database.
- [ ] Frontend: log in, mint a token without a lifetime → token gets max permitted; mint with `lifetime_minutes=60` → token expires in 60 minutes; mint with a lifetime above the cap → error message surfaces.
- [ ] Admin UI: existing flow of editing server/role expiry still works.

## Related work

This is the second of three planned PRs against FlowAuth. The visibility-of-roles change is in #7276 (issue #7273). The renewal endpoint is #7275 and depends on #7276's `tokens_with_roles` table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `lifetime_minutes` parameter to token minting, allowing tokens to be issued with shorter lifetimes below the configured maximum.

* **Changed**
  * Server and role absolute expiry caps are now optional; when disabled, token lifetime is constrained only by the longest configured token life.

* **Bug Fixes**
  * Fixed token limit calculations to correctly scope to the current user only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->