### PR TITLE
FlowAuth: add token renewal endpoint (#7275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - FlowAuth: roles assigned to a token at mint time are now recorded in a `tokens_with_roles` association table and exposed on the user's token list (`GET /tokens/tokens/<server_id>`), so users and admins can see which permissions an existing token carries without decoding the JWT. [#7273](https://github.com/Flowminder/FlowKit/issues/7273)
+- FlowAuth: new `POST /tokens/tokens/<token_id>/renew` endpoint mints a fresh JWT reusing the original token's name and roles. The original `TokenHistory` row is left intact so its JWT remains valid until its own `exp` claim passes, giving consumers a natural overlap window. The token list UI gains a "Renew" button on each active token. [#7275](https://github.com/Flowminder/FlowKit/issues/7275)
 
 ### Changed
 

--- a/flowauth/backend/flowauth/token_management.py
+++ b/flowauth/backend/flowauth/token_management.py
@@ -163,3 +163,105 @@ def add_token(server_id):
     db.session.commit()
 
     return jsonify({"token": token_string})
+
+
+@blueprint.route("/tokens/<int:token_id>/renew", methods=["POST"])
+@login_required
+def renew_token(token_id):
+    """
+    Renew an existing token: mint a fresh JWT with the same name and the same
+    roles as the original, owned by the current user, with a fresh expiry.
+
+    The existing TokenHistory row is left untouched — its JWT remains valid
+    until its own ``exp`` claim passes, giving consumers a natural overlap
+    window to switch over without downtime. A new TokenHistory row is created
+    for the renewed token.
+
+    Parameters
+    ----------
+    token_id: int
+        ID of the existing TokenHistory row to renew.
+
+    Notes
+    -----
+    Optionally accepts ``{"lifetime_minutes": <int>}`` to request a token
+    shorter than the maximum permitted by the server and original roles.
+    When omitted, the new token is issued at the maximum permitted lifetime.
+
+    Responds with ``{"token": <token_string>, "id": <new_token_id>}``.
+    """
+    original = TokenHistory.query.filter(TokenHistory.id == token_id).first_or_404()
+
+    if original.user_id != current_user.id:
+        raise Unauthorized("You can only renew your own tokens.")
+
+    if not original.roles:
+        raise InvalidUsage(
+            "This token has no roles recorded against it and cannot be "
+            "renewed; mint a new token instead.",
+            payload={"bad_field": "token_id"},
+        )
+
+    server = original.server
+
+    user_role_ids = {role.id for role in current_user.roles}
+    missing = [role.name for role in original.roles if role.id not in user_role_ids]
+    if missing:
+        raise Unauthorized(
+            "Cannot renew: the following roles are no longer assigned to you: "
+            + ", ".join(sorted(missing))
+        )
+
+    roles = list(original.roles)
+    max_token_expiry = min(
+        server.next_expiry(), min(role.next_expiry() for role in roles)
+    )
+
+    if max_token_expiry < datetime.datetime.now():
+        raise Unauthorized(
+            f"Token for {current_user.username} cannot be renewed: maximum "
+            "permitted expiry has already passed."
+        )
+
+    json = request.get_json(silent=True) or {}
+    requested_lifetime = json.get("lifetime_minutes")
+    if requested_lifetime is None:
+        token_expiry = max_token_expiry
+    else:
+        if not isinstance(requested_lifetime, int) or requested_lifetime <= 0:
+            raise InvalidUsage(
+                "lifetime_minutes must be a positive integer",
+                payload={"bad_field": "lifetime_minutes"},
+            )
+        requested_expiry = datetime.datetime.now() + datetime.timedelta(
+            minutes=requested_lifetime
+        )
+        if requested_expiry > max_token_expiry:
+            raise InvalidUsage(
+                "Requested lifetime exceeds the maximum permitted by the "
+                "server and original roles",
+                payload={"bad_field": "lifetime_minutes"},
+            )
+        token_expiry = requested_expiry
+
+    token_string = generate_token(
+        flowapi_identifier=server.name,
+        username=current_user.username,
+        private_key=current_app.config["PRIVATE_JWT_SIGNING_KEY"],
+        lifetime=token_expiry - datetime.datetime.now(),
+        roles={role.name: sorted(ss.name for ss in role.scopes) for role in roles},
+    )
+
+    history_entry = TokenHistory(
+        name=original.name,
+        user_id=current_user.id,
+        server_id=server.id,
+        expiry=token_expiry,
+        token=token_string,
+        roles=roles,
+    )
+
+    db.session.add(history_entry)
+    db.session.commit()
+
+    return jsonify({"token": token_string, "id": history_entry.id})

--- a/flowauth/backend/tests/test_token_generation.py
+++ b/flowauth/backend/tests/test_token_generation.py
@@ -122,6 +122,123 @@ def test_token_list_includes_assigned_roles(
             assert isinstance(role["id"], int)
 
 
+@pytest.mark.usefixtures("test_data_with_access_rights")
+@freeze_time(datetime.datetime(year=2020, month=12, day=31))
+def test_token_renewal_creates_new_row_with_same_name_and_roles(
+    client, auth, app, test_user_with_roles, public_key
+):
+    """Renewing a token mints a fresh JWT with the same name and roles, and
+    leaves the original TokenHistory row alone."""
+    with app.app_context():
+        uid, uname, upass = test_user_with_roles
+        response, csrf_cookie = auth.login(uname, upass)
+
+        mint = client.post(
+            "/tokens/tokens/1",
+            headers={"X-CSRF-Token": csrf_cookie},
+            json={
+                "name": "DUMMY_TOKEN",
+                "roles": [{"name": "runner"}, {"name": "reader"}],
+            },
+        )
+        assert mint.status_code == 200
+        original_token_string = mint.get_json()["token"]
+
+        listed = client.get(
+            "/tokens/tokens/1", headers={"X-CSRF-Token": csrf_cookie}
+        ).get_json()
+        original_id = listed[0]["id"]
+
+        renew = client.post(
+            f"/tokens/tokens/{original_id}/renew",
+            headers={"X-CSRF-Token": csrf_cookie},
+            json={},
+        )
+        assert renew.status_code == 200
+        renewed = renew.get_json()
+        assert "token" in renewed
+        assert renewed["token"] != original_token_string
+        assert renewed["id"] != original_id
+
+        listed_after = client.get(
+            "/tokens/tokens/1", headers={"X-CSRF-Token": csrf_cookie}
+        ).get_json()
+        assert len(listed_after) == 2
+        for entry in listed_after:
+            assert entry["name"] == "DUMMY_TOKEN"
+            assert sorted(r["name"] for r in entry["roles"]) == ["reader", "runner"]
+
+
+@pytest.mark.usefixtures("test_data_with_access_rights")
+@freeze_time(datetime.datetime(year=2020, month=12, day=31))
+def test_token_renewal_rejects_other_users_tokens(
+    client, auth, app, test_user_with_roles, test_admin
+):
+    """A user cannot renew a token they don't own."""
+    with app.app_context():
+        uid, uname, upass = test_user_with_roles
+        _, csrf_cookie = auth.login(uname, upass)
+        client.post(
+            "/tokens/tokens/1",
+            headers={"X-CSRF-Token": csrf_cookie},
+            json={"name": "DUMMY_TOKEN", "roles": [{"name": "reader"}]},
+        )
+        other_id = client.get(
+            "/tokens/tokens/1", headers={"X-CSRF-Token": csrf_cookie}
+        ).get_json()[0]["id"]
+
+        auth.logout()
+        admin_id, admin_name, admin_pw = test_admin
+        _, admin_csrf = auth.login(admin_name, admin_pw)
+        renew = client.post(
+            f"/tokens/tokens/{other_id}/renew",
+            headers={"X-CSRF-Token": admin_csrf},
+            json={},
+        )
+        assert renew.status_code == 401
+
+
+@pytest.mark.usefixtures("test_data_with_access_rights")
+@freeze_time(datetime.datetime(year=2020, month=12, day=31))
+def test_token_renewal_rejects_when_role_revoked(
+    client, auth, app, test_user_with_roles
+):
+    """If a role has been removed from the user since the token was minted,
+    renewal must fail rather than silently issuing a token they can no longer
+    legitimately request."""
+    with app.app_context():
+        uid, uname, upass = test_user_with_roles
+        _, csrf_cookie = auth.login(uname, upass)
+        client.post(
+            "/tokens/tokens/1",
+            headers={"X-CSRF-Token": csrf_cookie},
+            json={
+                "name": "DUMMY_TOKEN",
+                "roles": [{"name": "runner"}, {"name": "reader"}],
+            },
+        )
+        token_id = client.get(
+            "/tokens/tokens/1", headers={"X-CSRF-Token": csrf_cookie}
+        ).get_json()[0]["id"]
+
+        from flowauth.models import db, User, Role
+
+        user = db.session.execute(db.select(User).where(User.id == uid)).scalar()
+        runner = db.session.execute(
+            db.select(Role).where(Role.name == "runner")
+        ).scalar()
+        user.roles.remove(runner)
+        db.session.commit()
+
+        renew = client.post(
+            f"/tokens/tokens/{token_id}/renew",
+            headers={"X-CSRF-Token": csrf_cookie},
+            json={},
+        )
+        assert renew.status_code == 401
+        assert "runner" in renew.get_json()["message"]
+
+
 def test_token_rejected_for_expiry(client, auth, app, test_user_with_roles, public_key):
     with app.app_context():
         with freeze_time("2020-12-31") as frozentime:

--- a/flowauth/frontend/src/Token.jsx
+++ b/flowauth/frontend/src/Token.jsx
@@ -23,6 +23,8 @@ class Token extends React.Component {
   state = {
     isOpen: false,
     copySuccess: "",
+    renewing: false,
+    renewError: "",
   };
   toggleOpen = () => {
     this.setState({ isOpen: !this.state.isOpen });
@@ -44,9 +46,21 @@ class Token extends React.Component {
     document.body.appendChild(element);
     element.click();
   };
+  handleRenew = async () => {
+    const { id, onRenew } = this.props;
+    if (!onRenew) return;
+    this.setState({ renewing: true, renewError: "" });
+    try {
+      await onRenew(id);
+    } catch (err) {
+      this.setState({ renewError: err.message || "Renewal failed" });
+    } finally {
+      this.setState({ renewing: false });
+    }
+  };
   render() {
-    const { name, expiry, token, classes, roles } = this.props;
-    const { isOpen, copySuccess } = this.state;
+    const { name, expiry, token, classes, roles, onRenew } = this.props;
+    const { isOpen, copySuccess, renewing, renewError } = this.state;
     const isExpired = Date.parse(expiry) < Date.parse(new Date());
     const roleSummary =
       roles && roles.length > 0 ? roles.map((r) => r.name).join(", ") : null;
@@ -92,6 +106,22 @@ class Token extends React.Component {
           <Button variant="outlined" color="primary" onClick={this.toggleOpen}>
             View
           </Button>
+          {onRenew && !isExpired && (
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={this.handleRenew}
+              disabled={renewing}
+              className={classes.button}
+            >
+              {renewing ? "Renewing…" : "Renew"}
+            </Button>
+          )}
+          {renewError && (
+            <Typography variant="caption" color="error">
+              {renewError}
+            </Typography>
+          )}
           <Dialog
             open={isOpen}
             onClose={this.toggleOpen}

--- a/flowauth/frontend/src/TokenList.jsx
+++ b/flowauth/frontend/src/TokenList.jsx
@@ -11,7 +11,7 @@ import Typography from "@material-ui/core/Typography";
 import IconButton from "@material-ui/core/IconButton";
 import AddIcon from "@material-ui/icons/Add";
 import Token from "./Token";
-import { getMyTokensForServer, getServer } from "./util/api";
+import { getMyTokensForServer, getServer, renewToken } from "./util/api";
 
 const styles = (theme) => ({
   root: {
@@ -40,6 +40,11 @@ class TokenList extends React.Component {
       .then((server) => this.setState({ serverName: server.name }))
       .catch((err) => console.error(err));
   };
+  handleRenew = async (tokenId) => {
+    await renewToken(tokenId);
+    this.updateTokenList();
+  };
+
   componentDidMount() {
     this.updateTokenList();
     this.getServerName();
@@ -101,12 +106,14 @@ class TokenList extends React.Component {
           <Grid item xs={5} />
           {activeTokens.map((object) => (
             <Token
+              id={object.id}
               name={object.name}
               expiry={object.expires}
               token={object.token}
               roles={object.roles}
               classes={classes}
               editAction={editAction}
+              onRenew={this.handleRenew}
             />
           ))}
         </React.Fragment>
@@ -130,6 +137,7 @@ class TokenList extends React.Component {
             <Grid item xs={12} />
             {expiredTokens.map((object) => (
               <Token
+                id={object.id}
                 name={object.name}
                 expiry={object.expires}
                 token={object.token}

--- a/flowauth/frontend/src/util/api.js
+++ b/flowauth/frontend/src/util/api.js
@@ -403,6 +403,18 @@ export async function createToken(name, server_id, roles) {
   return await getResponse("/tokens/tokens/" + server_id, dat);
 }
 
+export async function renewToken(token_id, lifetime_minutes) {
+  const body = {};
+  if (lifetime_minutes != null && lifetime_minutes !== "") {
+    body.lifetime_minutes = parseInt(lifetime_minutes, 10);
+  }
+  var dat = {
+    method: "POST",
+    body: JSON.stringify(body),
+  };
+  return await getResponse("/tokens/tokens/" + token_id + "/renew", dat);
+}
+
 export async function login(username, password) {
   var dat = {
     method: "POST",


### PR DESCRIPTION
Closes #7275.

## Summary

New `POST /tokens/tokens/<token_id>/renew` endpoint that mints a fresh JWT reusing the original token's name and roles. The original `TokenHistory` row is left intact — its JWT remains valid until its own `exp` claim passes, giving consumers a natural overlap window to switch over without downtime.

This is the second half of the renewal story: combined with #7274 (drop the absolute expiry cap), it eliminates the multi-step admin-bump dance currently required to rotate long-lived service tokens (e.g. `flowbot`'s Airflow `FLOWAPI_TOKEN`).

## Why same-name renewal matters operationally

External monitoring tooling can key off `TokenHistory.name` to create services like `FlowAuth_Token_<name>`. Reusing the name on renewal keeps those alert channels stable across rotations — no reconfiguration needed.

## Behaviour

- **Roles are recovered** from the `tokens_with_roles` association added in #7273. The renewal must reproduce the original role set verbatim — no role substitution.
- **Authorization**: the caller must own the token *and* still hold every role it was minted with. If a role has been revoked since, renewal returns 401 with a message listing the missing role names. (No silent re-issue of permissions the user can no longer legitimately request.)
- **Old row is left alive**: a new `TokenHistory` row is inserted; the old one is untouched. There is no revocation mechanism in flowauth (FlowAPI just verifies the JWT signature), so the overlap window is bounded only by the original token's `exp`.
- **Lifetime**: optional `lifetime_minutes` in the body is honoured if `≤ min(server.next_expiry(), role.next_expiry())`; otherwise rejected with 400. Omitted means "max permitted" — same default as the mint endpoint.
- **Pre-#7273 tokens**: rows with no associated roles (created before that table existed) cannot be renewed; the endpoint returns 400 and asks the caller to mint a new token instead.

## Frontend

`TokenList.jsx` passes a `Renew` callback through to each active token. `Token.jsx` shows a `Renew` button for active (non-expired) tokens; clicking it calls the new endpoint and triggers a list refresh. Errors surface inline as a small caption beneath the row. Expired tokens get no button (the backend would reject anyway).

## Tests

- `test_token_renewal_creates_new_row_with_same_name_and_roles` — happy path: list goes from 1 row to 2, both with the same name and the same role set; new JWT differs from old.
- `test_token_renewal_rejects_other_users_tokens` — 401 when the calling user doesn't own the token.
- `test_token_renewal_rejects_when_role_revoked` — 401 with the missing role name in the message when a role has been removed from the user since mint.

## Branch base

This branch is **stacked on `flowauth/token-roles-visible`** (the PR for #7273) because the renewal endpoint reads roles from that PR's `tokens_with_roles` table. Once #7276 lands on master, I'll change this PR's base to master and rebase — the diff against master will then be just this PR's commit.

## Test plan

- [ ] Backend: `pytest flowauth/backend/tests/test_token_generation.py` — three new tests pass; existing don't regress.
- [ ] Frontend: log in, mint a token, click "Renew" on the active row → list refreshes with two rows of the same name; the new row has a later expiry. Old token still works for FlowAPI calls until its own expiry.
- [ ] Try renewing a token belonging to another user (manually) → 401.
- [ ] Remove a role from a user, try to renew their token → 401 with the role name in the error.
- [ ] Combined with #7277 (drop expiry cap): the full "no admin-bump needed" rotation flow works end-to-end.

## Related

- Depends on #7273 / #7276 (`tokens_with_roles` association).
- Complements #7274 / #7277 (drop the silent absolute-expiry cap).
- The original [wiki-documented manual renewal runbook](https://docs.flowminder.org/wiki/Flowauth#Token_Renewal) — for context on what this PR collapses into a single click.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Token renewal support: A new "Renew" button is now available in the token list for active tokens, allowing users to generate a fresh JWT without invalidating the original token until its expiration. Token name and roles are preserved during renewal.

* **Documentation**
  * Updated changelog with token renewal feature details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->