### PR TITLE
FlowAuth: enable SQLAlchemy pool_pre_ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - FlowAuth: `User.token_limits` now correctly filters by the current user when computing role-derived caps. Previously the join did not constrain by user id, so the function returned the most-permissive role on the server across *all* users. [#7274](https://github.com/Flowminder/FlowKit/issues/7274)
 - FlowAuth: the "Renew" button is now also shown on expired tokens. The renewal endpoint already accepted expired tokens (only the server/role caps are checked), but the button was hidden on the Expired tokens list and on rows whose `expiry` had passed.
 - FlowAuth: hide the "Renew" button on tokens minted before the `tokens_with_roles` association was introduced. Those rows have no roles recorded, so the renewal endpoint refuses them with `InvalidUsage`; previously the button was visible and clicking it returned an error. Old tokens must be re-minted from scratch.
+- FlowAuth: enable SQLAlchemy `pool_pre_ping` so dead connections in the pool are detected and replaced before each query instead of surfacing as `MySQLdb.OperationalError (2013, 'Lost connection to MySQL server during query')`. This eliminates the ~5-minute window of 500s after every container restart while the stale pool drains.
 
 ### Removed
 

--- a/flowauth/backend/flowauth/config.py
+++ b/flowauth/backend/flowauth/config.py
@@ -102,7 +102,7 @@ def get_config():
             ADMIN_USER=environ["FLOWAUTH_ADMIN_USERNAME"],
             ADMIN_PASSWORD=environ["FLOWAUTH_ADMIN_PASSWORD"],
             SQLALCHEMY_DATABASE_URI=db_uri,
-            SQLALCHEMY_ENGINE_OPTIONS=dict(pool_recycle=3600),
+            SQLALCHEMY_ENGINE_OPTIONS=dict(pool_recycle=3600, pool_pre_ping=True),
             SECRET_KEY=environ["SECRET_KEY"],
             SESSION_PROTECTION="strong",
             SQLALCHEMY_TRACK_MODIFICATIONS=False,


### PR DESCRIPTION
## Summary

Every container restart of the cloudrun-hosted flowauth produces a ~5 minute window of 500s while the SQLAlchemy connection pool hands out connections that MySQL has already dropped. Each query during that window dies with `MySQLdb.OperationalError (2013, 'Lost connection to MySQL server during query')` until the pool fully recycles. We've now seen this on three consecutive deploys; users hit "login failed" and have to wait it out.

`pool_pre_ping=True` issues a cheap `SELECT 1` before each connection checkout and transparently replaces dead connections. The very first request after a restart succeeds. Cost is a single extra round-trip per checkout — negligible against serving 500s for several minutes after every deploy.

One-line change to `flowauth/backend/flowauth/config.py:105` plus a CHANGELOG entry.

## Test plan

- [ ] Existing flowauth backend tests still pass (no engine-options changes touch test paths).
- [ ] After next deploy, the cloudrun-flowauth container should accept logins immediately rather than spending ~5 minutes returning 500s.

## References

SQLAlchemy docs on disconnect handling: https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection reliability by enabling health checks that detect and replace stale connections, preventing intermittent errors following container restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->