### PR TITLE
FlowAuth: make Latest expiry picker clearable on Server and Role admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - FlowAuth: the "Renew" button is now also shown on expired tokens. The renewal endpoint already accepted expired tokens (only the server/role caps are checked), but the button was hidden on the Expired tokens list and on rows whose `expiry` had passed.
 - FlowAuth: hide the "Renew" button on tokens minted before the `tokens_with_roles` association was introduced. Those rows have no roles recorded, so the renewal endpoint refuses them with `InvalidUsage`; previously the button was visible and clicking it returned an error. Old tokens must be re-minted from scratch.
 - FlowAuth: enable SQLAlchemy `pool_pre_ping` so dead connections in the pool are detected and replaced before each query instead of surfacing as `MySQLdb.OperationalError (2013, 'Lost connection to MySQL server during query')`. This eliminates the ~5-minute window of 500s after every container restart while the stale pool drains.
+- FlowAuth: the *Latest expiry* date pickers on the Server and Role admin forms now have a Clear button, and submit `null` rather than an Invalid Date / 1970 epoch string when empty. Without this the backend's nullable `latest_token_expiry` was unreachable from the UI — operators could see the "no cap" semantics in the API but had no way to actually clear an existing cap.
 
 ### Removed
 

--- a/flowauth/frontend/src/RoleDetails.jsx
+++ b/flowauth/frontend/src/RoleDetails.jsx
@@ -253,6 +253,8 @@ function RoleDetails(props) {
               label="Expiry date"
               value={expiryDate}
               onChange={setExpiryDate}
+              clearable={true}
+              helperText="Leave empty to remove the absolute expiry cap"
             />
           </MuiPickersUtilsProvider>
         </Grid>

--- a/flowauth/frontend/src/ServerAdminDetails.jsx
+++ b/flowauth/frontend/src/ServerAdminDetails.jsx
@@ -102,14 +102,12 @@ class ServerAdminDetails extends React.Component {
       max_life &&
       maxlife_helper_text === ""
     ) {
+      const isoExpiry = latest_expiry
+        ? new Date(latest_expiry).toISOString()
+        : null;
       const server = this.editMode()
-        ? editServer(
-            item_id,
-            name,
-            new Date(latest_expiry).toISOString(),
-            max_life,
-          )
-        : createServer(name, new Date(latest_expiry).toISOString(), max_life);
+        ? editServer(item_id, name, isoExpiry, max_life)
+        : createServer(name, isoExpiry, max_life);
       try {
         await editServerScopes((await server).id, rightsObjs);
         onClick();
@@ -265,6 +263,8 @@ class ServerAdminDetails extends React.Component {
               onChange={this.handleDateChange}
               disablePast={true}
               margin="normal"
+              clearable={true}
+              helperText="Leave empty to remove the absolute expiry cap"
             />
           </MuiPickersUtilsProvider>
         </Grid>


### PR DESCRIPTION
## Summary

The backend started accepting `NULL` for `latest_token_expiry` on Server and Role in #7277, but the admin UI made that value unreachable:

- The Material-UI v4 `DateTimePicker`s on both forms had no Clear option — there was no UI gesture that produced an empty value.
- `ServerAdminDetails.handleSubmit` always wrapped state in `new Date(latest_expiry).toISOString()`, so even if the picker held `null` you'd send the 1970 epoch string back to the API.

Both fixed here. Operators can now actually clear an existing absolute expiry cap on a server or role from the admin UI.

## Changes

- `flowauth/frontend/src/ServerAdminDetails.jsx` — `clearable={true}` on the picker, helper text, conditional `null`/ISO string in `handleSubmit`.
- `flowauth/frontend/src/RoleDetails.jsx` — `clearable={true}` on the picker. The role form already passes the picker value through unchanged, so the API path is fine once the Clear button exists.

## Test plan

- [ ] Server admin → edit existing server → click the Clear button on *Latest expiry* → save → reload → field shows blank, GET `/servers/<id>` returns `latest_token_expiry: null`.
- [ ] Role admin → same flow on a role.
- [ ] Mint a token against a server with cleared `latest_token_expiry` and `longest_token_life_minutes` only → token expiry equals `now + longest_token_life_minutes`, no silent clamp.
- [ ] Editing a server/role *with* an expiry set still works (regression check).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Latest expiry fields in Role and Server administrator forms can now be cleared with clear action buttons and helpful text guidance.

* **Bug Fixes**
  * Empty Latest expiry field values now correctly submit as null instead of invalid date strings.
  * Updated the submission logic to properly handle empty expiry fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->