### PR TITLE
ci: pin pipenv==2024.4.1 in flowmachine Docker + CI to fix hash drift

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,6 +329,15 @@ jobs:
       - checkout
       - restore_cache:
           key: flowmachine-deps-12-{{ checksum "flowmachine/Pipfile.lock" }}
+      # Pin pipenv to match flowmachine.Dockerfile. Different pipenv versions
+      # hash the same Pipfile to different `_meta.hash` values; without this
+      # pin, the cimg image's bundled pipenv and the Dockerfile's
+      # `pip install pipenv` end up disagreeing, and no single Pipfile.lock
+      # can satisfy both jobs. 2024.4.1 is the version that hashes the
+      # current Pipfile to the value stored in Pipfile.lock.
+      - run:
+          name: Install pipenv
+          command: pip install --upgrade pip "pipenv==2024.4.1"
       # Need to install graphviz and pygraphviz manually because it was removed from the Pipfile
       # (see https://github.com/Flowminder/FlowKit/issues/952)
       - run: cd flowmachine && pipenv install --dev --deploy

--- a/flowmachine.Dockerfile
+++ b/flowmachine.Dockerfile
@@ -8,13 +8,22 @@ ARG SOURCE_VERSION=0+unknown
 ENV SOURCE_VERSION=${SOURCE_VERSION}
 ENV SOURCE_TREE=FlowKit-${SOURCE_VERSION}
 ENV TINI_VERSION="v0.19.0"
+# Pin pipenv: different pipenv versions hash the same Pipfile differently.
+# 2024.4.1 is the version that hashes flowmachine/Pipfile to the value
+# stored in the current Pipfile.lock; using a newer pipenv produces a
+# different hash and breaks `--deploy`. Keep this in sync with
+# .circleci/config.yml's install_flowmachine_deps job.
+#
+# Note: do NOT name this ARG `PIPENV_VERSION` — pipenv treats that as its
+# `--version` boolean flag and fails on any non-boolean value.
+ARG PIPENV_PIN=2024.4.1
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 WORKDIR /${SOURCE_TREE}/flowmachine
 COPY ./flowmachine/Pipfile* ./
 RUN apt-get update && \
         apt-get install -y --no-install-recommends git && \
-        pip install --no-cache-dir pipenv && pipenv install --clear --deploy && \
+        pip install --no-cache-dir "pipenv==${PIPENV_PIN}" && pipenv install --clear --deploy && \
         apt-get -y remove git && \
         apt purge -y --auto-remove && \
         rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

`build_flowmachine` was failing on every PR with `pipenv install --deploy` aborting on a Pipfile.lock hash mismatch:

```
Pipfile.lock is out of date.
[DeployException] Aborting deploy
```

## Root cause

Two CI contexts install flowmachine's deps **with different pipenv versions**:

- `build_flowmachine` (Dockerfile) does `pip install pipenv` → latest, which hashes the current `Pipfile` to one value.
- `install_flowmachine_deps` (CircleCI job) used the pipenv pre-baked into `cimg/python:3.12`, which hashes the same Pipfile to a *different* value — and that value happens to match what's stored in `Pipfile.lock`.

Pipenv's `_meta.hash.sha256` is deterministic *for a given pipenv version*, so different pipenv versions produce different hashes for the same Pipfile. Whoever last regenerated the lock (with whatever pipenv version they had locally) baked in a hash that only some pipenv versions can match — and `build_flowmachine`'s "latest" was no longer one of them. No single Pipfile.lock could simultaneously satisfy both jobs as long as they were on different pipenv versions.

## Fix

Pin both contexts to `pipenv==2024.4.1`, the version that hashes the current `flowmachine/Pipfile` to the value stored in `flowmachine/Pipfile.lock`. I established this empirically: installed several pipenv versions locally and asked each to verify the lock; 2024.4.1 reports up-to-date; newer versions (2025.x, 2026.x) report drift.

- `flowmachine.Dockerfile`: `pip install pipenv` → `pip install pipenv==${PIPENV_VERSION}` (defaulted via `ARG` to 2024.4.1 so a future bump is a single override).
- `.circleci/config.yml install_flowmachine_deps`: explicit `pip install --upgrade pip pipenv==2024.4.1` step before `pipenv install --deploy`. Comments at each pin site cross-reference the other.

## Why this approach (vs. regenerating the lock)

I initially regenerated `Pipfile.lock` with current pipenv, which fixed the hash drift but *also* pulled forward many transitive dependency versions. That immediately surfaced years of latent code rot in flowmachine — `run_flowmachine_tests` started failing across ~25 tests with pandas 2.2+ removing `'H'`/`'T'` frequency aliases, pandas 2.1+ removing `fillna(method=)`, and marshmallow 3.13+ removing `missing=`. None of those were new — they were masked by CircleCI's stale virtualenv cache (the lock-hash drift meant `pipenv install --deploy` had been failing in `install_flowmachine_deps` too, and the cache restore was hydrating an even-older venv that still worked).

Pinning pipenv to the version that matches the existing lock keeps the lock content unchanged, which keeps the cached venv valid, which keeps the latent bugs latent. That's not a long-term solution but it's the right immediate unblock — it gets CI honest enough to land flowauth work without forcing a multi-week migration of pandas/marshmallow usage in flowmachine first.

## Follow-up needed (separate work, not this PR)

When pipenv is bumped — either deliberately, or because someone regenerates the lock with a newer version — the cache key (`flowmachine-deps-12-{{ checksum "Pipfile.lock" }}`) will invalidate, fresh install will pull current pandas / marshmallow / etc., and the latent bugs will surface. That's the trigger to migrate the flowmachine schemas and pandas usage forward. Not a small piece of work; needs a flowmachine domain reviewer.

## Test plan

- [ ] `build_flowmachine` goes green
- [ ] `install_flowmachine_deps` stays green
- [ ] `run_flowmachine_tests` stays green
- [ ] `run_flowauth_end_to_end_tests` and `cypress: default-group` stay green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment configurations to use an explicitly pinned pipenv version, ensuring consistent and reproducible dependency installations across CircleCI pipelines and Docker builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->