### PR TITLE
FlowAuth: show Renew button on expired tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - FlowAuth: `User.token_limits` now correctly filters by the current user when computing role-derived caps. Previously the join did not constrain by user id, so the function returned the most-permissive role on the server across *all* users. [#7274](https://github.com/Flowminder/FlowKit/issues/7274)
+- FlowAuth: the "Renew" button is now also shown on expired tokens. The renewal endpoint already accepted expired tokens (only the server/role caps are checked), but the button was hidden on the Expired tokens list and on rows whose `expiry` had passed.
 
 ### Removed
 

--- a/flowauth/frontend/src/Token.jsx
+++ b/flowauth/frontend/src/Token.jsx
@@ -106,7 +106,7 @@ class Token extends React.Component {
           <Button variant="outlined" color="primary" onClick={this.toggleOpen}>
             View
           </Button>
-          {onRenew && !isExpired && (
+          {onRenew && (
             <Button
               variant="outlined"
               color="primary"

--- a/flowauth/frontend/src/TokenList.jsx
+++ b/flowauth/frontend/src/TokenList.jsx
@@ -144,6 +144,7 @@ class TokenList extends React.Component {
                 roles={object.roles}
                 classes={classes}
                 editAction={editAction}
+                onRenew={this.handleRenew}
               />
             ))}
             <Grid item xs={12} />


### PR DESCRIPTION
## Summary

- The renewal endpoint added in #7275 already accepts expired tokens — it only checks the server's and role's expiry caps, not the original token's `expires`. But the UI was hiding the button on any row whose `expiry` had passed, so there was no way to actually trigger it.
- Drop the `!isExpired` guard in `Token.jsx` and pass `onRenew={this.handleRenew}` on the `expiredTokens.map` iteration in `TokenList.jsx`. Three lines.

This unblocks the service-account use case (e.g. Airflow's `flowbot` token): when the JWT has already expired, the operator can renew it in place from the Expired tokens list rather than re-minting from scratch and rewiring consumers.

## Test plan

- [ ] On a server where the user has a token with `expiry` in the past: open the token list, confirm the "Renew" button now appears in the Expired tokens section.
- [ ] Click Renew on an expired token; confirm a fresh JWT is minted and the new row appears in Active tokens.
- [ ] Existing active-token Renew flow still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The Renew button is now available for expired tokens, allowing you to renew them directly from the expired tokens list without additional steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->