### PR TITLE
FlowAuth: hide Renew button on tokens with no recorded roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - FlowAuth: `User.token_limits` now correctly filters by the current user when computing role-derived caps. Previously the join did not constrain by user id, so the function returned the most-permissive role on the server across *all* users. [#7274](https://github.com/Flowminder/FlowKit/issues/7274)
 - FlowAuth: the "Renew" button is now also shown on expired tokens. The renewal endpoint already accepted expired tokens (only the server/role caps are checked), but the button was hidden on the Expired tokens list and on rows whose `expiry` had passed.
+- FlowAuth: hide the "Renew" button on tokens minted before the `tokens_with_roles` association was introduced. Those rows have no roles recorded, so the renewal endpoint refuses them with `InvalidUsage`; previously the button was visible and clicking it returned an error. Old tokens must be re-minted from scratch.
 
 ### Removed
 

--- a/flowauth/frontend/src/Token.jsx
+++ b/flowauth/frontend/src/Token.jsx
@@ -106,7 +106,7 @@ class Token extends React.Component {
           <Button variant="outlined" color="primary" onClick={this.toggleOpen}>
             View
           </Button>
-          {onRenew && (
+          {onRenew && roles && roles.length > 0 && (
             <Button
               variant="outlined"
               color="primary"


### PR DESCRIPTION
## Summary

- Follow-up to #7282. The renew endpoint refuses tokens with no rows in `tokens_with_roles` (`flowauth/backend/flowauth/token_management.py:216-221` raises `InvalidUsage`). That covers anything minted before #7273 added the association table — typically the older tokens still sitting in operators' Active and Expired lists today.
- Previously the button was rendered for those tokens, so clicking Renew always 400'd. Add `roles && roles.length > 0` to the render guard so the button only appears for tokens the API will actually accept.
- Old tokens need to be re-minted from scratch (the UI already supports that path).

## Test plan

- [ ] Token list contains both pre-#7273 tokens (no roles displayed under the nickname) and post-#7273 tokens (with `Roles: ...` caption).
- [ ] Renew button appears only on rows with roles.
- [ ] Clicking Renew on a row with roles still works as before, both in the Active and Expired sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a UI issue where the "Renew" button appeared on certain tokens but would fail when clicked. The button now only displays when renewal is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->